### PR TITLE
New Hosted Handler - DISABLED

### DIFF
--- a/source/me/mast3rplan/phantombot/IrcHostHandler.java
+++ b/source/me/mast3rplan/phantombot/IrcHostHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 www.phantombot.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package me.mast3rplan.phantombot;
+
+import java.lang.Integer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import me.mast3rplan.phantombot.event.EventBus;
+import me.mast3rplan.phantombot.event.twitch.host.TwitchHostedEvent;
+import me.mast3rplan.phantombot.event.twitch.host.TwitchHostsInitializedEvent;
+import me.mast3rplan.phantombot.event.twitch.host.TwitchUnhostedEvent;
+
+import me.mast3rplan.phantombot.jerklib.Channel;
+import me.mast3rplan.phantombot.jerklib.ModeAdjustment;
+import me.mast3rplan.phantombot.jerklib.Session;
+import me.mast3rplan.phantombot.jerklib.events.*;
+import me.mast3rplan.phantombot.jerklib.listeners.IRCEventListener;
+
+/*
+ * Only looks for PMs from jtv regarding being hosted.
+ */
+public class IrcHostHandler implements IRCEventListener {
+
+    private final ArrayList<String> mods = new ArrayList<>();
+
+    @Override
+    public void receiveEvent(IRCEvent event) {
+        if (PhantomBot.instance().isExiting()) {
+            return;
+        }
+
+        EventBus eventBus = EventBus.instance();
+        Session session = event.getSession();
+
+        switch (event.getType()) {
+
+        case CONNECT_COMPLETE:
+            com.gmt2001.Console.out.println("Host Monitoring Connected to IRC " + session.getNick() + "@" + session.getConnectedHostName());
+            EventBus.instance().post(new TwitchHostsInitializedEvent());
+            break;
+
+        case PRIVATE_MESSAGE:
+            MessageEvent pmessageEvent = (MessageEvent) event;
+            String pusername = pmessageEvent.getNick();
+            String pmessage = pmessageEvent.getMessage();
+
+            if (pusername.equalsIgnoreCase("jtv")) {
+                /* hoster is now hosting you for XX viewers. */
+                if (pmessage.contains("is now hosting you for")) {
+                    String[] messageSplit = pmessage.split(" ");
+                    String hoster = messageSplit[0];
+                    int users = Integer.parseInt(messageSplit[6]);
+                    com.gmt2001.Console.out.println("Detected Host from " + hoster + " for " + users + " users");
+                    EventBus.instance().post(new TwitchHostedEvent(hoster, users));
+                }
+            }
+            break;
+        }
+    }
+}

