### PR TITLE
Block @mentions from Twitter API

### DIFF
--- a/source/com/illusionaryone/TwitterAPI.java
+++ b/source/com/illusionaryone/TwitterAPI.java
@@ -176,7 +176,7 @@ public class TwitterAPI {
         }
 
         try {
-            Status status = twitter.updateStatus(statusString);
+            Status status = twitter.updateStatus(statusString.replaceAll("@", ""));
             com.gmt2001.Console.debug.println("TwitterAPI::updateStatus: Success");
             return "true";
         } catch (TwitterException ex) {
@@ -198,7 +198,7 @@ public class TwitterAPI {
         }
 
         try {
-            StatusUpdate statusUpdate = new StatusUpdate(statusString);
+            StatusUpdate statusUpdate = new StatusUpdate(statusString.replaceAll("@", ""));
             statusUpdate.setMedia(new File(filename));
             Status status = twitter.updateStatus(statusUpdate);
             com.gmt2001.Console.debug.println("TwitterAPI::updateStatus: Success");


### PR DESCRIPTION
**TwitterAPI.java**
- Per a request from Twitter, @mentions are not allowed from a Bot.  The @ character is stripped off now and the message still sent.
