### PR TITLE
Add !pricecom Support for Sub-commands and Sub-Actions

### DIFF
--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -797,6 +797,8 @@
                 command = event.getCommand().toLowerCase(),
                 args = event.getArgs(),
                 subCommand = (args[0] ? args[0] : ''),
+                subCommandAction = (args[1] ? args[1] : ''),
+                commandCost = 0,
                 permComCheck = $.permCom(sender, command, subCommand),
                 isModv3 = $.isModv3(sender, event.getTags());
 
@@ -864,11 +866,14 @@
                 return;
             }
 
-            if ($.inidb.exists('pricecom', command)) {
+            if (($.inidb.exists('pricecom', command) ||
+                 $.inidb.exists('pricecom', command + ' ' + subCommand) ||
+                 $.inidb.exists('pricecom', (command + ' ' + subCommand + ' ' + subCommandAction)))) {
                 if ((((isModv3 && pricecomMods && !$.isBot(sender)) || !isModv3))) {
                     if (isModuleEnabled('./systems/pointSystem.js')) {
-                        if ($.getUserPoints(sender) < $.getCommandPrice(command)) {
-                            $.say($.whisperPrefix(sender) + $.lang.get('cmd.needpoints', $.getPointsString($.inidb.get('pricecom', command))));
+                        commandCost = $.getCommandPrice(command, subCommand, subCommandAction);
+                        if ($.getUserPoints(sender) < commandCost) {
+                            $.say($.whisperPrefix(sender) + $.lang.get('cmd.needpoints', $.getPointsString(commandCost)));
                             return;
                         }
                     }
@@ -881,8 +886,8 @@
                 if (parseInt($.inidb.get('paycom', command)) > 0) {
                     $.inidb.incr('points', sender, $.inidb.get('paycom', command));
                 }
-                if ($.inidb.exists('pricecom', command) && parseInt($.inidb.get('pricecom', command)) > 0) {
-                    $.inidb.decr('points', sender, $.inidb.get('pricecom', command));
+                if (commandCost > 0) {
+                    $.inidb.decr('points', sender, commandCost);
                 }
             }
             handleInitCommands(event);

--- a/javascript-source/lang/english/commands/commands-customCommands.js
+++ b/javascript-source/lang/english/commands/commands-customCommands.js
@@ -21,7 +21,7 @@ $.lang.register('customcommands.set.perm.404', 'This command does not seem to ex
 $.lang.register('customcommands.set.price.error.404', 'please select a command that exists and is available to non-mods.');
 $.lang.register('customcommands.set.price.error.invalid', 'please enter a valid price, 0 or greater.');
 $.lang.register('customcommands.set.price.success', 'the price for !$1 has been set to $2 $3.');
-$.lang.register('customcommands.set.price.usage', 'usage: !pricecom (command) (price)');
+$.lang.register('customcommands.set.price.usage', 'usage: !pricecom (command) [subcommand] [subaction] (price). Optional: subcommand and subaction');
 $.lang.register('customcommands.set.pay.error.404', 'please select a command that exists and is available to non-mods.');
 $.lang.register('customcommands.set.pay.error.invalid', 'please enter a valid payment, 0 or greater.');
 $.lang.register('customcommands.set.pay.success', 'the pay for !$1 has been set to $2 $3.');


### PR DESCRIPTION
**init.js**
- Perform the additional checks on a command and subcommand and subcommand action to check for price.

**customCommands.js**
- Get the proper price for a command.
- Modified !pricecom
