### PR TITLE
Caps Limit Auto-Raise with Emotes Length

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -359,9 +359,12 @@
     function performModeration(event) {
         var sender = event.getSender().toLowerCase(),
             message = event.getMessage().toLowerCase(),
-            messageLength = message.length();
+            messageLength = message.length(),
+            localCapsTriggerLength = capsTriggerLength,
+            emotesObject = {};
 
         if (!$.isModv3(sender, event.getTags())) {
+
             if (linksToggle && $.patternDetector.hasLinks(event)) {
                 if (checkYoutubePlayer(message) || checkPermitList(sender) || checkWhiteList(message)) {
                     return;
@@ -375,18 +378,6 @@
                 sendMessage(sender, linksMessage, silentTimeout.Links);
                 $.logEvent('chatModerator.js', 269, sender + ' was timed out for linking.');
                 return;
-            }
-
-            if (capsToggle && messageLength > capsTriggerLength) {
-                if (((parseFloat($.patternDetector.getNumberOfCaps(event)) / messageLength) * 100) > capsLimitPercent) {
-                    if (!regulars.Caps && $.isReg(sender) || !subscribers.Caps && $.isSubv3(sender, event.getTags())) {
-                        return;
-                    }
-                    timeout(sender, warningTime.Caps, timeoutTime.Caps);
-                    sendMessage(sender, capsMessage, silentTimeout.Caps);
-                    $.logEvent('chatModerator.js', 280, sender + ' was timed out for overusing caps.');
-                    return;
-                }
             }
 
             if (symbolsToggle && messageLength > symbolsTriggerLength) {
@@ -411,7 +402,24 @@
                 return;
             }
 
-            if (emotesToggle && $.patternDetector.getNumberOfEmotes(event) > emotesLimit) {
+            if (!$.bot.isModuleEnabled('./handlers/emotesHandler.js')) {
+                emotesObject = $.patternDetector.getNumberOfEmotes(event);
+                localCapsTriggerLength += emotesObject.length + emotesObject.matches;
+            }
+
+            if (capsToggle && messageLength > localCapsTriggerLength) {
+                if (((parseFloat($.patternDetector.getNumberOfCaps(event)) / messageLength) * 100) > capsLimitPercent) {
+                    if (!regulars.Caps && $.isReg(sender) || !subscribers.Caps && $.isSubv3(sender, event.getTags())) {
+                        return;
+                    }
+                    timeout(sender, warningTime.Caps, timeoutTime.Caps);
+                    sendMessage(sender, capsMessage, silentTimeout.Caps);
+                    $.logEvent('chatModerator.js', 280, sender + ' was timed out for overusing caps.');
+                    return;
+                }
+            }
+
+            if (emotesToggle && emotesObject.matches > emotesLimit) {
                 if (!regulars.Emotes && $.isReg(sender) || !subscribers.Emotes && $.isSubv3(sender, event.getTags())) {
                     return;
                 }

--- a/javascript-source/handlers/emotesHandler.js
+++ b/javascript-source/handlers/emotesHandler.js
@@ -71,7 +71,9 @@
      */
     function getEmotesMatchCount(checkString) {
         var matches = 0,
-            sequences;
+            length = 0,
+            sequences,
+            retObject = {};
 
         if (!emotesLoaded()) {
             return 0;
@@ -79,9 +81,15 @@
 
         for (var i = 0; i < emotesRegExpList.length; i++) {
             sequences = checkString.match(emotesRegExpList[i]);
-            matches += (sequences == null ? 0 : sequences.length);
+            if (sequences !== null) {
+                matches += sequences.length;
+                for (var j = 0; j < sequences.length; j++) {
+                    length += sequences[j].length;
+              }
+            }
         }
-        return matches;
+        retObject = { "matches" : matches, "length" : length };
+        return retObject;
     }
 
     /**


### PR DESCRIPTION
**emotesHandler.js**
- The emotes checker returns an object now with length of the emote(s) matched and the count found.

**chatModerator.js**
- Takes the length of the emotes, plus the number of emotes (assuming a space before each emote) and adds to the capsLimit check.
