### PR TITLE
Print JS Errors to Console

### DIFF
--- a/javascript-source/core/logging.js
+++ b/javascript-source/core/logging.js
@@ -121,13 +121,14 @@
         }
 
         try {
-            throw new Error('eventlog');
+            throw new Error('errorlog');
         } catch (e) {
             sourceFile = e.stack.split('\n')[1].split('@')[1];
         }
 
         var now = new Date();
         $.writeToFile('[' + getLogEntryTimeDateString(now) + '] [' + sourceFile + '] ' + message,'./logs/error/' + getLogDateString() + '.txt', true);
+        Packages.com.gmt2001.Console.err.printlnRhino(java.util.Objects.toString('[' + sourceFile + '] ' + message));
     };
 
     /**


### PR DESCRIPTION
**logging.js**
- $.error.log() now prints to console as well so that if watching the console, errors are seen immediately.
