### PR TITLE
Fix Issue with some JSON Parsing

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -287,7 +287,7 @@
                         } catch (ex) {
                             if (ex.message.indexOf('not a string') != -1) {
                                 try {
-                                    customAPIResponse = jsonObject.getInt(jsonCheckList[0]);
+                                    customAPIResponse = new JSONObject(origCustomAPIResponse).getInt(jsonCheckList[0]);
                                 } catch (ex) {
                                     return $.lang.get('customcommands.customapijson.err', command);
                                 }


### PR DESCRIPTION
**customCommands.java**
- Certain JSON formats were causing a parse issue.  In this instance, when an Integer was found past the initial set of JSON object(s).
