### PR TITLE
Followers Init Event Happens First

### DIFF
--- a/source/me/mast3rplan/phantombot/cache/FollowersCache.java
+++ b/source/me/mast3rplan/phantombot/cache/FollowersCache.java
@@ -323,17 +323,17 @@ public class FollowersCache implements Runnable {
         this.cache = newCache;
         this.count = newCache.size();
 
+        if (firstUpdate) {
+            firstUpdate = false;
+            EventBus.instance().post(new TwitchFollowsInitializedEvent(PhantomBot.instance().getChannel("#" + this.channel)));
+        }
+
         for (String follower : followers) {
             EventBus.instance().post(new TwitchFollowEvent(follower, PhantomBot.instance().getChannel("#" + this.channel)));
         }
 
         for (String follower : unfollowers) {
             EventBus.instance().post(new TwitchUnfollowEvent(follower, PhantomBot.instance().getChannel("#" + this.channel)));
-        }
-
-        if (firstUpdate) {
-            firstUpdate = false;
-            EventBus.instance().post(new TwitchFollowsInitializedEvent(PhantomBot.instance().getChannel("#" + this.channel)));
         }
     }
 


### PR DESCRIPTION
- FollowersCache.java
  - The init event for followers was after the first set of followers/unfollowers was sent.  This meant that people that followed while the bot was offline, or as the bot was booting up, would not be announced or added to the followers db.
