### PR TITLE
Updated playtime Command

### DIFF
--- a/javascript-source/commands/streamCommand.js
+++ b/javascript-source/commands/streamCommand.js
@@ -75,7 +75,7 @@
                 $.say($.whisperPrefix(sender) + $.channelName + ' is currently offline.');
                 return;
             }
-            $.say('@' + $.username.resolve(sender) + ', ' + $.username.resolve($.channelName) + ' has been playing ' + $.getGame($.channelName) + ' for ' + $.getPlayTime() + '!');
+            $.say('@' + $.username.resolve(sender) + ', ' + $.username.resolve($.channelName) + ' has been playing ' + $.getPlayTimeGame() + ' for ' + $.getPlayTime() + '!');
         }
     });
 

--- a/javascript-source/core/streamInfo.js
+++ b/javascript-source/core/streamInfo.js
@@ -1,4 +1,59 @@
 (function() {
+
+    var playTime = null;
+    var lastGame = null;
+    var currentGame = null;
+
+    /**
+     * @function updatePlayTime()
+     */
+    function updatePlayTime() {
+        if ($.twitchcache.isStreamOnlineString().equals('false')) {
+            playTime = null;
+            currentGame = null;
+
+            if ($.bot.isModuleEnabled('./handlers/panelHandler.js')) {
+                $.inidb.set('panelstats', 'playTimeStart', 0);
+            }
+            return;
+        }
+
+        currentGame = $.twitchcache.getGameTitle() + '';
+
+        if (currentGame != null && lastGame != currentGame) {
+            lastGame = currentGame;
+            playTime = $.systemTime();
+
+            if ($.bot.isModuleEnabled('./handlers/panelHandler.js')) {
+                $.inidb.set('panelstats', 'playTimeStart', playTime);
+            }
+        }
+    };
+
+    /**
+     * @function getPlayTimeGame()
+     * @export $
+     */
+    function getPlayTimeGame() {
+        if (currentGame == null) {
+            return "Some Game";
+        }
+        return currentGame;
+    }  
+
+    /**
+     * @function getPlayTime()
+     * @export $
+     */
+    function getPlayTime() { 
+        if (playTime != null) {
+            var time = $.systemTime() - playTime;
+            return $.getTimeString(time / 1000);
+        } else {
+            return '0 seconds'; //Put this here, but it should never happen.
+        }
+    };
+
     /**
      * @function isOnline
      * @export $
@@ -215,7 +270,16 @@
         }
     };
 
+    /**
+     * Execute the updatePlayTime function.
+     */
+    setInterval(function() {
+        updatePlayTime();
+    }, 6e4, 'updatePlayTime');
+
     /** Export functions to API */
+    $.getPlayTime = getPlayTime;
+    $.getPlayTimeGame = getPlayTimeGame;
     $.getFollows = getFollows;
     $.getGame = getGame;
     $.getStatus = getStatus;

--- a/resources/web/panel/js/globalPanel.js
+++ b/resources/web/panel/js/globalPanel.js
@@ -106,7 +106,7 @@
                     $("#streamUptime").html("<span class=\"purplePill\" data-toggle=\"tooltip\" title=\"Uptime\"><i class=\"fa fa-clock-o fa-lg\" /> " + msgObject['results']['streamUptime'] + "</span>");
                 }
                 if (panelCheckQuery(msgObject, 'global_playTime')) {
-                    $("#timePlayed").html("<span class=\"purplePill\" data-toggle=\"tooltip\" title=\"Time Played\"><i class=\"fa fa-gamepad fa-lg\" /> " + msgObject['results']['timePlay'] + "</span>");
+                    $("#timePlayed").html("<span class=\"purplePill\" data-toggle=\"tooltip\" title=\"Time Played\"><i class=\"fa fa-gamepad fa-lg\" /> " + msgObject['results']['playTime'] + "</span>");
                 }
                 if (panelCheckQuery(msgObject, 'global_viewerCount')) {
                     $("#viewerCount").html("<span class=\"purplePill\" data-toggle=\"tooltip\" title=\"Viewers\"><i class=\"fa fa-users fa-lg\" /> " + msgObject['results']['viewerCount'] + "</span>");

--- a/source/me/mast3rplan/phantombot/cache/TwitchCache.java
+++ b/source/me/mast3rplan/phantombot/cache/TwitchCache.java
@@ -59,7 +59,7 @@ public class TwitchCache implements Runnable {
     private boolean killed = false;
 
     /* Cached data */
-    private boolean isOnline = false;
+    private Boolean isOnline = false;
     private long streamUptimeSeconds = 0L;
     private String gameTitle = "Some Game";
 
@@ -143,8 +143,8 @@ public class TwitchCache implements Runnable {
     private void updateCache() throws Exception {
         Boolean isOnline = false;
         String  gameTitle = "Some Game";
-        Date    streamCreatedDate;
-        Date    currentDate;
+        Date    streamCreatedDate = new Date();
+        Date    currentDate = new Date();
         long    streamUptimeSeconds = 0L;
 
         /* Retrieve Stream Information */
@@ -169,8 +169,7 @@ public class TwitchCache implements Runnable {
 
                 if (isOnline) {
                     /* Calculate the stream uptime in seconds. */
-                    currentDate = new Date();
-                    SimpleDateFormat dateFormat = new SimpleDateFormat("YYYY-MM-DD'T'HH:mm:ss'Z'");
+                    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
                     dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
                     try {
                         streamCreatedDate = dateFormat.parse(streamObj.getJSONObject("stream").getString("created_at"));
@@ -206,14 +205,25 @@ public class TwitchCache implements Runnable {
     /*
      * Returns if the channel is online or not.
      */
-    public boolean isStreamOnline() {
+    public Boolean isStreamOnline() {
         return this.isOnline;
+    }
+
+    /*
+     * Returns a String representation of true/false to indicate if the stream is online or not.
+     */
+    public String isStreamOnlineString() {
+        if (this.isOnline) {
+            return new String("true");
+        }
+        return new String("false");
     }
 
     /*
      * Returns the uptime of the channel in seconds.
      */
     public long getStreamUptimeSeconds() {
+        com.gmt2001.Console.debug.println("getStreamUptimeSeconds::CORE::" + this.streamUptimeSeconds);
         return this.streamUptimeSeconds;
     }
 

--- a/source/me/mast3rplan/phantombot/script/ScriptEventManager.java
+++ b/source/me/mast3rplan/phantombot/script/ScriptEventManager.java
@@ -77,15 +77,13 @@ public class ScriptEventManager implements Listener {
         try {
             for (EventHandlerEntry entry : entries) {
                 if (event.getClass().isAssignableFrom(entry.eventClass)) {
-                    if (PhantomBot.enableDebugging) {
-                        com.gmt2001.Console.out.println(">>>[DEBUG] Dispatching event " + entry.eventClass.getName());
-                    }
+                    com.gmt2001.Console.debug.println("Dispatching event " + entry.eventClass.getName());
 
                     entry.handler.handle(event);
                 }
             }
         } catch (Exception e) {
-            com.gmt2001.Console.out.println(">>>[DEBUG] Failed to dispatch event " + event.getClass().getName());
+            com.gmt2001.Console.err.println("Failed to dispatch event " + event.getClass().getName());
             com.gmt2001.Console.err.printStackTrace(e);
         }
     }


### PR DESCRIPTION
**streamCommand.js**
- No longer talks to API for the game title, requests the name from the variable in streamInfo.  This also ensures that the proper game is named that is reported.  Previously, if a game was changed, the previous playtime was displayed, which didn't make sense.

**streamInfo.js**
- Using the new calls to the twitchcache object in the Core.

**panelHandler.js**
- Moved the playtime handlers to streamInfo.js
- Revamped to use twitchcache instead of calling the API directly

**TwitchCache.java**
- Fix made to the streamUptime calculation.

**ScriptEventManager.java**
- Changed DEBUG statements to make more sense.
