### PR TITLE
Fixed init commands and !module enable

### DIFF
--- a/javascript-source/commands/dualstreamCommand.js
+++ b/javascript-source/commands/dualstreamCommand.js
@@ -1,7 +1,8 @@
 (function() {
     var otherChannels = ($.inidb.exists('dualStreamCommand', 'otherChannels') ? $.inidb.get('dualStreamCommand', 'otherChannels') : null),
         timerToggle = ($.inidb.exists('dualStreamCommand', 'timerToggle') ? $.inidb.get('dualStreamCommand', 'timerToggle') : false),
-        timerInterval = (parseInt($.inidb.exists('dualStreamCommand', 'timerInterval')) ? parseInt($.inidb.get('dualStreamCommand', 'timerInterval')) : 5);
+        timerInterval = (parseInt($.inidb.exists('dualStreamCommand', 'timerInterval')) ? parseInt($.inidb.get('dualStreamCommand', 'timerInterval')) : 5),
+        initIntervalStarted = false;
 
     $.bind('command', function(event) {
         var sender = event.getSender(),
@@ -116,14 +117,18 @@
     $.bind('initReady', function() {
         if ($.bot.isModuleEnabled('./commands/dualstreamCommand.js')) {
             $.registerChatCommand('./commands/dualstreamCommand.js', 'multi', 7);
-            setInterval(function() {
-                if (otherChannels != null) {
-                    if (timerToggle && $.isOnline($.channelName)) {
-                        $.say($.lang.get('dualstreamcommand.link') + $.username.resolve($.channelName) + otherChannels);
-                        return;
+
+            if (!initIntervalStarted) {
+                initIntervalStarted = true;
+                setInterval(function() {
+                    if (otherChannels != null) {
+                        if (timerToggle && $.isOnline($.channelName)) {
+                            $.say($.lang.get('dualstreamcommand.link') + $.username.resolve($.channelName) + otherChannels);
+                            return;
+                        }
                     }
-                }
-            }, timerInterval * 60 * 1000);
+                }, timerInterval * 60 * 1000);
+            }
         }
     });
 })();

--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -45,6 +45,8 @@
         if ($.inidb.exists('permcom', command + " " + subcommand)) {
             var newGroupId = parseInt($.inidb.get('permcom', command + " " + subcommand));
             groupId = newGroupId;
+        } else {
+            $.inidb.set('permcom', command + " " + subcommand, groupId);
         }
 
         commands[command].subcommands[subcommand] = {
@@ -74,6 +76,8 @@
         if ($.inidb.exists('permcom', command)) {
             var newGroupId = parseInt($.inidb.get('permcom', command));
             groupId = newGroupId;
+        } else {
+            $.inidb.set('permcom', command, groupId);
         }
 
         commands[command] = {
@@ -156,7 +160,9 @@
         var group = '';
 
         if (commandExists(command)) {
-            if (commands[command].groupId == 1) {
+            if (commands[command].groupId == 0) {
+                group = "Caster";
+            } else if (commands[command].groupId == 1) {
                 group = 'Administrator';
             } else if (commands[command].groupId == 2) {
                 group = 'Moderator';

--- a/javascript-source/games/8ball.js
+++ b/javascript-source/games/8ball.js
@@ -50,7 +50,9 @@
      */
     $.bind('initReady', function() {
         if ($.bot.isModuleEnabled('./games/8ball.js')) {
-            loadResponses();
+            if (responseCount == 0) {
+                loadResponses();
+            }
             $.registerChatCommand('./games/8ball.js', '8ball', 7);
         }
     });

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -24,7 +24,9 @@
         tgExpIncr = 0.5,
         tgFoodDecr = 0.25,
         currentAdventure = 1,
-        stories = [];
+        stories = [],
+        moduleLoaded = false;
+
 
     /**
      * @function loadStories
@@ -403,7 +405,10 @@
     $.bind('initReady', function() {
         if ($.bot.isModuleEnabled('./games/adventureSystem.js')) {
             clearCurrentAdventure();
-            loadStories();
+            if (!moduleLoaded) {
+                loadStories();
+                moduleLoaded = true;
+            }
             $.registerChatCommand('./games/adventureSystem.js', 'adventure', 7);
         }
     });

--- a/javascript-source/games/killCommand.js
+++ b/javascript-source/games/killCommand.js
@@ -55,7 +55,9 @@
      */
     $.bind('initReady', function() {
         if ($.bot.isModuleEnabled('./games/killCommand.js')) {
-            loadResponses();
+            if (selfMessageCount == 0 && otherMessageCount == 0) {
+              loadResponses();
+            }
             $.registerChatCommand('./games/killCommand.js', 'kill', 6);
         }
     });

--- a/javascript-source/games/random.js
+++ b/javascript-source/games/random.js
@@ -42,7 +42,9 @@
      */
     $.bind('initReady', function() {
         if ($.bot.isModuleEnabled('./games/random.js')) {
-            loadResponses();
+            if (randomsCount == 0) {
+                loadResponses();
+            }
             $.registerChatCommand('./games/random.js', 'random');
         }
     });

--- a/javascript-source/games/roulette.js
+++ b/javascript-source/games/roulette.js
@@ -100,7 +100,9 @@
      */
     $.bind('initReady', function() {
         if ($.bot.isModuleEnabled('./games/roulette.js')) {
-            loadResponses();
+            if (responseCounts.win == 0 && responseCounts.lost == 0) {
+                loadResponses();
+            }
             $.registerChatCommand('./games/roulette.js', 'roulette', 7);
             $.registerChatCommand('./games/roulette.js', 'roulettetimeouttime', 1);
         }

--- a/javascript-source/handlers/panelHandler.js
+++ b/javascript-source/handlers/panelHandler.js
@@ -4,6 +4,7 @@
  */
 
 (function() {
+    var alreadyStarted = false;
 
     /**
      * @function updateViewerCount()
@@ -60,17 +61,18 @@
      * set the table as such.
      */
     $.bind('initReady', function() {
-        if ($.bot.isModuleEnabled('./handlers/panelHandler.js')) {
-            $.consoleLn("Web Panel Statistics Enabled");
-            $.inidb.set('panelstats', 'enabled', 'true');
-            updateAll();
-    
-            setInterval(function() {
+        if (!alreadyStarted) {
+            if ($.bot.isModuleEnabled('./handlers/panelHandler.js')) {
+                alreadyStarted = true;
+                $.inidb.set('panelstats', 'enabled', 'true');
                 updateAll();
-            }, 6e4);
-        } else {
-            $.consoleLn("Web Panel Statistics Disabled");
-            $.inidb.set('panelstats', 'enabled', 'false');
+        
+                setInterval(function() {
+                    updateAll();
+                }, 6e4);
+            } else {
+                $.inidb.set('panelstats', 'enabled', 'false');
+            }
         }
     });
 

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -295,6 +295,196 @@
         }
     };
 
+
+    /**
+     * @function handleInitCommands
+     * @param event
+     */
+    function handleInitCommands(event) {
+        var sender = event.getSender().toLowerCase(),
+            username = $.username.resolve(sender, event.getTags()),
+            command = event.getCommand(),
+            args = event.getArgs(),
+            action = args[0],
+            pointsRelatedModules = [],
+            temp,
+            index;
+
+        /**
+         * @commandpath reconnect - Tell the bot to reconnect to Twitch chat and the various APIs
+         */
+        if (command.equalsIgnoreCase('reconnect')) {
+            if (!$.isModv3(sender, event.getTags())) {
+                $.say($.whisperPrefix(sender) + $.modMsg);
+                return;
+            }
+
+            $.logEvent('init.js', 354, username + ' requested a reconnect!');
+            $.connmgr.reconnectSession($.hostname);
+            $.say($.lang.get('init.reconnect'));
+        }
+
+        /**
+         * @commandpath module - Display the usage for !module
+         */
+        if (command.equalsIgnoreCase('module')) {
+            if (!$.isAdmin(sender)) {
+                $.say($.whisperPrefix(sender) + $.adminMsg);
+                return;
+            }
+
+            if (!action) {
+                $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
+                return;
+            }
+
+            if (!action) {
+                $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
+                return;
+            }
+
+            /**
+             * @commandpath module list - List all known modules
+             */
+            if (action.equalsIgnoreCase('list')) {
+                var lstr = '';
+                for (index in modules) {
+                    if (modules[index].scriptFile.indexOf('./core/') != -1 || modules[index].scriptFile.indexOf('./lang/') != -1) {
+                        continue;
+                    }
+                    lstr += ' - ';
+                    lstr += modules[index].scriptFile + ' (';
+                    if (modules[index].enabled) {
+                        lstr += 'enabled';
+                    } else {
+                        lstr += 'disabled';
+                    }
+                    lstr += ')';
+                }
+                $.say($.whisperPrefix(sender) + lstr);
+            }
+
+            /**
+             * @commandpath module enable [./path/module] - Enable a module using the path and name of the module
+             */
+            if (action.equalsIgnoreCase('enable')) {
+                temp = args[1];
+
+                if (!temp) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
+                    return;
+                }
+
+                if (temp.indexOf('./core/') > -1 || temp.indexOf('./lang/') > -1) {
+                    return;
+                }
+
+                index = getModuleIndex(temp);
+
+                if (index > -1) {
+                    $.logEvent('init.js', 393, username + ' enabled module "' + modules[index].scriptFile + '"');
+                    modules[index].enabled = true;
+                    $.setIniDbBoolean('modules', modules[index].scriptFile, true);
+                    loadScript(modules[index].scriptFile);
+
+                    var hookIdx = getHookIndex(modules[index].scriptFile, 'initReady');
+                    try {
+                        hooks[hookIdx].handler(null);
+                    } catch (e) {
+                        $.logError('init.js', 394, 'Unable to call initReady for enabled module (' + modules[index].scriptFile +'): ' + e);
+                    }
+
+                    // callHook('initReady', null, true);
+
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.enabled', modules[index].getModuleName()));
+                } else {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.404'));
+                }
+            }
+
+            /**
+             * @commandpath module disable [./path/module] - Disable a module using the path and name of the module
+             */
+            if (action.equalsIgnoreCase('disable')) {
+                temp = args[1];
+
+                if (!temp) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
+                    return;
+                }
+
+                if (temp.indexOf('./core/') > -1 || temp.indexOf('./lang/') > -1) {
+                    return;
+                }
+
+                index = getModuleIndex(temp);
+
+                if (index > -1) {
+                    $.logEvent('init.js', 393, username + ' disabled module "' + modules[index].scriptFile + '"');
+                    modules[index].enabled = false;
+                    $.setIniDbBoolean('modules', modules[index].scriptFile, false);
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.disabled', modules[index].getModuleName()));
+
+                    if (modules[index].scriptFile == './systems/pointSystem.js') {
+                        pointsRelatedModules.push('./games/adventureSystem.js');
+                        pointsRelatedModules.push('./games/roll.js');
+                        pointsRelatedModules.push('./games/slotMachine.js');
+                        pointsRelatedModules.push('./systems/ticketRaffleSystem.js');
+                        pointsRelatedModules.push('./systems/raffleSystem.js');
+
+                        for (var i = 0; i < pointsRelatedModules.length; i++) {
+                            index = getModuleIndex(pointsRelatedModules[i]);
+                            if (index > -1) {
+                                $.logEvent('init.js', 393, username + ' auto-disabled module "' + modules[index].scriptFile + '"');
+                                modules[index].enabled = false;
+                                $.setIniDbBoolean('modules', modules[index].scriptFile, false);
+                            }
+                        }
+                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.auto-disabled'));
+                    }
+                } else {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.404'));
+                }
+            }
+
+            /**
+             * @commandpath module status [./path/module] - Retrieve the current status (enabled/disabled) of the given module
+             */
+            if (action.equalsIgnoreCase('status')) {
+                temp = args[1];
+
+                if (!temp) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
+                    return;
+                }
+
+                index = getModuleIndex(temp);
+
+                if (index > 1) {
+                    if (modules[index].enabled) {
+                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.check.enabled', modules[index].getModuleName()))
+                    } else {
+                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.check.disabled', modules[index].getModuleName()))
+                    }
+                } else {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.404'));
+                }
+            }
+        }
+
+        /**
+         * @commandpath chat [message] - In the console, can be used to chat as the bot. Also used by the webpanel to communicate with chat
+         */
+        if (command.equalsIgnoreCase('chat')) {
+            if (!$.isAdmin(sender)) {
+                $.say($.whisperPrefix(sender) + $.adminMsg);
+                return;
+            }
+            $.say(event.getArguments());
+        }
+    }
+
+
     /**
      * Load her up!
      */
@@ -419,6 +609,7 @@
                 }
             }
             callHook('command', event, false);
+            handleInitCommands(event);
         });
 
         /**
@@ -706,189 +897,11 @@
         consoleLn('');
 
         /**
-         * @event command
-         */
-        $api.on($script, 'command', function(event) {
-            var sender = event.getSender().toLowerCase(),
-                username = $.username.resolve(sender, event.getTags()),
-                command = event.getCommand(),
-                args = event.getArgs(),
-                action = args[0],
-                pointsRelatedModules = [],
-                temp,
-                index;
-
-            /**
-             * @commandpath reconnect - Tell the bot to reconnect to Twitch chat and the various APIs
-             */
-            if (command.equalsIgnoreCase('reconnect')) {
-                if (!$.isModv3(sender, event.getTags())) {
-                    $.say($.whisperPrefix(sender) + $.modMsg);
-                    return;
-                }
-
-                $.logEvent('init.js', 354, username + ' requested a reconnect!');
-                $.connmgr.reconnectSession($.hostname);
-                $.say($.lang.get('init.reconnect'));
-            }
-
-            /**
-             * @commandpath module - Display the usage for !module
-             */
-            if (command.equalsIgnoreCase('module')) {
-                if (!$.isAdmin(sender)) {
-                    $.say($.whisperPrefix(sender) + $.adminMsg);
-                    return;
-                }
-
-                if (!action) {
-                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
-                    return;
-                }
-
-                if (!action) {
-                    $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
-                    return;
-                }
-
-                /**
-                 * @commandpath module list - List all known modules
-                 */
-                if (action.equalsIgnoreCase('list')) {
-                    var lstr = '';
-                    for (index in modules) {
-                        if (modules[index].scriptFile.indexOf('./core/') != -1 || modules[index].scriptFile.indexOf('./lang/') != -1) {
-                            continue;
-                        }
-                        lstr += ' - ';
-                        lstr += modules[index].scriptFile + ' (';
-                        if (modules[index].enabled) {
-                            lstr += 'enabled';
-                        } else {
-                            lstr += 'disabled';
-                        }
-                        lstr += ')';
-                    }
-                    $.say($.whisperPrefix(sender) + lstr);
-                }
-
-                /**
-                 * @commandpath module enable [./path/module] - Enable a module using the path and name of the module
-                 */
-                if (action.equalsIgnoreCase('enable')) {
-                    temp = args[1];
-
-                    if (!temp) {
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
-                        return;
-                    }
-
-                    if (temp.indexOf('./core/') > -1 || temp.indexOf('./lang/') > -1) {
-                        return;
-                    }
-
-                    index = getModuleIndex(temp);
-
-                    if (index > -1) {
-                        $.logEvent('init.js', 393, username + ' enabled module "' + modules[index].scriptFile + '"');
-                        modules[index].enabled = true;
-                        $.setIniDbBoolean('modules', modules[index].scriptFile, true);
-                        loadScript(modules[index].scriptFile);
-                        callHook('initReady', null, true);
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.enabled', modules[index].getModuleName()));
-                    } else {
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.404'));
-                    }
-                }
-
-                /**
-                 * @commandpath module disable [./path/module] - Disable a module using the path and name of the module
-                 */
-                if (action.equalsIgnoreCase('disable')) {
-                    temp = args[1];
-
-                    if (!temp) {
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
-                        return;
-                    }
-
-                    if (temp.indexOf('./core/') > -1 || temp.indexOf('./lang/') > -1) {
-                        return;
-                    }
-
-                    index = getModuleIndex(temp);
-
-                    if (index > -1) {
-                        $.logEvent('init.js', 393, username + ' disabled module "' + modules[index].scriptFile + '"');
-                        modules[index].enabled = false;
-                        $.setIniDbBoolean('modules', modules[index].scriptFile, false);
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.disabled', modules[index].getModuleName()));
-
-                        if (modules[index].scriptFile == './systems/pointSystem.js') {
-                            pointsRelatedModules.push('./games/adventureSystem.js');
-                            pointsRelatedModules.push('./games/roll.js');
-                            pointsRelatedModules.push('./games/slotMachine.js');
-                            pointsRelatedModules.push('./systems/ticketRaffleSystem.js');
-                            pointsRelatedModules.push('./systems/raffleSystem.js');
-
-                            for (var i = 0; i < pointsRelatedModules.length; i++) {
-                                index = getModuleIndex(pointsRelatedModules[i]);
-                                if (index > -1) {
-                                    $.logEvent('init.js', 393, username + ' auto-disabled module "' + modules[index].scriptFile + '"');
-                                    modules[index].enabled = false;
-                                    $.setIniDbBoolean('modules', modules[index].scriptFile, false);
-                                }
-                            }
-                            $.say($.whisperPrefix(sender) + $.lang.get('init.module.auto-disabled'));
-                        }
-                    } else {
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.404'));
-                    }
-                }
-
-                /**
-                 * @commandpath module status [./path/module] - Retrieve the current status (enabled/disabled) of the given module
-                 */
-                if (action.equalsIgnoreCase('status')) {
-                    temp = args[1];
-
-                    if (!temp) {
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.usage'));
-                        return;
-                    }
-
-                    index = getModuleIndex(temp);
-
-                    if (index > 1) {
-                        if (modules[index].enabled) {
-                            $.say($.whisperPrefix(sender) + $.lang.get('init.module.check.enabled', modules[index].getModuleName()))
-                        } else {
-                            $.say($.whisperPrefix(sender) + $.lang.get('init.module.check.disabled', modules[index].getModuleName()))
-                        }
-                    } else {
-                        $.say($.whisperPrefix(sender) + $.lang.get('init.module.404'));
-                    }
-                }
-            }
-
-            /**
-             * @commandpath chat [message] - In the console, can be used to chat as the bot. Also used by the webpanel to communicate with chat
-             */
-            if (command.equalsIgnoreCase('chat')) {
-                if (!$.isAdmin(sender)) {
-                    $.say($.whisperPrefix(sender) + $.adminMsg);
-                    return;
-                }
-                $.say(event.getArguments());
-            }
-        });
-
-        /**
          * @event initReady
          */
-        $.registerChatCommand('./init.js', 'chat', 7);
-        $.registerChatCommand('./init.js', 'module', 7);
-        $.registerChatCommand('./init.js', 'reconnect', 7);
+        $.registerChatCommand('./init.js', 'chat', 1);
+        $.registerChatCommand('./init.js', 'module', 1);
+        $.registerChatCommand('./init.js', 'reconnect', 1);
 
         // emit initReady event
         callHook('initReady', null, true);

--- a/javascript-source/lang/english/main.js
+++ b/javascript-source/lang/english/main.js
@@ -168,6 +168,7 @@ $.lang.register('init.module.check.enabled', 'Module $1 is currently enabled!');
 $.lang.register('init.module.auto-disabled', 'Modules related to pointSystem have been disabled. See logs.');
 $.lang.register('init.module.disabled', 'Module "$1" disabled!');
 $.lang.register('init.module.enabled', 'Module "$1" enabled!');
+$.lang.register('init.module.error', 'Module "$1" enabled but did not initialize! Check error logs!');
 $.lang.register('init.module.list', '$1 registered modules: $2');
 $.lang.register('init.module.usage', 'Usage: !module list, !module enable [module name], !module disable [module name], !module status [module name]');
 $.lang.register('init.reconnect', 'Reconnecting to chat...');

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -1419,31 +1419,33 @@
             $.registerChatCommand('./systems/youtubePlayer.js', 'nextsong');
             $.registerChatSubcommand('wrongsong', 'user', 2);
 
-            /** Pre-load last activated playlist */
-            currentPlaylist = new BotPlayList(activePlaylistname, true);
+            if (currentPlaylist == null) {
+                /** Pre-load last activated playlist */
+                currentPlaylist = new BotPlayList(activePlaylistname, true);
 
-            /** if the current playlist is "default" and it's empty, add some default songs. */
-            if (currentPlaylist.getPlaylistname().equals('default') && currentPlaylist.getplaylistLength() == 0) {
-                /** CyberPosix - Under The Influence (Outertone Free Release) */
-                try {
-                    currentPlaylist.addToPlaylist(new YoutubeVideo('gotxnim9h8w', $.botName));
-                } catch (ex) {
-                    $.logError("youtubePlayer.js", 839, "YoutubeVideo::exception: " + ex);
-                }
-
-                /** Different Heaven & Eh!de - My Heart (Outertone 001 - Zero Release) */
-                try {
-                    currentPlaylist.addToPlaylist(new YoutubeVideo('WFqO9DoZZjA', $.botName));
-                } catch (ex) {
-                    $.logError("youtubePlayer.js", 846, "YoutubeVideo::exception: " + ex);
-                }
-
-
-                /** Tobu - Higher (Outertone Release) */
-                try {
-                    currentPlaylist.addToPlaylist(new YoutubeVideo('l7C29RM1UmU', $.botName))
-                } catch (ex) {
-                    $.logError("youtubePlayer.js", 855, "YoutubeVideo::exception: " + ex);
+                /** if the current playlist is "default" and it's empty, add some default songs. */
+                if (currentPlaylist.getPlaylistname().equals('default') && currentPlaylist.getplaylistLength() == 0) {
+                    /** CyberPosix - Under The Influence (Outertone Free Release) */
+                    try {
+                        currentPlaylist.addToPlaylist(new YoutubeVideo('gotxnim9h8w', $.botName));
+                    } catch (ex) {
+                        $.logError("youtubePlayer.js", 839, "YoutubeVideo::exception: " + ex);
+                    }
+    
+                    /** Different Heaven & Eh!de - My Heart (Outertone 001 - Zero Release) */
+                    try {
+                        currentPlaylist.addToPlaylist(new YoutubeVideo('WFqO9DoZZjA', $.botName));
+                    } catch (ex) {
+                        $.logError("youtubePlayer.js", 846, "YoutubeVideo::exception: " + ex);
+                    }
+    
+    
+                    /** Tobu - Higher (Outertone Release) */
+                    try {
+                        currentPlaylist.addToPlaylist(new YoutubeVideo('l7C29RM1UmU', $.botName))
+                    } catch (ex) {
+                        $.logError("youtubePlayer.js", 855, "YoutubeVideo::exception: " + ex);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**init.js**
- The bot commands are now encapsulated in their own function which is called. The second $api.on() call was causing issues.
- When a module is enabled, initReady will be called for only that module.

**commandRegister.js**
- Fixed API which returned the group string for a command, was missing Caster and Admin was mispelled.

**8ball.js**
**adventureSystem.js**
**killCommand.js**
**random.js**
**roulette.js**
**panelHandler.js**
**youtubePlayer.js**
- Were calling additional functionality in initReady that, when the module was disabled and enabled again (also, before the initReady fix in init.js) would cause lists to increase in size incorrectly, objects to be lost, and various other issues.
