### PR TITLE
Patch to API Method to Always Send OAUTH

### DIFF
--- a/source/com/gmt2001/TwitchAPIv3.java
+++ b/source/com/gmt2001/TwitchAPIv3.java
@@ -99,6 +99,10 @@ public class TwitchAPIv3 {
 
             if (!oauth.isEmpty()) {
                 c.addRequestProperty("Authorization", "OAuth " + oauth);
+            } else {
+                if (!this.oauth.isEmpty()) {
+                    c.addRequestProperty("Authorization", "OAuth " + oauth);
+                }
             }
 
             c.setRequestMethod(type.name());


### PR DESCRIPTION
**TwitchAPIv3.java** 
- When performing a REST call, was not checking this.oauth; only oauth, resulting in not always using the globally set version with some calls.
