### PR TITLE
Fix randRange()

### DIFF
--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -160,7 +160,7 @@
         if (min == max) {
             return min;
         }
-        return (rand(max) + min);
+        return (rand(max - min + 1) + min);
     };
 
     /**


### PR DESCRIPTION
**misc.js**
- The randRange() function was not properly handling minimum values other than 0 and 1.
