### PR TITLE
Fix AWT Errors

### DIFF
--- a/resources/launch-service.osx.sh
+++ b/resources/launch-service.osx.sh
@@ -17,4 +17,5 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 cd "$DIR"
 
+unset DISPLAY
 java -Dfile.encoding=UTF-8 -jar PhantomBot.jar

--- a/resources/launch-service.sh
+++ b/resources/launch-service.sh
@@ -10,4 +10,5 @@
 
 cd $(dirname $(readlink -f $0))
 
+unset DISPLAY
 java -Dfile.encoding=UTF-8 -jar PhantomBot.jar

--- a/resources/launch.osx.sh
+++ b/resources/launch.osx.sh
@@ -17,4 +17,5 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 cd "$DIR"
 
+unset DISPLAY
 java -Dinteractive -Dfile.encoding=UTF-8 -jar PhantomBot.jar

--- a/resources/launch.sh
+++ b/resources/launch.sh
@@ -9,4 +9,5 @@
 
 cd $(dirname $(readlink -f $0))
 
+unset DISPLAY
 java -Dinteractive -Dfile.encoding=UTF-8 -jar PhantomBot.jar 


### PR DESCRIPTION
At times the Java Core will toss an error:
java.awt.AWTError: Can't connect to X11 window server using 'cpe-67-241-179-93.buffalo.res.rr.com:0.0' as the value of the DISPLAY variable.

Ensuring that DISPLAY is not set in the launch and service scripts.
