### PR TITLE
Speed Enhancements for Chat Moderation

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -354,9 +354,9 @@
     };
 
     /**
-     * @event ircChannelMessage
+     * @function performModeration
      */
-    $.bind('ircChannelMessage', function(event) {
+    function performModeration(event) {
         var sender = event.getSender().toLowerCase(),
             message = event.getMessage().toLowerCase(),
             messageLength = message.length();
@@ -444,7 +444,7 @@
             if (message && checkBlackList(sender, message)) {
             }
         }
-    });
+    }
 
     /**
      * @function blacklistAndWhitelistCommands()
@@ -1544,6 +1544,7 @@
     });
 
     /** Export functions to API */
+    $.performModeration = performModeration;
     $.timeoutUser = timeoutUserFor;
     $.permitUserLink = permitUser;
 })();

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -570,6 +570,14 @@
         loadScriptRecursive('.');
 
         // Bind all $api events
+
+        /**
+         * @event api-ircModeration
+         */
+        $api.on($script, 'ircModeration', function(event) {
+            $.performModeration(event);
+        });
+
         /**
          * @event api-ircChannelMessage
          */

--- a/source/me/mast3rplan/phantombot/event/EventBus.java
+++ b/source/me/mast3rplan/phantombot/event/EventBus.java
@@ -28,9 +28,12 @@ public class EventBus {
     public static EventBus instance() {
         return instance;
     }
+
     private final com.google.common.eventbus.AsyncEventBus aeventBus = new com.google.common.eventbus.AsyncEventBus(Executors.newFixedThreadPool(8), new ExceptionHandler());
-    private final com.google.common.eventbus.EventBus eventBus = new com.google.common.eventbus.EventBus(new ExceptionHandler());
     private final com.google.common.eventbus.AsyncEventBus ceventBus = new com.google.common.eventbus.AsyncEventBus(Executors.newCachedThreadPool(), new ExceptionHandler());
+    private final com.google.common.eventbus.EventBus meventBus = new com.google.common.eventbus.EventBus(new ExceptionHandler());
+    private final com.google.common.eventbus.EventBus eventBus = new com.google.common.eventbus.EventBus(new ExceptionHandler());
+
     private final Set<Listener> listeners = Sets.newHashSet();
 
     public void register(Listener listener) {
@@ -38,6 +41,7 @@ public class EventBus {
         eventBus.register(listener);
         aeventBus.register(listener);
         ceventBus.register(listener);
+        meventBus.register(listener);
     }
 
     public void unregister(Listener listener) {
@@ -45,6 +49,7 @@ public class EventBus {
         eventBus.unregister(listener);
         aeventBus.unregister(listener);
         ceventBus.register(listener);
+        meventBus.register(listener);
     }
 
     public void post(Event event) {
@@ -70,4 +75,13 @@ public class EventBus {
 
         ceventBus.post(event);
     }
+
+    public void postModeration(Event event) {
+        if (PhantomBot.instance() == null || PhantomBot.instance().isExiting()) {
+            return;
+        }
+
+        meventBus.post(event);
+    }
+
 }

--- a/source/me/mast3rplan/phantombot/event/irc/message/IrcModerationEvent.java
+++ b/source/me/mast3rplan/phantombot/event/irc/message/IrcModerationEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 www.phantombot.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package me.mast3rplan.phantombot.event.irc.message;
+
+import java.util.Map;
+import me.mast3rplan.phantombot.jerklib.Channel;
+import me.mast3rplan.phantombot.jerklib.Session;
+
+public class IrcModerationEvent extends IrcMessageEvent {
+
+    public IrcModerationEvent(Session session, String sender, String message, Channel channel) {
+        super(session, sender, message, null, channel);
+    }
+
+    public IrcModerationEvent(Session session, String sender, String message, Channel channel, Map<String, String> tags) {
+        super(session, sender, message, tags, channel);
+    }
+}


### PR DESCRIPTION
**chatModerator.js**
- Replaced the $bind call for the previous IRC Event, and moved to a new function performModeration

**init.js**
- Call the $.performModeration() function directly in chatModeration when ircModerationEvent is received.

**IrcEventHandler.java**
- Added call to IrcModerationEvent.  Also re-ordered the processing of IRC Messages (chat).

**ircModerationEvent.java**
- Event calls for IRC Moderation.
