### PR TITLE
Fix SQLite and MySQL DataStores

### DIFF
--- a/source/com/gmt2001/MySQLStore.java
+++ b/source/com/gmt2001/MySQLStore.java
@@ -28,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import org.apache.commons.io.FileUtils;
-import org.sqlite.SQLiteConfig;
 
 import me.mast3rplan.phantombot.PhantomBot;
 
@@ -67,6 +66,7 @@ public class MySQLStore extends DataStore {
         this.pass = pass;
         try {
             connection = DriverManager.getConnection(db, user, pass);
+            connection.setAutoCommit(getAutoCommitCtr() == 0);
             com.gmt2001.Console.out.println("Connected to MySQL");
             return connection;
         } catch (SQLException ex) {
@@ -387,8 +387,9 @@ public class MySQLStore extends DataStore {
         fName = validateFname(fName);
         AddFile(fName);
 
+        setAutoCommit(false);
+
         try {
-            connection.setAutoCommit(false);
             try (PreparedStatement statement = connection.prepareStatement("REPLACE INTO phantombot_" + fName + " (value, section, variable) values(?, ?, ?);")) {
                 statement.setQueryTimeout(10);
                 for (int idx = 0; idx < keys.length; idx++) {
@@ -405,19 +406,13 @@ public class MySQLStore extends DataStore {
                 statement.executeBatch();
                 statement.clearBatch();
                 connection.commit();
-                connection.setAutoCommit(true);
             }
         } catch (SQLException ex) {
             com.gmt2001.Console.err.println(ex);
             com.gmt2001.Console.err.printStackTrace(ex);
         }
 
-        try {
-            connection.setAutoCommit(true);
-        } catch (SQLException ex) {
-            com.gmt2001.Console.err.println(ex);
-            com.gmt2001.Console.err.printStackTrace(ex);
-        }
+        setAutoCommit(true);
     }
 
     @Override

--- a/source/com/gmt2001/SqliteStore.java
+++ b/source/com/gmt2001/SqliteStore.java
@@ -106,7 +106,7 @@ public class SqliteStore extends DataStore {
                     }
                 }
 
-                connection = CreateConnection(dbname, cache_size, safe_write, journal);
+                connection = CreateConnection(dbname, cache_size, safe_write, journal, true);
             }
         } catch (IOException ex) {
             com.gmt2001.Console.err.printStackTrace(ex);
@@ -117,7 +117,7 @@ public class SqliteStore extends DataStore {
                };
     }
 
-    private static Connection CreateConnection(String dbname, int cache_size, boolean safe_write, boolean journal) {
+    private static Connection CreateConnection(String dbname, int cache_size, boolean safe_write, boolean journal, boolean autocommit) {
         Connection connection = null;
 
         try {
@@ -127,7 +127,7 @@ public class SqliteStore extends DataStore {
             config.setTempStore(SQLiteConfig.TempStore.MEMORY);
             config.setJournalMode(journal ? SQLiteConfig.JournalMode.TRUNCATE : SQLiteConfig.JournalMode.OFF);
             connection = DriverManager.getConnection("jdbc:sqlite:" + dbname.replaceAll("\\\\", "/"), config.toProperties());
-            connection.setAutoCommit(getAutoCommitCtr() == 0);
+            connection.setAutoCommit(autocommit);
         } catch (SQLException ex) {
             com.gmt2001.Console.err.printStackTrace(ex);
         }
@@ -164,7 +164,7 @@ public class SqliteStore extends DataStore {
     private void CheckConnection() {
         try {
             if (connection == null || connection.isClosed() || !connection.isValid(10)) {
-                connection = CreateConnection(dbname, cache_size, safe_write, journal);
+                connection = CreateConnection(dbname, cache_size, safe_write, journal, getAutoCommitCtr() == 0);
             }
         } catch (SQLException ex) {
             com.gmt2001.Console.err.printStackTrace(ex);


### PR DESCRIPTION
Set auto commit to current auto commit state upon connection
Remove unnecessary reference to org.sqlite.SQLiteConfig in MySQLStore
Use helper setAutoCommit method to change auto commit mode in SetBatchString so the proper state is restored afterwards
Move setAutoCommit calls in SetBatchString to proper locations and remove extra setAutoCommit call
