### PR TITLE
- fixes, stop breaking things.

### DIFF
--- a/javascript-source/core/fileSystem.js
+++ b/javascript-source/core/fileSystem.js
@@ -8,7 +8,7 @@
         JFileInputStream = java.io.FileInputStream,
         JFileOutputStream = java.io.FileOutputStream;
 
-    var fileHandles = {};
+    var fileHandles = [];
 
     /**
      * @function readFile
@@ -86,8 +86,8 @@
      * @function closeOpenFiles
      */
     function closeOpenFiles() {
-        for (key in fileHandles) {
-            if (fileHandles[key].lastWrite + 36e5 >= $.systemTime()) { 
+        for (var key in fileHandles) {
+            if (fileHandles[key].lastWrite + 36e5 <= $.systemTime()) { 
                 fileHandles[key].fos.close();
                 delete fileHandles[key];
             }
@@ -107,9 +107,9 @@
 
         closeOpenFiles();
 
-        if (fileHandles.path !== undefined) {
-            fos = fileHandles.path.fos;
-            ps = fileHandles.path.ps;
+        if (fileHandles[path] !== undefined) {
+            fos = fileHandles[path].fos;
+            ps = fileHandles[path].ps;
             fileHandles[path].lastWrite = $.systemTime();
         } else {
             fos = new JFileOutputStream(path, append);


### PR DESCRIPTION
**fileSystem.js**
- You cannot use `array.something` for a lookup array. It needs to be `array[something]`.
- Also fixed the `<=` being wrong and deleting the file all the time. 
