### PR TITLE
MySQL Auto-Commit Support

### DIFF
--- a/source/com/gmt2001/MySQLStore.java
+++ b/source/com/gmt2001/MySQLStore.java
@@ -44,7 +44,7 @@ public class MySQLStore extends DataStore {
     private String db = "";
     private String user = "";
     private String pass = "";
-   
+    private int autoCommitCtr = 0;
 
     public static MySQLStore instance() {
         return instance;
@@ -466,4 +466,34 @@ public class MySQLStore extends DataStore {
         }
     }
 
+    @Override
+    public void setAutoCommit(boolean mode) {
+        CheckConnection();
+
+        try {
+            if (mode == true) {
+                decrAutoCommitCtr();
+                if (getAutoCommitCtr() == 0) {
+                    connection.commit();
+                    connection.setAutoCommit(mode);
+                }
+            } else {
+                incrAutoCommitCtr();
+                connection.setAutoCommit(mode);
+                com.gmt2001.Console.debug.println(getAutoCommitCtr());
+            }
+        } catch (SQLException ex) {
+            com.gmt2001.Console.debug.println("MySQL commit was attempted too early, will perform later.");
+        }
+    }
+
+    private synchronized void incrAutoCommitCtr() {
+        autoCommitCtr++;
+    }
+    private synchronized void decrAutoCommitCtr() {
+        autoCommitCtr--;
+    }
+    private synchronized int getAutoCommitCtr() {
+        return autoCommitCtr;
+    }
 }

--- a/source/me/mast3rplan/phantombot/PhantomBot.java
+++ b/source/me/mast3rplan/phantombot/PhantomBot.java
@@ -1352,6 +1352,7 @@ public class PhantomBot implements Listener {
             mysql.RemoveFile(table);
         }
 
+        mysql.setAutoCommit(false);
         com.gmt2001.Console.out.println("  Converting SQLite to MySQL...");
         String[] tables = sqlite.GetFileList();
         for (String table : tables) {
@@ -1365,6 +1366,7 @@ public class PhantomBot implements Listener {
                 }
             }
         }
+        mysql.setAutoCommit(true);
         sqlite.CloseConnection();
         com.gmt2001.Console.out.println("  Finished Converting Tables.");
 


### PR DESCRIPTION
**MySQLStore.java**
- Added in @Override for setAutoCommit()

**PhantomBot.java**
- Disable auto-commit during conversion of SQLite database to MySQL. Originally needed ~5 minutes with my data set.  Now 10 seconds.
