### PR TITLE
Add local .txt song file functionality to ytPlayer

### DIFF
--- a/javascript-source/lang/english/systems/systems-youtubeplayer.js
+++ b/javascript-source/lang/english/systems/systems-youtubeplayer.js
@@ -1,4 +1,7 @@
 $.lang.register('ytplayer.client.404', 'The YouTube Player is not connected!');
+$.lang.register('ytplayer.local.404', 'Local music functionality is not enabled.');
+$.lang.register('ytplayer.local.announce.nextsong', '[\u266B] Now Playing [$1]');
+$.lang.register('ytplayer.local.localpath.404', 'Could not locate local now playing file at [$1]');
 $.lang.register('ytplayer.playlist.404', 'Cannot find playlist [$1]');
 $.lang.register('ytplayer.announce.nextsong', '[\u266B] Now Playing [$1] Requester: $2');
 $.lang.register('ytplayer.console.client.connected', '[\u266B] YouTube Player is connected! [\u266B]');
@@ -36,7 +39,8 @@ $.lang.register('ytplayer.command.songrequest.failed', 'Failed adding song to qu
 $.lang.register('ytplayer.command.previoussong', 'Previous song was [$1] requested by $2 from $3');
 $.lang.register('ytplayer.command.previoussong.404', 'There is not a previous song to report');
 $.lang.register('ytplayer.command.currentsong', 'Current song is [$1] requested by $2 from $3');
-$.lang.register('ytplayer.command.currentsong.404', 'There is not a curent song');
+$.lang.register('ytplayer.command.currentsong.local', 'Current song is [$1]');
+$.lang.register('ytplayer.command.currentsong.404', 'No song is currently playing.');
 $.lang.register('ytplayer.command.delrequest.success', 'Removed song with ID [$1] and title of [$2] from song requests.');
 $.lang.register('ytplayer.command.delrequest.404', 'Song requests do not have a song with an ID of [$1]');
 $.lang.register('ytplayer.command.delrequest.usage', 'usage: !ytp delrequest [YouTube ID]');
@@ -51,6 +55,10 @@ $.lang.register('ytplayer.command.nextsong.range', 'Songs in Range: $1');
 $.lang.register('ytplayer.command.nextsong.usage', 'usage: !nextsong [index number | next [n] | list [x-y]. Display next song, or title at index number or next n songs or a range with list x-y');
 $.lang.register('ytplayer.command.nextsong.404', 'Song request queue is empty.');
 $.lang.register('ytplayer.command.nextsong.range.404', 'No songs found in that range.');
+$.lang.register('ytplayer.command.togglelocal.toggled', '$1 local now playing.');
+$.lang.register('ytplayer.command.localpath.usage', 'usage: !ytp localpath [./path/to/file.txt]');
+$.lang.register('ytplayer.command.localpath.get', 'Path to local now playing file set to [$1]');
+$.lang.register('ytplayer.command.localpath.set', 'Local now playing file updated to [$1]');
 $.lang.register('ytplayer.requestsong.error.maxrequests', 'exceeds maximum concurrent requests');
 $.lang.register('ytplayer.requestsong.error.disabled', 'song requests are disabled');
 $.lang.register('ytplayer.requestsong.error.yterror', 'YouTube error ($1)');

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -78,7 +78,7 @@
                         }
                     }
                 } else {
-                    $.consoleLn($.lang.get('ytplayer.local.localpath.404');
+                    $.consoleLn($.lang.get('ytplayer.local.localpath.404'));
                 }
             }
             setTimeout(updateLocalSong, 5 * 1000);
@@ -1071,7 +1071,7 @@
                 $.setIniDbBoolean('ytSettings', 'localMusicPlayer', localMusicPlayer);
 
                 var state = localMusicPlayer ? 'Enabled' : 'Disabled';
-                $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.togglelocal.toggled', state);
+                $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.togglelocal.toggled', state));
                 return;
             }
 
@@ -1523,33 +1523,32 @@
             $.registerChatSubcommand('wrongsong', 'user', 2);
             setTimeout(updateLocalSong, 10 * 1000);
     
