### PR TITLE
Minor Bug in delquote Command - Success and 404 Not Presented Properly

### DIFF
--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -98,7 +98,7 @@
 
       var newCount;
 
-      if (newCount = deleteQuote(args[0]) < 0) {
+      if ((newCount = deleteQuote(args[0])) >= 0) {
         $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.del.success', args[0], newCount));
       } else {
         $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.del.404', args[0]));


### PR DESCRIPTION
Fixed minor bug in delquote command. newQuote was being assigned the boolean result of the comparison. Additionally, the improper return value was being evalulated.
This was resulting in the "404" error being presented when deleting a valid quote
and when deleting a valid quote the number shown was "true" rather than the
real number of remaining quotes.
