### PR TITLE
Raffle Refuses Registered !commands as Keywords

### DIFF
--- a/javascript-source/lang/english/systems/systems-raffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-raffleSystem.js
@@ -31,3 +31,4 @@ $.lang.register('rafflesystem.timer.set', 'Raffle message timer has been set to 
 $.lang.register('rafflesystem.common.following', 'and you need to be following the channel');
 $.lang.register('rafflesystem.common.timer', 'The raffle will close in $1 minutes.');
 $.lang.register('rafflesystem.common.message', 'no longer');
+$.lang.register('rafflesystem.open.keyword-exists', 'Keyword cannot be an existing command: $1');

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -80,10 +80,17 @@
         if (args[i] !== undefined) {
             keyword = args[i];
             i++;
+
+            /* Ensure that keyword is not already a registered command. */
+            if (keyword.startsWith('!') && $.commandExists(keyword.substring(1))) {
+                $.say($.whisperPrefix(username) + $.lang.get('rafflesystem.open.keyword-exists', keyword));
+                return;
+            }
         } else {
             $.say($.whisperPrefix(username) + $.lang.get('rafflesystem.open.usage'));
             return;
         }
+
 
         /* Check if the caster wants a auto close timer */
         if (!isNaN(parseInt(args[i])) && parseInt(args[i]) !== 0) {


### PR DESCRIPTION
**raffleSystem.js**
- Check if a keyword starts with ! and if it is a registered command.
- If so, provide an error message.

**systems-raffleSystem.js**
- Error message added for above condition.