### PR TITLE
New Method to Count Parameters for a Lang Entry

### DIFF
--- a/javascript-source/core/lang.js
+++ b/javascript-source/core/lang.js
@@ -72,6 +72,31 @@
         return string;
     }
 
+     /**
+      * @function paramCount
+      * @export $.lang
+      * @param {string} key
+      * @returns {Number}
+      */
+     function paramCount(key) {
+         var string = data[key.toLowerCase()],
+             i,
+             ctr = 0;
+ 
+         if (!string) {
+             return 0;
+         }
+ 
+         for (i = 1; i < 99; i++) {
+             if (string.indexOf("$" + i) >= 0) {
+                 ctr++;
+             } else {
+                 break;
+             }
+         }
+         return ctr;
+     }
+
     /**
      * @function exists
      * @export $.lang
@@ -155,6 +180,7 @@
         exists: exists,
         get: get,
         register: register,
+        paramCount: paramCount
     };
 
     // Run the load function to enable modules, loaded after lang.js, to access the language strings immediatly


### PR DESCRIPTION
**lang.js**
- Added $.lang.paramCount(key)
- Returns the number of parameters ($x) present in the string
- Useful when wanting to determine ahead of time if a target or other data is required