### PR TITLE
Enable ChannelUsersCache

### DIFF
--- a/source/me/mast3rplan/phantombot/PhantomBot.java
+++ b/source/me/mast3rplan/phantombot/PhantomBot.java
@@ -486,8 +486,7 @@ public class PhantomBot implements Listener {
             this.donationsCache = DonationsCache.instance(this.channel.getName().toLowerCase());
         }
         this.emotesCache = EmotesCache.instance(this.channel.getName().toLowerCase());
-
-        //this.channelUsersCache = ChannelUsersCache.instance(this.channel.getName().toLowerCase());
+        this.channelUsersCache = ChannelUsersCache.instance(this.channel.getName().toLowerCase());
     }
 
     @Subscribe

--- a/source/me/mast3rplan/phantombot/cache/UsernameCache.java
+++ b/source/me/mast3rplan/phantombot/cache/UsernameCache.java
@@ -76,15 +76,21 @@ public class UsernameCache {
 
                         return displayName;
                     } else {
+                        if (user.getInt("_http") == 404 && user.has("message") && !user.isNull("message")) {
+                            if (user.getString("message").endsWith("does not exist")) {
+                                com.gmt2001.Console.debug.println("UsernameCache.updateCache: " + user.getString("message"));
+                                return username;
+                            }
+                        }
                         try {
                             throw new Exception("[HTTPErrorException] HTTP " + user.getInt("_http") + " " + user.getString("error") + ". req="
                                                 + user.getString("_type") + " " + user.getString("_url") + " " + user.getString("_post") + "   "
                                                 + (user.has("message") && !user.isNull("message") ? "message=" + user.getString("message") : "content=" + user.getString("_content")));
                         } catch (Exception e) {
-                            com.gmt2001.Console.out.println("UsernameCache.updateCache>>Failed to get username: " + e.getMessage());
-                            com.gmt2001.Console.err.logStackTrace(e);
+                              com.gmt2001.Console.out.println("UsernameCache.updateCache>>Failed to get username: " + e.getMessage());
+                              com.gmt2001.Console.err.logStackTrace(e);
 
-                            return username;
+                              return username;
                         }
                     }
                 } else {


### PR DESCRIPTION
- PhantomBot.java
  - Enable the ChannelUsersCache again
- ChannelUsersCache.java
  - Will attempt to get the user list at startup from TMI every 30 seconds; once completed, will try once an hour.
  - This is to ensure that the $.users data in the bot has all users that may be connected before the bot boots up.
- UsernameCache.jva
  - Stop errors when a user is not found.  Will send to debug log though if enabled.
