### PR TITLE
Auto-Detect AWS Chat IRC Server

### DIFF
--- a/source/com/gmt2001/TwitchAPIv3.java
+++ b/source/com/gmt2001/TwitchAPIv3.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONString;
 
 /**
  * Communicates with Twitch Kraken server using the version 3 API
@@ -510,4 +511,18 @@ public class TwitchAPIv3 {
     {
         return GetData(request_type.GET, base_url + "/chat/emoticons", false);
     }
+
+    /**
+     * Requests Twitch to send chat server information
+     * @param channel
+     * @return JSONObject
+     */
+    public JSONObject GetChatServer(String channel) {
+        return GetData(request_type.GET, "https://tmi.twitch.tv/servers?channel=" + channel, false);
+    }
+    public String GetChatServerType(String channel) {
+        JSONObject chatServerJSON = GetChatServer(channel);
+        return chatServerJSON.getString("cluster");
+    }
+  
 }


### PR DESCRIPTION
**TwitchAPIv3.java**
- Added new methods GetChatServer(){JSONObject} and GetChatServerType(){String}.
- GetChatServerType() is a wrapper to GetChatServer() to return the string value from the required key.

**PhantomBot.java**
- Added support to auto-detect server type (AWS or not) at bootup and to connect to proper IRC server.
- Automatically adds awshostname=irc.chat.twitch.tv to botlogin.txt
