### PR TITLE
Fix Follow Train Increment Issue

### DIFF
--- a/javascript-source/handlers/followHandler.js
+++ b/javascript-source/handlers/followHandler.js
@@ -40,9 +40,8 @@
       }
       else if (followTrain == 50) {
         $.say($.lang.get('followhandler.followtrain.unbelievable', followTrain));
-      } else {
-        ++followTrain;
-      }
+      } 
+      ++followTrain;
     }
     else {
       followTrain = 1;


### PR DESCRIPTION
No, I did not test this, but the logic makes sense.
Previously, in the switch() statement, when one of the follow train
amounts was not matched (3, 4, 5, 20, 30, 50) then followTrain was
incremented.  So, when 3 was matched, followTrain never incremented
and this resulted in 3 only being reported.
