### PR TITLE
Add support for Proxy to PhantomBot

### DIFF
--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -38,10 +38,10 @@
                     var urlInfo = window.location.host.split(":");
                     var url = urlInfo[0];
                     var port;
-                    if (urlInfo[1].endsWith("0")) {
+                    if (typeof urlInfo[1] !== 'undefined' && urlInfo[1].endsWith("0")) {
                        port = (parseInt(urlInfo[1]) + 5);
                     } else {
-                       port = urlInfo[1];
+                       port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
                     }
                     document.write('<a target="_blank" style="color: white;" href="http://' + urlInfo[0] + ':' + port + '/ytplayer">');
                 </script>
@@ -59,10 +59,10 @@
                     var urlInfo = window.location.host.split(":");
                     var url = urlInfo[0];
                     var port;
-                    if (urlInfo[1].endsWith("0")) {
+                    if (typeof urlInfo[1] !== 'undefined' && urlInfo[1].endsWith("0")) {
                        port = (parseInt(urlInfo[1]) + 5);
                     } else {
-                       port = urlInfo[1];
+                       port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
                     }
                     document.write('<a target="_blank" style="color: white;" href="http://' + urlInfo[0] + ':' + port + '/panel">');
                 </script>
@@ -80,10 +80,10 @@
                     var urlInfo = window.location.host.split(":");
                     var url = urlInfo[0];
                     var port;
-                    if (urlInfo[1].endsWith("0")) {
+                    if (typeof urlInfo[1] !== 'undefined' && urlInfo[1].endsWith("0")) {
                        port = (parseInt(urlInfo[1]) + 5);
                     } else {
-                       port = urlInfo[1];
+                       port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
                     }
                     document.write('<a target="_blank" style="color: white;" href="http://' + urlInfo[0] + ':' + port + '/playlist">');
                 </script>

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -37,11 +37,9 @@
                 <script>
                     var urlInfo = window.location.host.split(":");
                     var url = urlInfo[0];
-                    var port;
-                    if (typeof urlInfo[1] !== 'undefined' && urlInfo[1].endsWith("0")) {
-                       port = (parseInt(urlInfo[1]) + 5);
-                    } else {
-                       port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
+                    var port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
+                    if (port.endsWith("0") && port !== '80') {
+                       port = (parseInt(port) + 5);
                     }
                     document.write('<a target="_blank" style="color: white;" href="http://' + urlInfo[0] + ':' + port + '/ytplayer">');
                 </script>
@@ -58,11 +56,9 @@
                 <script>
                     var urlInfo = window.location.host.split(":");
                     var url = urlInfo[0];
-                    var port;
-                    if (typeof urlInfo[1] !== 'undefined' && urlInfo[1].endsWith("0")) {
-                       port = (parseInt(urlInfo[1]) + 5);
-                    } else {
-                       port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
+                    var port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
+                    if (port.endsWith("0") && port !== '80') {
+                       port = (parseInt(port) + 5);
                     }
                     document.write('<a target="_blank" style="color: white;" href="http://' + urlInfo[0] + ':' + port + '/panel">');
                 </script>
@@ -79,11 +75,9 @@
                 <script>
                     var urlInfo = window.location.host.split(":");
                     var url = urlInfo[0];
-                    var port;
-                    if (typeof urlInfo[1] !== 'undefined' && urlInfo[1].endsWith("0")) {
-                       port = (parseInt(urlInfo[1]) + 5);
-                    } else {
-                       port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
+                    var port = (typeof urlInfo[1] === 'undefined' ? '80' : urlInfo[1]);
+                    if (port.endsWith("0") && port !== '80') {
+                       port = (parseInt(port) + 5);
                     }
                     document.write('<a target="_blank" style="color: white;" href="http://' + urlInfo[0] + ':' + port + '/playlist">');
                 </script>


### PR DESCRIPTION
Fix javascript URL creation to support standard port 80 proxy to PhantomBot port.

When running PhantomBot behind proxy (e.g. nginx, Apache) the landing page links fail to be created because urlInfo[1] doesn't exist.  This tests for existence and adjusts accordingly.
