### PR TITLE
Audio Hooks from Chat

### DIFF
--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -171,6 +171,23 @@
         $.inidb.set('updates', 'installedv2.0.7.2', 'true');
     }
 
+    if (!$.inidb.exists('updates', 'installedv2.0.8') || $.inidb.get('updates', 'installedv2.0.8') != 'true') {
+        $.consoleLn('Starting PhantomBot version 2.0.8 updates...');
+
+        var newDefaultDisabledModules = [
+            './handlers/twitterHandler.js',
+            './systems/audioPanelSystem.js',
+        ]; //ADD NEW MODULES IN 2.0.8 TO BE DISABLED PLEASE.
+
+        $.consoleLn('Disabling new default modules...');
+        for (i in newDefaultDisabledModules) {
+            $.inidb.set('modules', newDefaultDisabledModules[i], 'false');
+        }
+
+        $.consoleLn("PhantomBot v2.0.8 updates completed!');
+        $.inidb.set('updates', 'installedv2.0.8', 'true');
+    }
+
     /**
      * @function getTableContents
      * @param {string} tableName

--- a/javascript-source/lang/english/systems/systems-audioPanelSystem.js
+++ b/javascript-source/lang/english/systems/systems-audioPanelSystem.js
@@ -1,0 +1,5 @@
+$.lang.register('audiohook.usage', 'usage: !audiohook [play | list]');
+$.lang.register('audiohook.play.usage', 'usage: !audiohook play [audio_hook]');
+$.lang.register('audiohook.play.404', 'Audiohook does not exist: $1');
+$.lang.register('audiohook.play.success', 'Sent audio hook: $1');
+$.lang.register('audiohook.list', 'Audio Hooks: $1');

--- a/javascript-source/systems/audioPanelSystem.js
+++ b/javascript-source/systems/audioPanelSystem.js
@@ -1,0 +1,78 @@
+/**
+ * audioPanelSystem.js
+ *
+ * Play audio on the PhantomBot Control Panel Audio Panel
+ */
+(function() {
+
+    /**
+     * @event command
+     */
+    $.bind('command', function(event) {
+        var sender = event.getSender().toLowerCase(),
+            command = event.getCommand(),
+            args = event.getArgs(),
+            subCommand = args[0],
+            audioHook = args[1],
+            audioHookListStr;
+
+        /**
+         * @commandpath audiohook [play | list] - Base command for audio hooks.
+         * @commandpath audiohook play [audio_hook] - Sends the audio_hook request to the Panel. 
+         * @commandpath audiohook list - Lists the audio hooks.
+         */
+        if (command.equalsIgnoreCase('audiohook')) {
+            var hookKeys = $.inidb.GetKeyList('audio_hooks', ''),
+                hookList = [],
+                idx;
+
+            for (idx in hookKeys) {
+                hookList[hookKeys[idx]] = hookKeys[idx];
+            }
+
+            if (subCommand === undefined) {
+                $.say($.whisperPrefix(sender) + $.lang.get('audiohook.usage'));
+                return;
+            }
+
+            if (subCommand.equalsIgnoreCase('play')) {
+                if (audioHook === undefined) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('audiohook.play.usage'));
+                    return;
+                }
+
+                if (hookList[audioHook] === undefined) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('audiohook.play.404', audioHook));
+                    return;
+                }
+                $.panelsocketserver.triggerAudioPanel(audioHook);
+                $.say($.whisperPrefix(sender) + $.lang.get('audiohook.play.success', audioHook));
+            }
+
+            if (subCommand.equalsIgnoreCase('list')) {
+                audioHookListStr = '';
+                for (idx in hookKeys) {
+                    audioHookListStr += hookKeys[idx];
+                    if (audioHookListStr.length >= 450) {
+                        $.say($.whisperPrefix(sender) + $.lang.get('audiohook.list', audioHookListStr));
+                        audioHookListStr = '';
+                    } else {
+                        if (idx < hookKeys.length - 1) {
+                            audioHookListStr += ', ';
+                        }
+                    }
+                }
+                $.say($.whisperPrefix(sender) + $.lang.get('audiohook.list', audioHookListStr));
+            }
+        }
+    });
+
+    /**
+     * @event initReady
+     */
+    $.bind('initReady', function() {
+        if ($.bot.isModuleEnabled('./systems/audioPanelSystem.js')) {
+            $.registerChatCommand('./systems/audioPanelSystem.js', 'audiohook', 2);
+        }
+    });
+})();

--- a/resources/web/panel/js/audioPanel.js
+++ b/resources/web/panel/js/audioPanel.js
@@ -84,6 +84,8 @@
             ready_callback: ionSoundLoaded,
             ended_callback: clearIonSoundPlaying 
         });
+
+        sendAudioHooksToCore();
     });
 
     /**
@@ -110,7 +112,23 @@
             if (panelCheckQuery(msgObject, 'audio_ytpDJName')) {
                 $('#ytpDJNameInput').attr('placeholder', msgObject['results']['playlistDJname']);
             }
+            if (panelCheckQuery(msgObject, 'audio_panel_hook')) {
+                logMsg('Will Play: ' + msgObject['audio_panel_hook']);
+            }
         }
+
+        if (msgObject['audio_panel_hook'] !== undefined) {
+            playIonSound(msgObject['audio_panel_hook']);
+        }
+    }
+
+    /**
+     * @function sendAudioHooksToCore
+     */
+    function sendAudioHooksToCore() {
+        var jsonObject = {};
+        jsonObject["audio_hooks"] = sounds;
+        connection.send(JSON.stringify(jsonObject));
     }
 
     /**

--- a/source/me/mast3rplan/phantombot/PhantomBot.java
+++ b/source/me/mast3rplan/phantombot/PhantomBot.java
@@ -599,6 +599,7 @@ public class PhantomBot implements Listener {
         Script.global.defineProperty("channelStatus", channelStatus, 0);
         Script.global.defineProperty("musicplayer", musicsocketserver, 0);
         Script.global.defineProperty("ytplayer", ytsocketserver, 0);
+        Script.global.defineProperty("panelsocketserver", panelsocketserver, 0);
         Script.global.defineProperty("random", rng, 0);
         Script.global.defineProperty("youtube", YouTubeAPIv3.instance(), 0);
         Script.global.defineProperty("pollResults", pollResults, 0);


### PR DESCRIPTION
This change allows authorized groups to use !audiohook to list/play audio hooks in the PhantomBot Control Panel Audio Panel

**updates.js**
- Updated to disable module by default.

**systems-audioPanelSystem.js**
- Lang for audioPanelSystem.js

**audioPanelSystem.js**
- Contains the command !audiohook

**audioPanel.js**
- Updated to send list of audio hooks to the Websocket Server
- Updated to accept audio hook command from the Core

**PhantomBot.java**
- Export PanelSocketServer to Rhino

*_PanelSocketServer.java_
- Handle incoming list of audio hooks and insert into the DB
- Send command to the Panel to play an audio hook
