### PR TITLE
Allow Empty Lang Messages

### DIFF
--- a/javascript-source/core/lang.js
+++ b/javascript-source/core/lang.js
@@ -21,7 +21,7 @@
         }
 
         if ($.isDirectory('./scripts/lang/custom')) {
-            $.bot.loadScriptRecursive('./lang/custom', true);
+            $.bot.loadScriptRecursive('./lang/custom', false);
         }
 
         // Set "response_@chat" to true if it hasn't been set yet, so the bot isn't muted when using a fresh install
@@ -40,6 +40,9 @@
         if (key && string) {
             data[key] = string;
         }
+        if (key && string.length === 0) {
+            data[key] = '<<EMPTY_PLACEHOLDER>>';
+        }
     }
 
     /**
@@ -55,6 +58,9 @@
             $.log.error('Language string missing for "' + key + '"');
             $.consoleLn('[lang.js] Missing string "' + key + '"');
             return 'Could not find string for "' + key + '"';
+        }
+        if (string.equals('<<EMPTY_PLACEHOLDER>>')) {
+            return '';
         }
         for (i = 1; i < arguments.length; i++) {
             while (string.indexOf("$" + i) >= 0) {

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -96,6 +96,10 @@
      */
     function say(message) {
         if ($.channel !== null) {
+            if (message.length === 0) {
+                return;
+            }
+
             if (message.substr(0, 1).equals('.')) {
                 $.channel.say(message);
                 $.consoleLn('[CHAT] ' + message);


### PR DESCRIPTION
**lang.js**
- If a lang.register has no text associated ($.lang.register('key', '')) then an empty placeholder is created
- When processing with $.lang.get() the empty placeholder returns an empty string.

**misc.js**
- The $.say() command will not send anything to chat if an empty message is presented.
