### PR TITLE
Update Launch Scripts

### DIFF
--- a/resources/launch-service.osx.sh
+++ b/resources/launch-service.osx.sh
@@ -19,19 +19,21 @@ cd "$DIR"
 
 unset DISPLAY
 
-if type -p java; then
+if type -p java 1>/dev/null 2>/dev/null; then
     _java=java
 elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     _java="$JAVA_HOME/bin/java"
 else
-    echo "You don't have Java installed! Download it from https://www.java.com/en/download/"
+    echo "You don't have Java installed! Download the Java 8 JDK for MacOS from: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
 fi
 
 if [[ "$_java" ]]; then
-    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-    if [[ "$version" > "1.8" ]]; then
+    version=$(java -version 2>&1)
+    version=${version#*.}
+    version=${version%%.*}
+    if [[ $version -ge 8 ]]; then
         java -Dfile.encoding=UTF-8 -jar PhantomBot.jar
     else
-        echo Your Java is out of date! Please download Java 8 at https://www.java.com/en/download/
+        echo "Your Java is out of date! Please download the Java 8 JDK for MacOS from: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
     fi
 fi

--- a/resources/launch-service.sh
+++ b/resources/launch-service.sh
@@ -7,12 +7,11 @@
 # % ./launch-service.sh
 #
 
-
 cd $(dirname $(readlink -f $0))
 
 unset DISPLAY
 
-if type -p java; then
+if type -p java 1>/dev/null 2>/dev/null; then
     _java=java
 elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     _java="$JAVA_HOME/bin/java"
@@ -21,8 +20,10 @@ else
 fi
 
 if [[ "$_java" ]]; then
-    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-    if [[ "$version" > "1.8" ]]; then
+    version=$(java -version 2>&1)
+    version=${version#*.}
+    version=${version%%.*}
+    if [[ $version -ge 8 ]]; then
         java -Dfile.encoding=UTF-8 -jar PhantomBot.jar
     else
         echo Your Java is out of date! Please download Java 8 at https://www.java.com/en/download/

--- a/resources/launch.osx.sh
+++ b/resources/launch.osx.sh
@@ -19,19 +19,21 @@ cd "$DIR"
 
 unset DISPLAY
 
-if type -p java; then
+if type -p java 1>/dev/null 2>/dev/null; then
     _java=java
 elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     _java="$JAVA_HOME/bin/java"
 else
-    echo "You don't have Java installed! Download it from https://www.java.com/en/download/"
+    echo "You don't have Java installed! Download the Java 8 JDK for MacOS from: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
 fi
 
 if [[ "$_java" ]]; then
-    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-    if [[ "$version" > "1.8" ]]; then
+    version=$(java -version 2>&1)
+    version=${version#*.}
+    version=${version%%.*}
+    if [[ $version -ge 8 ]]; then
         java -Dinteractive -Dfile.encoding=UTF-8 -jar PhantomBot.jar
     else
-        echo Your Java is out of date! Please download Java 8 at https://www.java.com/en/download/
+        echo "Your Java is out of date! Please download the Java 8 JDK for MacOS from: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"
     fi
 fi

--- a/resources/launch.sh
+++ b/resources/launch.sh
@@ -11,7 +11,7 @@ cd $(dirname $(readlink -f $0))
 
 unset DISPLAY
 
-if type -p java; then
+if type -p java 1>/dev/null 2>/dev/null; then
     _java=java
 elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     _java="$JAVA_HOME/bin/java"
@@ -20,8 +20,10 @@ else
 fi
 
 if [[ "$_java" ]]; then
-    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-    if [[ "$version" > "1.8" ]]; then
+    version=$(java -version 2>&1)
+    version=${version#*.}
+    version=${version%%.*}
+    if [[ $version -ge 8 ]]; then
         java -Dinteractive -Dfile.encoding=UTF-8 -jar PhantomBot.jar
     else
         echo Your Java is out of date! Please download Java 8 at https://www.java.com/en/download/


### PR DESCRIPTION
**launch-service.osx.sh, launch-service.sh, launch.osx.sh, launch.sh**
- Updated the OSX scripts to show the Java 8 JDK download link as the JDK is required in MacOS.
- Updated the scripts to use Bash internal string replacement functions rather than external programs.