### PR TITLE
- Fixed hook call for timer

### DIFF
--- a/javascript-source/handlers/twitterHandler.js
+++ b/javascript-source/handlers/twitterHandler.js
@@ -7,8 +7,7 @@
  * 
  */
 (function() {
-    var moduleStarted = false,
-        randPrev = 0,
+    var randPrev = 0,
         onlinePostDelay = 10 * 6e4; // 10 minutes must pass between Online Posts. This should take care of Twitch/OBS issues.
  
     /* Set default values for all configuration items. */
@@ -399,6 +398,10 @@
         }
     }
 
+    setInterval(function() { 
+        checkAutoUpdate(); 
+    }, 6e4, 'checkAutoUpdate');
+
     /**
      * @event initReady
      */
@@ -411,12 +414,6 @@
             $.registerChatSubcommand('twitter', 'lastmention', 7);
             $.registerChatSubcommand('twitter', 'lastretweet', 7);
             $.registerChatSubcommand('twitter', 'id', 7);
-
-            if (!moduleStarted) {
-                moduleStarted = true;
-                setInterval(function() { checkAutoUpdate(); }, 6e4, 'checkAutoUpdate');
-            }
         }
     });
-
 })();


### PR DESCRIPTION
Sometimes the scripts reloads when you enable a module and it freaks out the timers. I can't get it to happen, but I see it in logs
