### PR TITLE
FFZ API Fix

### DIFF
--- a/source/me/mast3rplan/phantombot/cache/EmotesCache.java
+++ b/source/me/mast3rplan/phantombot/cache/EmotesCache.java
@@ -246,7 +246,7 @@ public class EmotesCache implements Runnable {
 
         jsonResult = FrankerZAPIv1.instance().GetLocalEmotes(this.channel);
         if (checkJSONExceptions(jsonResult, true, "Local FrankerZ")) {
-            String currentSet = String.valueOf(jsonResult.getJSONObject("sets").getInt("set"));
+            String currentSet = String.valueOf(jsonResult.getJSONObject("room").getInt("set"));
             jsonArray = jsonResult.getJSONObject("sets").getJSONObject(currentSet).getJSONArray("emoticons");
             for (int i = 0; i < jsonArray.length(); i++) {
                 emote = jsonArray.getJSONObject(i).getString("name").replace("(", "\\(")


### PR DESCRIPTION
**EmotesCache.java**
- FFZ changed the format of the User (personal) emotes API to match the Global, and this broke getting emotes.
