### PR TITLE
WebSocket Server Support for dbkeyslist

### DIFF
--- a/resources/web/panel/js/panelUtils.js
+++ b/resources/web/panel/js/panelUtils.js
@@ -194,6 +194,21 @@ function sendDBKeys(unique_id, table) {
 }
 
 /**
+ * @function sendDBKeysList
+ * @param {String} unique_id
+ * @param {Array}{String} tables
+ */
+function sendDBKeysList(unique_id, tableList) {
+    jsonObject = {};
+    jsonObject["dbkeyslist"] = unique_id;
+    jsonObject["query"] = [];
+    for (i in tableList) {
+        jsonObject["query"].push({ "table": tableList[i] });
+    }
+    connection.send(JSON.stringify(jsonObject));
+}
+
+/**
  * @function sendDBUpdate
  * @param {String} unique_id
  * @param {String} table

--- a/source/me/mast3rplan/phantombot/panel/PanelSocketServer.java
+++ b/source/me/mast3rplan/phantombot/panel/PanelSocketServer.java
@@ -36,6 +36,7 @@
  *
  * // Query DB keys and values
  * { "dbkeys" : "query_id", "query" : { "table" : "table_name"  } }
+ * { "dbkeyslist" : "query_id", "query" : [ { "table" : "table_name"  } ] }
  *
  * // Update DB
  * { "dbupdate" : "query_id", "update" : { "table" : "table_name", "key" : "key_name", "value" : "new_value" } }
@@ -231,6 +232,10 @@ public class PanelSocketServer extends WebSocketServer {
                 uniqueID = jsonObject.getString("dbkeys");
                 String table = jsonObject.getJSONObject("query").getString("table");
                 doDBKeysQuery(webSocket, uniqueID, table);
+            } else if (jsonObject.has("dbkeyslist")) {
+                uniqueID = jsonObject.getString("dbkeyslist");
+                jsonArray = jsonObject.getJSONArray("query");
+                doDBKeysListQuery(webSocket, uniqueID, jsonArray);
             } else if (jsonObject.has("dbupdate") && !sessionData.isReadOnly()) {
                 uniqueID = jsonObject.getString("dbupdate");
                 String table = jsonObject.getJSONObject("update").getString("table");
@@ -354,6 +359,39 @@ public class PanelSocketServer extends WebSocketServer {
         jsonObject.endArray().endObject();
         webSocket.send(jsonObject.toString());
     }
+
+    private void doDBKeysListQuery(WebSocket webSocket, String id, JSONArray jsonArray) {
+        JSONStringer jsonObject = new JSONStringer();
+
+        if (jsonArray.length() == 0) {
+            return;
+        }
+
+        jsonObject.object().key("query_id").value(id).key("results").array();
+
+        try {
+            for (int i = 0; i < jsonArray.length(); i++) {
+                if (jsonArray.getJSONObject(i).has("table")) {
+                    String table = jsonArray.getJSONObject(i).getString("table");
+                    String[] dbKeys = PhantomBot.instance().getDataStore().GetKeyList(table, "");
+                    for (String dbKey : dbKeys) {
+                        String value = PhantomBot.instance().getDataStore().GetString(table, "", dbKey);
+                        jsonObject.object().key("table").value(table).key("key").value(dbKey).key("value").value(value).endObject();
+                    }
+                }
+            }
+        } catch (NullPointerException ex) {
+            if (!dbCallNull) {
+                debugMsg("NULL returned from DB. DB Object not created yet.");
+            }
+            return;
+        }
+
+        jsonObject.endArray().endObject();
+com.gmt2001.Console.out.println("doDBKeysListQuery: " + jsonObject.toString());
+        webSocket.send(jsonObject.toString());
+    }
+
 
     private void doDBUpdate(WebSocket webSocket, String id, String table, String key, String value) {
         JSONStringer jsonObject = new JSONStringer();

--- a/source/me/mast3rplan/phantombot/panel/PanelSocketServer.java
+++ b/source/me/mast3rplan/phantombot/panel/PanelSocketServer.java
@@ -388,7 +388,6 @@ public class PanelSocketServer extends WebSocketServer {
         }
 
         jsonObject.endArray().endObject();
-com.gmt2001.Console.out.println("doDBKeysListQuery: " + jsonObject.toString());
         webSocket.send(jsonObject.toString());
     }
 


### PR DESCRIPTION
**PanelSocketServer.java**
- Support new query type 'dbkeyslist' which will take a list of table names to query.
- Returns in same format as 'dbkeys'

**panelUtils.js**
- Added API wrapper sendDBKeysList(unique_id, tableList)
- unique_id is a String
- tableList is a Array of Strings in the format of [ "table1", "table2", ... ]
