### PR TITLE
Custom Commands now parse tags

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -58,10 +58,10 @@
             }
         }
 
-        // This needs to be improved, we can loose up to 500ms with all of the replace() methods when
+        // This needs to be improved, we can lose up to 500ms with all of the replace() methods when
         // there is nothing to replace.  This is a quick fix to just not even attempt to perform the
         // replace when we don't appear to see tags.
-        if (message.match('/\(sender\)|\(touser\)|\(@sender\)|\(baresender\)|\(random\)|\(pointname\)|\(uptime\)|\(game\)|\(status\)|\(follows\)|\(count\)|\(price\)/,g'))
+        if (message.match(/\(sender\)|\(touser\)|\(@sender\)|\(baresender\)|\(random\)|\(pointname\)|\(uptime\)|\(game\)|\(status\)|\(follows\)|\(count\)|\(price\)/))
         return message
             .replace('(sender)', $.username.resolve(event.getSender()))
 	    .replace('(touser)', $.username.resolve(touser))


### PR DESCRIPTION
A quick fix to parse the tags when a custom command is ran. Note that these commands can still take over a second with enough tags in it.  That still needs to be addressed.
