### PR TITLE
Added !createdat Command - Intended for Mods+

### DIFF
--- a/javascript-source/commands/streamCommand.js
+++ b/javascript-source/commands/streamCommand.js
@@ -168,6 +168,26 @@
                 return;
             } 
         }
+
+        /**
+         * @commandpath createdat [channel] - Returns when a channel was created in Twitch Timestamp format.
+         *
+         * The purpose of this command is for moderators to help identify potential trolls that created a new
+         * account after being banned.
+         */
+        if (command.equalsIgnoreCase('createdat')) {
+            if (args.length === 0) {
+                $.say($.whisperPrefix(sender) + $.lang.get('streamcommand.createdat.404'));
+                return;
+            }
+            var createdAt = $.twitch.getChannelCreatedDate(args[0]);
+            if (createdAt.equals("ERROR")) {
+                $.say($.whisperPrefix(sender) + $.lang.get('streamcommand.createdat.error'));
+            } else {
+                $.say($.whisperPrefix(sender) + $.lang.get('streamcommand.createdat', args[0], createdAt));
+            }
+            return;
+        }
     });
 
 
@@ -184,6 +204,7 @@
             $.registerChatCommand('./commands/streamCommand.js', 'title', 7);
             $.registerChatCommand('./commands/streamCommand.js', 'playtime', 7);
             $.registerChatCommand('./commands/streamCommand.js', 'vod', 7);
+            $.registerChatCommand('./commands/streamCommand.js', 'createdat', 2);
 
             $.registerChatSubcommand('game', 'set', 1);
             $.registerChatSubcommand('title', 'set', 1);

--- a/javascript-source/lang/english/commands/commands-streamCommands.js
+++ b/javascript-source/lang/english/commands/commands-streamCommands.js
@@ -11,3 +11,6 @@ $.lang.register('streamcommand.game.set.usage', 'usage: !game set [game title]. 
 $.lang.register('streamcommand.viewers', 'Currently $1 viewers are watching.');
 $.lang.register('streamcommand.online.offline', 'Stream is offline.');
 $.lang.register('streamcommand.online.online', 'Stream is online.');
+$.lang.register('streamcommand.createdat.404', 'Please provide a channel');
+$.lang.register('streamcommand.createdat.error', 'The channel does not exist or a Twitch API error occurred.');
+$.lang.register('streamcommand.createdat', 'Channel: $1 | Created At: $2');

--- a/source/com/gmt2001/TwitchAPIv3.java
+++ b/source/com/gmt2001/TwitchAPIv3.java
@@ -603,6 +603,20 @@ public class TwitchAPIv3 {
     }
 
     /**
+     * Returns when a Twitch account was created.
+     *
+     * @param   String   channel
+     * @return  String   date-time representation (2015-05-09T00:08:04Z)
+     */
+    public String getChannelCreatedDate(String channel) {
+        JSONObject jsonInput = GetData(request_type.GET, base_url + "/channels/" + channel, false);
+        if (jsonInput.has("created_at")) {
+            return jsonInput.getString("created_at");
+        }
+        return "ERROR";
+    }
+
+    /**
      * Tests the Twitch API to ensure that authentication is good.
      */
     public boolean TestAPI() {


### PR DESCRIPTION
**TwitchAPIv4.java**
- Added support for getting when a channel was created.

**streamCommand.js**
- Added !createdat [channel] This is intended for mods+ to be able to see when a channel (Twitch account) was created. This is useful for determining if someone that was banned may have created a brand new account and come back.
