### PR TITLE
Fix Username Cache

### DIFF
--- a/source/me/mast3rplan/phantombot/cache/UsernameCache.java
+++ b/source/me/mast3rplan/phantombot/cache/UsernameCache.java
@@ -115,8 +115,10 @@ public class UsernameCache {
     }
 
     public void addUser(String userName, String displayName) {
-        if (!cache.containsKey(userName)) {
-            cache.put(userName, displayName);
+        if (displayName.length() > 0) {
+            if (!cache.containsKey(userName)) {
+                cache.put(userName, displayName);
+            }
         }
     }
 }


### PR DESCRIPTION
**UsernameCache.java**
- When passing data to update the cache directly, ensure that the data is not blank.
- This was a problem with Twitch IRC tags. Although the tag was present, the value was empty.
