### PR TITLE
Allow for the WS-IRC PING Wait Times to be Configurable

### DIFF
--- a/source/me/mast3rplan/phantombot/twitchwsirc/TwitchWSIRC.java
+++ b/source/me/mast3rplan/phantombot/twitchwsirc/TwitchWSIRC.java
@@ -65,6 +65,9 @@ public class TwitchWSIRC extends WebSocketClient {
     private long lastPing = 0L;
     private boolean sentPing = false;
 
+    private int sendPingWaitTime = Integer.parseInt(System.getProperty("ircsendpingwait", "480000"));
+    private int pingWaitTime = Integer.parseInt(System.getProperty("ircpingwait", "600000"));
+
     /*
      * Creates an instance for a channel.
      *
@@ -102,6 +105,16 @@ public class TwitchWSIRC extends WebSocketClient {
         this.eventBus = eventBus;
         this.channel = channel;
         this.session = session;
+
+        /* Lowest value for sendPingWaitTime is 5.5 minutes */
+        if (this.sendPingWaitTime < 330000) {
+            this.sendPingWaitTime = 330000;
+        }
+
+        /* Lowest value for pingWaitTime is 6 minutes */
+        if (this.pingWaitTime < 360000) {
+            this.pingWaitTime = 360000;
+        }
     }
 
     /*
@@ -253,19 +266,20 @@ public class TwitchWSIRC extends WebSocketClient {
      * period of time.
      */
     private void checkPingTime() {
+        com.gmt2001.Console.debug.println("Ping Wait Time: " + pingWaitTime + " Send Ping Wait Time: " + sendPingWaitTime);
         ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
         service.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {
                 /* If 8 minutes has passed, request a PONG from Twitch. */
-                if (System.currentTimeMillis() - lastPing >= 480000 && !sentPing) {
+                if (System.currentTimeMillis() - lastPing >= sendPingWaitTime && !sentPing) {
                     sentPing = true;
                     send("PING tmi.twitch.tv");
                     com.gmt2001.Console.debug.println("Sending a PING to Twitch to Verify Connection");
                 }
 
                 /* If 10 minutes has passed, force a disconnect which results in a reconnect. */
-                if (System.currentTimeMillis() - lastPing >= 600000) {
+                if (System.currentTimeMillis() - lastPing >= pingWaitTime) {
                     com.gmt2001.Console.debug.println("PING not Detected from Twitch in 10 minutes, Forcing Reconnect");
                     close();
                 }


### PR DESCRIPTION
**TwitchWSHostIRC.java, TwitchWSIRC.java**
- Passing -Dircsendpingwait=xxxxx during startup allows for setting, in milliseconds, the amount of time to wait before sending a PING to Twitch if one is not received. Will default to 330000 (5.5 minutes) for the lowest setting if a lower value is passed.
- Passing -Dircpingwait=xxxxx during startup allows for setting, in milliseconds, the amount of time to wait before forcing a reconnect if Twitch does not send a PING. Will default to 360000 (6 minutes) for the lowest setting if a lower value is passed.
- These values are the minimum values as Twitch documentation indicates that PING messages should be sent around every 5 minutes.