### PR TITLE
Change target and source compile.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -90,7 +90,7 @@
 
     <target depends="pre.compile" name="compile.src">
         <echo>Compiling with Java Version ${ant.java.version} (${java.version})</echo>
-        <javac target="1.7" source="1.7" debug="on" destdir="${classes}" srcdir="${src}" includeantruntime="false" >
+        <javac target="1.8" source="1.8" debug="on" destdir="${classes}" srcdir="${src}" includeantruntime="false" >
             <compilerarg value="-Xlint:unchecked" />
             <compilerarg value="-Xlint:-options" />
             <classpath refid="reference.class.path" />
@@ -104,7 +104,7 @@
     </target>
     
     <target depends="clean.build.test" name="compile.src.test">
-        <javac target="1.7" source="1.7" debug="on" destdir="${classes}" srcdir="${src}" includeantruntime="false" >
+        <javac target="1.8" source="1.8" debug="on" destdir="${classes}" srcdir="${src}" includeantruntime="false" >
             <compilerarg value="-Xlint:all" />
             <compilerarg value="-Xlint:-options" />
             <classpath refid="reference.class.path" />


### PR DESCRIPTION
Change target and source compile, when Java 7 support has been deprecated.