### PR TITLE
GameWisp Auto-Refresh Tokens; Enhance AWS-Chat

### DIFF
--- a/source/com/gmt2001/TwitchAPIv3.java
+++ b/source/com/gmt2001/TwitchAPIv3.java
@@ -522,7 +522,12 @@ public class TwitchAPIv3 {
     }
     public String GetChatServerType(String channel) {
         JSONObject chatServerJSON = GetChatServer(channel);
-        return chatServerJSON.getString("cluster");
+        if (chatServerJSON.has("cluster")) {
+            return chatServerJSON.getString("cluster");
+        } else {
+            com.gmt2001.Console.err.println("TwitchAPIv3::GetChatServerType: Failed to communicate with Twitch API server. Assuming not AWS-chat");
+            return "main";
+        }
     }
   
 }


### PR DESCRIPTION
**TwitchAPIv3.java**
- Detect error in AWS Chat Twitch API service and return "normal" chat server.

**GameWispAPIv1.java**
- Added support for renewal of GameWisp Tokens.

**PhantomBot.java**
- Added support for renewal of GameWisp Tokens.
- Cache the AWS-chat server setting in DB and avoid further calls to Twitch API server.
- Re-ordered some assignments of variables to ensure that PhantomBot instance was built correctly.