--- a/source/me/mast3rplan/phantombot/PhantomBot.java
+++ b/source/me/mast3rplan/phantombot/PhantomBot.java
@@ -119,7 +119,9 @@ public class PhantomBot implements Listener {
     private TreeMap<String, Integer> pollResults;
     private TreeSet<String> voters;
     private ConnectionManager connectionManager;
+    // private ConnectionManager hostConnectionManager; // new hostHandler
     private final Session session;
+    // private final Session hostSession; // new HostHandler
     public static Session tgcSession;
     private Channel channel;
     private final HashMap<String, Channel> channels;
@@ -148,6 +150,14 @@ public class PhantomBot implements Listener {
         return instance;
     }
 
+    public String botVersion() {
+        return "PhantomBot Core 2.0.6";
+    }
+
+    public String getBotInfo() {
+        return botVersion() + " (Revision: " + RepoVersion.getRepoVersion() + ")";
+    }
+
     public PhantomBot(String username, String oauth, String apioauth, String clientid, String channel,
                       String owner, int baseport, String hostname, int port, String ghostname, int gport,
                       double msglimit30, String datastore, String datastoreconfig, String youtubekey,
@@ -158,7 +168,7 @@ public class PhantomBot implements Listener {
         Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
 
         com.gmt2001.Console.out.println();
-        com.gmt2001.Console.out.println("PhantomBot Core 2.0.6");
+        com.gmt2001.Console.out.println(botVersion());
         com.gmt2001.Console.out.println("Build revision " + RepoVersion.getRepoVersion());
         com.gmt2001.Console.out.println("Creator: mast3rplan");
         com.gmt2001.Console.out.println("Developers: PhantomIndex, Kojitsari, Scania, Zelakto, IllusionaryOne, SimeonF, & Juraji");
@@ -197,6 +207,10 @@ public class PhantomBot implements Listener {
 
         Profile profile = new Profile(username.toLowerCase());
         this.connectionManager = new ConnectionManager(profile);
+
+        // Profile hostProfile = new Profile(owner.toLowerCase()); // new hosted method 
+        // this.hostConnectionManager = new ConnectionManager(hostProfile); // new hosted method
+       
 
         if (clientid.length() == 0) {
             this.clientid = "rp2uhin43rvpr70nzwnh07417x2gck0";
@@ -296,6 +310,12 @@ public class PhantomBot implements Listener {
         TwitchAlertsAPIv1.instance().SetDonationPullLimit(twitchalertslimit);
 
         this.session.addIRCEventListener(new IrcEventHandler());
+
+        /* Connect caster to Twitch IRC for host monitoring - disabled for now. */
+        // com.gmt2001.Console.out.println("Sending to Extra connection");
+        // this.hostSession = hostConnectionManager.requestConnection(this.hostname, this.port, casterOauth);
+        // this.hostSession.addIRCEventListener(new IrcHostHandler());
+        
     }
 
     public static void setDebugging(boolean debug) {
@@ -537,6 +557,7 @@ public class PhantomBot implements Listener {
 
         com.gmt2001.Console.out.println("[SHUTDOWN] Disconnecting from Twitch IRC...");
         connectionManager.quit();
+        // hostConnectionManager.quit(); // new hostHandler
 
         com.gmt2001.Console.out.println("[SHUTDOWN] Waiting for JVM to exit...");
     }

--- a/source/me/mast3rplan/phantombot/cache/ChannelHostCache.java
+++ b/source/me/mast3rplan/phantombot/cache/ChannelHostCache.java
@@ -93,7 +93,7 @@ public class ChannelHostCache implements Runnable {
         try {
             Thread.sleep(30 * 1000);
         } catch (InterruptedException e) {
-            com.gmt2001.Console.out.println("ChannelHostCache.run>>Failed to initial sleep: [InterruptedException] " + e.getMessage());
+            com.gmt2001.Console.out.println("ChannelHostCache.run>> Failed to initial sleep: [InterruptedException] " + e.getMessage());
             com.gmt2001.Console.err.logStackTrace(e);
         }
 
@@ -122,7 +122,7 @@ public class ChannelHostCache implements Runnable {
                         }
                     }
 
-                    com.gmt2001.Console.out.println("ChannelHostCache.run>>Failed to update hosts: " + e.getMessage());
+                    com.gmt2001.Console.out.println("ChannelHostCache.run>> Failed to update hosts: " + e.getMessage());
                     com.gmt2001.Console.err.logStackTrace(e);
                 }
             } catch (Exception e) {
@@ -132,7 +132,7 @@ public class ChannelHostCache implements Runnable {
             try {
                 Thread.sleep(30 * 1000);
             } catch (InterruptedException e) {
-                com.gmt2001.Console.out.println("ChannelHostCache.run>>Failed to sleep: [InterruptedException] " + e.getMessage());
+                com.gmt2001.Console.out.println("ChannelHostCache.run>> Failed to sleep: [InterruptedException] " + e.getMessage());
                 com.gmt2001.Console.err.logStackTrace(e);
             }
         }
@@ -149,7 +149,12 @@ public class ChannelHostCache implements Runnable {
             if (j.getBoolean("_success")) {
                 if (j.getInt("_http") == 200) {
                     id = j.getInt("_id");
+                    com.gmt2001.Console.debug.println("ChannelHostCache>> Got ID: " + id);
+                } else {
+                    com.gmt2001.Console.debug.println("ChannelHostCache>> ID check HTTP failure: " + j.getInt("_id"));
                 }
+            } else {
+                com.gmt2001.Console.debug.println("ChannelHostCache>> ID check fail");
             }
         }
 
@@ -162,9 +167,11 @@ public class ChannelHostCache implements Runnable {
         if (j.getBoolean("_success")) {
             if (j.getInt("_http") == 200) {
                 JSONArray hosts = j.getJSONArray("hosts");
+                com.gmt2001.Console.debug.println("ChannelHostCache>> Success with TMI");
 
                 for (int i = 0; i < hosts.length(); i++) {
                     newCache.put(hosts.getJSONObject(i).getString("host_login"), hosts.getJSONObject(i));
+                    com.gmt2001.Console.debug.println("ChannelHostCache>> Added: " + hosts.getJSONObject(i).getString("host_login"));
                 }
             } else {
                 try {

--- a/source/me/mast3rplan/phantombot/event/twitch/host/TwitchHostEvent.java
+++ b/source/me/mast3rplan/phantombot/event/twitch/host/TwitchHostEvent.java
@@ -23,6 +23,7 @@ public abstract class TwitchHostEvent extends TwitchEvent {
 
     private final String hoster;
     private final Type type;
+    private final int users;
 
     public enum Type {
 
@@ -33,12 +34,25 @@ public abstract class TwitchHostEvent extends TwitchEvent {
     protected TwitchHostEvent(String hoster, Type type) {
         this.hoster = hoster;
         this.type = type;
+        this.users = 0;
+    }
+    protected TwitchHostEvent(String hoster, Type type, int users) {
+        this.hoster = hoster;
+        this.type = type;
+        this.users = users;
     }
 
     protected TwitchHostEvent(String hoster, Type type, Channel channel) {
         super(channel);
         this.hoster = hoster;
         this.type = type;
+        this.users = 0;
+    }
+    protected TwitchHostEvent(String hoster, Type type, int users, Channel channel) {
+        super(channel);
+        this.hoster = hoster;
+        this.type = type;
+        this.users = users;
     }
 
     public String getHoster() {
@@ -47,6 +61,10 @@ public abstract class TwitchHostEvent extends TwitchEvent {
 
     public Type getType() {
         return type;
+    }
+
+    public int getUsers() {
+        return users;
     }
 
     public String toEventSocket() {

--- a/source/me/mast3rplan/phantombot/event/twitch/host/TwitchHostedEvent.java
+++ b/source/me/mast3rplan/phantombot/event/twitch/host/TwitchHostedEvent.java
@@ -23,8 +23,14 @@ public class TwitchHostedEvent extends TwitchHostEvent {
     public TwitchHostedEvent(String hoster) {
         super(hoster, Type.HOST);
     }
-
+    public TwitchHostedEvent(String hoster, int users) {
+        super(hoster, Type.HOST, users);
+    }
     public TwitchHostedEvent(String hoster, Channel channel) {
-        super(hoster, Type.HOST, channel);
+        super(hoster, Type.HOST, 0, channel);
+    }
+
+    public TwitchHostedEvent(String hoster, int users, Channel channel) {
+        super(hoster, Type.HOST, users, channel);
     }
 }


### PR DESCRIPTION
A new way of getting hosted events is included but this is disabled and not quite finished, it would still need to gather the Caster Twitch OAUTH from botlogin.txt. This is more of a placeholder in case we need to swap over to this instead of TMI.

**IrcHostHandler.java**
- Monitors PMs from Twitch to the caster and looks for the hosted message.

**ChannelHostCache.java**
- Added additional debug statements.

**TwitchHostEvent.java**
**TwitchHostedEvent.java**
- The host event accepts, optionally, the number of users on the hosting channel.

**PhantomBot.java**
- Commented out code for using IrcHostHander.
