### PR TITLE
Eclipse tutorial & and buildfile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,7 @@ genTwitterTokens/classes/generatetwittertokens
 nbproject
 
 # Eclipse Project files
+.settings\
+.classpath
+.project
 

--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -57,4 +57,16 @@ DONE! Happy coding <3
 ##Eclipse
 You can get Eclipse [here](https://www.eclipse.org/downloads/).
 
-Yet to be written.
+1. Open up Eclipse
+2. Clone repository using File -> Import
+3. Type on filter text **Git**, then select **Projects from Git**. Click **Next**.
+4. Select **Clone URI**. Click **Next**.
+5. Paste or enter repository url. On **Authentication** column enter your GitHub username and password. **Next** page!
+6. Select the branches you want. Click **Next**.
+7. Choose a destination folder, default branch and remote name. Click **Next**.
+8. When the clone process is finished select *"Import using the New Project wizard"*. Click **Next**. And press **Finish** to adding project.
+9. Select or type filter text *"Java Project from Existing Ant Buildfile"*. **Next** page!
+10. Click **Browse** to select `build.xml` from destination folder. Also mark *Link to the buildfile in the file system*. Press **Finish**
+  `./libraries` has been automatically imported to *Referenced Libraries*.
+
+DONE! Happy coding <3

--- a/build.xml
+++ b/build.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project basedir="." default="dist">
+<project name="PhantomBot" basedir="." default="dist">
 
     <!-- To specify a Nightly Build run as ant -Dnightly=nightly_build -->
 
     <property environment="env" />
     <property name="project.base.dir" value="." />
-    <property name="name" value="PhantomBot" />
     <property name="version" value="2.3.1" />
     <property name="webpanel.version" value="1.1" />
     <property name="java.class.path" value="" />
@@ -14,8 +13,8 @@
     <property name="build" value="${project.base.dir}/build" />
     <property name="classes" value="${build}/classes" />
     <property name="dist" value="${project.base.dir}/dist" />
-    <property name="versionfolder" value="${dist}/${name}-${version}" />
-    <property name="version.name" value="${name}-${version}" />
+    <property name="versionfolder" value="${dist}/${ant.project.name}-${version}" />
+    <property name="version.name" value="${ant.project.name}-${version}" />
     <property name="build.dir" value="${dist}/build" />
     <property name="res.dir" value="${build.dir}" />
     <property name="lib.dir" value="${build.dir}/lib" />
@@ -75,8 +74,8 @@
     </target>
 
     <target depends="init,git.revision" name="pre.compile">
-        <echo>PhantomBot Version ${version} (${repository.version}) (${nightly_build})</echo>
-        <echo>PhantomBot Control Panel Version ${webpanel.version}</echo>
+        <echo>${ant.project.name} Version ${version} (${repository.version}) (${nightly_build})</echo>
+        <echo>${ant.project.name} Control Panel Version ${webpanel.version}</echo>
         <replace
             file="source/me/mast3rplan/phantombot/RepoVersion.java"
             token="@repository.version@"
@@ -130,14 +129,14 @@
     </target>
 
     <target depends="compile.src,post.compile,git.revision" name="jar">
-        <jar destfile="${build.dir}/PhantomBot.jar">
+        <jar destfile="${build.dir}/${ant.project.name}.jar">
             <fileset dir="${classes}" />
             <manifest>
-                <attribute name="Bundle-Name" value="${name}" />
+                <attribute name="Bundle-Name" value="${ant.project.name}" />
                 <attribute name="Bundle-Version" value="${version}" />
                 <attribute name="Bundle-Revision" value="${git.revision}" />
                 <attribute name="Bundle-Date" value="${NOW}" />
-                <attribute name="Implementation-Title" value="${name}" />
+                <attribute name="Implementation-Title" value="${ant.project.name}" />
                 <attribute name="Implementation-Version" value="${version}" />
                 <attribute name="Implementation-Revision" value="${git.revision}" />
                 <attribute name="Implementation-URL" value="https://phantombot.tv" />
@@ -174,7 +173,7 @@
         <java fork="true" classname="me.mast3rplan.phantombot.PhantomBot" dir="${build.dir}">
             <classpath>
                 <path refid="classpath" />
-                <path location="${build.dir}/PhantomBot.jar" />
+                <path location="${build.dir}/${ant.project.name}.jar" />
             </classpath>
         </java>
     </target>


### PR DESCRIPTION
**build.xml**
- added project name - for Eclipse importing.
- Renaming all **PhantomBot** typos and retake from project name

**DEVSETUP.md**
- adding Eclipse tutorial - worked from Eclipse Neon (4.7)

**.gitignore**
- adding `.settings` , `.classpath` and `.project` to ignoring files - created by Eclipse

_Please check some typos before merge to the repo._