-                if (currentPlaylist == null) {
-                    /** Pre-load last activated playlist */
-                    currentPlaylist = new BotPlayList(activePlaylistname, true);
-    
-                    /** if the current playlist is "default" and it's empty, add some default songs. */
-                    if (currentPlaylist.getPlaylistname().equals('default') && currentPlaylist.getplaylistLength() == 0) {
-                        /** CyberPosix - Under The Influence (Outertone Free Release) */
-                        try {
-                            currentPlaylist.addToPlaylist(new YoutubeVideo('gotxnim9h8w', $.botName));
-                        } catch (ex) {
-                            $.logError("youtubePlayer.js", 839, "YoutubeVideo::exception: " + ex);
-                        }
-        
-                        /** Different Heaven & Eh!de - My Heart (Outertone 001 - Zero Release) */
-                        try {
-                            currentPlaylist.addToPlaylist(new YoutubeVideo('WFqO9DoZZjA', $.botName));
-                        } catch (ex) {
-                            $.logError("youtubePlayer.js", 846, "YoutubeVideo::exception: " + ex);
-                        }
-        
-        
-                        /** Tobu - Higher (Outertone Release) */
-                        try {
-                            currentPlaylist.addToPlaylist(new YoutubeVideo('l7C29RM1UmU', $.botName))
-                        } catch (ex) {
-                            $.logError("youtubePlayer.js", 855, "YoutubeVideo::exception: " + ex);
-                        }
+            if (currentPlaylist == null) {
+                /** Pre-load last activated playlist */
+                currentPlaylist = new BotPlayList(activePlaylistname, true);
+
+                /** if the current playlist is "default" and it's empty, add some default songs. */
+                if (currentPlaylist.getPlaylistname().equals('default') && currentPlaylist.getplaylistLength() == 0) {
+                    /** CyberPosix - Under The Influence (Outertone Free Release) */
+                    try {
+                        currentPlaylist.addToPlaylist(new YoutubeVideo('gotxnim9h8w', $.botName));
+                    } catch (ex) {
+                        $.logError("youtubePlayer.js", 839, "YoutubeVideo::exception: " + ex);
+                    }
+
+                    /** Different Heaven & Eh!de - My Heart (Outertone 001 - Zero Release) */
+                    try {
+                        currentPlaylist.addToPlaylist(new YoutubeVideo('WFqO9DoZZjA', $.botName));
+                    } catch (ex) {
+                        $.logError("youtubePlayer.js", 846, "YoutubeVideo::exception: " + ex);
+                    }
+
+
+                    /** Tobu - Higher (Outertone Release) */
+                    try {
+                        currentPlaylist.addToPlaylist(new YoutubeVideo('l7C29RM1UmU', $.botName))
+                    } catch (ex) {
+                        $.logError("youtubePlayer.js", 855, "YoutubeVideo::exception: " + ex);
                     }
                 }
             }

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -1514,7 +1514,7 @@
             $.registerChatCommand('./systems/youtubePlayer.js', 'jumptosong', 1);
             $.registerChatCommand('./systems/youtubePlayer.js', 'playsong', 1);
             $.registerChatCommand('./systems/youtubePlayer.js', 'skipsong', 1);
-            $.registerChatCommand('./systems/youtubePlayerx.js', 'songrequest');
+            $.registerChatCommand('./systems/youtubePlayer.js', 'songrequest');
             $.registerChatCommand('./systems/youtubePlayer.js', 'addsong');
             $.registerChatCommand('./systems/youtubePlayer.js', 'previoussong');
             $.registerChatCommand('./systems/youtubePlayer.js', 'currentsong');

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -49,18 +49,19 @@
         var lastLocalSong = '';
         /* Read from local file when YouTube Player is not connected */
         function updateLocalSong() {
-            if (localMusicPlayer && !connectedPlayerClient && $.isOnline($.channelName)) {
+            if (localMusicPlayer && !connectedPlayerClient) {
                 if ($.fileExists(localNowPlayingFile)) {
                     var localSongTitle = $.readFile(localNowPlayingFile).toString().trim();
-                    var separator = '    |    ';
-                    if (!localSongTitle.equalsIgnoreCase(lastLocalSong)) {
+                    var separator = '             //             ';
+                    if (localSongTitle !== lastLocalSong) {
                         lastLocalSong = localSongTitle;
                         if (localSongTitle === null || localSongTitle === undefined || localSongTitle === '') {
                             $.writeToFile(
-                                $.lang.get('ytplayer.command.currentsong.404') + separator,
+                                ($.lang.get('ytplayer.command.currentsong.404') + separator),
                                 baseFileOutputPath + 'currentSong.txt',
                                 false
                             );
+                            setTimeout(updateLocalSong, 5 * 1000);
                             return;
                         } else {
                             $.writeToFile(
@@ -68,20 +69,22 @@
                                 baseFileOutputPath + 'currentSong.txt',
                                 false
                             );
+                            setTimeout(updateLocalSong, 5 * 1000);
                             if (announceInChat) {
                                 $.say($.lang.get('ytplayer.local.announce.nextsong', localSongTitle));
-                                $.consoleLn($.lang.get('ytplayer.local.announce.nextsong', localSongTitle));
                                 return;
                             } else {
                                 $.consoleLn($.lang.get('ytplayer.local.announce.nextsong', localSongTitle));
+                                return;
                             }
                         }
                     }
+                    setTimeout(updateLocalSong, 5 * 1000);
                 } else {
                     $.consoleLn($.lang.get('ytplayer.local.localpath.404'));
+                    setTimeout(updateLocalSong, 30 * 1000);
                 }
             }
-            setTimeout(updateLocalSong, 5 * 1000);
         }
 
     /**
@@ -1521,7 +1524,7 @@
             $.registerChatCommand('./systems/youtubePlayer.js', 'wrongsong');
             $.registerChatCommand('./systems/youtubePlayer.js', 'nextsong');
             $.registerChatSubcommand('wrongsong', 'user', 2);
-            setTimeout(updateLocalSong, 10 * 1000);
+            setTimeout(updateLocalSong, 15 * 1000);
     
             if (currentPlaylist == null) {
                 /** Pre-load last activated playlist */

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -49,7 +49,7 @@
         var lastLocalSong = '';
         /* Read from local file when YouTube Player is not connected */
         function updateLocalSong() {
-            if (localMusicPlayer && !connectedPlayerClient) {
+            if (localMusicPlayer && !connectedPlayerClient && $.isOnline($.channelName)) {
                 if ($.fileExists(localNowPlayingFile)) {
                     var localSongTitle = $.readFile(localNowPlayingFile).toString().trim();
                     var separator = '             //             ';


### PR DESCRIPTION
For your consideration :)

Allows users to enable reading from a locally saved *.txt file of their choosing for now playing information whenever song requests are disabled or otherwise not available. Local now playing has the same functionality as song requests in terms of !currentsong and chat / console announcements.

Commits also include necessary lang additions.

commands:

```
/*** ADDED ***/
!ytp togglelocal - enable or disable local file functionality
!ytp localpath [./path/to/file.txt] - change or view the path to the .txt file. MUST end in .txt ( command checks for this )

/*** MODIFIED ***/
!currentsong - reads from local file if song requests aren't available, responds with "No song is currently playing" if neither are available. As a result this command has moved above the check for the connected player client in order to allow it to run if requests are disabled.
```
