### PR TITLE
Allow Auto-Commit to be Disabled with SQLite

### DIFF
--- a/javascript-source/core/timeSystem.js
+++ b/javascript-source/core/timeSystem.js
@@ -365,10 +365,12 @@
             i;
 
         if ($.isOnline($.channelName) || keepTimeWhenOffline) {
+            $.inidb.setAutoCommit(false);
             for (i in $.users) {
                 username = $.users[i][0].toLowerCase();
                 $.inidb.incr('time', username, 61);
             }
+            $.inidb.setAutoCommit(true);
         }
     }, 6e4);
 

--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -205,6 +205,7 @@
             }
         }
 
+        $.inidb.setAutoCommit(false);
         for (i in $.users) {
             username = $.users[i][0].toLowerCase();
             if ($.isOnline($.channelName)) {
@@ -257,6 +258,7 @@
                 uUsers.push(username + '(' + amount + ')');
             }
         }
+        $.inidb.setAutoCommit(true);
         $.log.file('pointSystem', 'Executed ' + pointNameMultiple + ' payouts. Users: ' + (uUsers.length > 0 ? uUsers.join(', ') : 'none'));
         lastPayout = now;
     };

--- a/source/com/gmt2001/DataStore.java
+++ b/source/com/gmt2001/DataStore.java
@@ -220,4 +220,7 @@ public class DataStore {
     public Connection CreateConnection(String db, String user, String pass) {
         return null;
     }
+
+    public void setAutoCommit(boolean mode) {
+    }
 }

--- a/source/com/gmt2001/SqliteStore.java
+++ b/source/com/gmt2001/SqliteStore.java
@@ -538,4 +538,17 @@ public class SqliteStore extends DataStore {
         }
     }
 
+    @Override
+    public void setAutoCommit(boolean mode) {
+        CheckConnection();
+
+        try {
+            connection.setAutoCommit(mode);
+            if (mode == true) {
+                connection.commit();
+            }
+        } catch (SQLException ex) {
+            com.gmt2001.Console.err.printStackTrace(ex);
+        }
+    }
 }


### PR DESCRIPTION
**DataStore.java** 
- Provide public method to setAutoCommit(boolean)

**SqliteStore.java**
- SQLite implemention for setAutoCommit. After autoCommit is re-enabled, all data is committed.

**timeSystem.js**
- Disables auto commit before updating all user times.

**pointSystem.js**
- Disables auto commit before updating all user points.
