### PR TITLE
Catch Invalid NICK from Twitch / Ignore . (dot) Files in Script Loader

### DIFF
--- a/source/me/mast3rplan/phantombot/script/Script.java
+++ b/source/me/mast3rplan/phantombot/script/Script.java
@@ -53,7 +53,7 @@ public class Script {
         }
         this.file = file;
 
-        if (!file.getName().endsWith(".js")) {
+        if (!file.getName().endsWith(".js") || file.getName().startsWith(".")) {
             return;
         }
 

--- a/source/me/mast3rplan/phantombot/twitchwsirc/TwitchWSIRCParser.java
+++ b/source/me/mast3rplan/phantombot/twitchwsirc/TwitchWSIRCParser.java
@@ -421,6 +421,13 @@ public class TwitchWSIRCParser {
             com.gmt2001.Console.out.println();
             System.exit(0);
             return;
+        } else if (message.equals("Invalid NICK")) {
+            com.gmt2001.Console.out.println();
+            com.gmt2001.Console.out.println("Twitch Inidicated Invalid Bot Name. Check 'user' setting in botlogin.txt");
+            com.gmt2001.Console.out.println("Exiting PhantomBot.");
+            com.gmt2001.Console.out.println();
+            System.exit(0);
+            return;
         } else {
             eventBus.postAsync(new IrcPrivateMessageEvent(this.session, "jtv", message, tagsMap));
             com.gmt2001.Console.debug.println("Message from jtv (NOTICE): " + message); 


### PR DESCRIPTION
**Script.java**
- Will ignore any . (dot) files - hidden, temporary files in Unix-like OSs.

**TwitchWSIRCParser.java**
- Catch the Invalid NICK notice from Twitch and shutdown bot with a warning message to the user.