### PR TITLE
Fix Follow Only Update Based on Time / DataStore.RenameFile()

### DIFF
--- a/source/com/gmt2001/DataStore.java
+++ b/source/com/gmt2001/DataStore.java
@@ -183,6 +183,9 @@ public class DataStore {
     public void RemoveFile(String fName) {
     }
 
+    public void RenameFile(String fNameSource, String fNameDest) {
+    }
+
     public boolean FileExists(String fName) {
         return false;
     }

--- a/source/com/gmt2001/IniStore.java
+++ b/source/com/gmt2001/IniStore.java
@@ -121,6 +121,10 @@ public class IniStore extends DataStore implements ActionListener {
     }
 
     private void SaveFile(String fName, IniFile data) {
+        if (data == null) {
+            return;
+        }
+
         try {
             String wdata = "";
             Object[] adata = data.data.keySet().toArray();
@@ -480,6 +484,30 @@ public class IniStore extends DataStore implements ActionListener {
         f.delete();
 
         files.remove(fName);
+    }
+
+    @Override
+    public void RenameFile(String fNameSource, String fNameDest) {
+        fNameSource = validatefName(fNameSource);
+        fNameDest = validatefName(fNameDest);
+
+        SaveFile(fNameSource, files.get(fNameSource));
+        if (!FileExists(fNameSource)) {
+            return;
+        }
+
+        SaveFile(fNameDest, files.get(fNameDest));
+        if (FileExists(fNameDest)) {
+            RemoveFile(fNameDest);
+        }
+
+        File sourceFile = new File("./" + inifolder + "/" + fNameSource + ".ini");
+        File destFile = new File("./" + inifolder + "/" + fNameDest + ".ini");
+        
+        sourceFile.renameTo(destFile);
+
+        files.remove(fNameSource);
+        LoadFile(fNameDest, false);
     }
 
     @Override

--- a/source/com/gmt2001/IniStore.java
+++ b/source/com/gmt2001/IniStore.java
@@ -201,7 +201,7 @@ public class IniStore extends DataStore implements ActionListener {
                 }
 
                 if (n.length > 0) {
-                    com.gmt2001.Console.out.println(">>>Saving " + n.length + " files");
+                    com.gmt2001.Console.debug.println("Saving " + n.length + " files");
                 }
 
                 for (Object n1 : n) {
@@ -221,10 +221,10 @@ public class IniStore extends DataStore implements ActionListener {
                 nextSave.setTime(new Date().getTime() + saveInterval);
 
                 if (n.length > 0) {
-                    com.gmt2001.Console.out.println(">>>Save complete");
+                    com.gmt2001.Console.debug.println("Save complete");
                 }
             } else {
-                com.gmt2001.Console.out.println(">>>Object null, nothing to save.");
+                com.gmt2001.Console.debug.println("Object null, nothing to save.");
             }
         }
     }

--- a/source/com/gmt2001/MySQLStore.java
+++ b/source/com/gmt2001/MySQLStore.java
@@ -170,6 +170,27 @@ public class MySQLStore extends DataStore {
     }
 
     @Override
+    public void RenameFile(String fNameSource, String fNameDest) {
+        CheckConnection();
+
+        fNameSource = validateFname(fNameSource);
+        fNameDest = validateFname(fNameDest);
+
+        if (!FileExists(fNameSource)) {
+            return;
+        }
+
+        RemoveFile(fNameDest);
+
+        try (Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(10);
+            statement.executeUpdate("ALTER TABLE phantombot_" + fNameSource + " RENAME TO phantombot_" + fNameDest + ";");
+        } catch (SQLException ex) {
+            com.gmt2001.Console.err.printStackTrace(ex);
+        }
+    }
+
+    @Override
     public boolean FileExists(String fName) {
         CheckConnection();
 

--- a/source/com/gmt2001/SqliteStore.java
+++ b/source/com/gmt2001/SqliteStore.java
@@ -241,6 +241,27 @@ public class SqliteStore extends DataStore {
     }
 
     @Override
+    public void RenameFile(String fNameSource, String fNameDest) {
+        CheckConnection();
+
+        fNameSource = validateFname(fNameSource);
+        fNameDest = validateFname(fNameDest);
+
+        if (!FileExists(fNameSource)) {
+            return;
+        }
+
+        RemoveFile(fNameDest);
+
+        try (Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(10);
+            statement.executeUpdate("ALTER TABLE phantombot_" + fNameSource + " RENAME TO phantombot_" + fNameDest + ";");
+        } catch (SQLException ex) {
+            com.gmt2001.Console.err.printStackTrace(ex);
+        }
+    }
+
+    @Override
     public boolean FileExists(String fName) {
         CheckConnection();
 

--- a/source/com/gmt2001/TwitchAPIv3.java
+++ b/source/com/gmt2001/TwitchAPIv3.java
@@ -630,7 +630,7 @@ public class TwitchAPIv3 {
                 if (followsArray.getJSONObject(idx).getJSONObject("user").has("name")) {
                     if (dataStore.exists("time", followsArray.getJSONObject(idx).getJSONObject("user").getString("name"))) {
                         insertCtr++;
-                        dataStore.set("followed", followsArray.getJSONObject(idx).getJSONObject("user").getString("name"), "true");
+                        dataStore.set("followed_fixtable", followsArray.getJSONObject(idx).getJSONObject("user").getString("name"), "true");
                     }
                 }
             }
@@ -682,6 +682,7 @@ public class TwitchAPIv3 {
             }
         } while (jsonInput.getJSONArray("follows").length() > 0) ;
 
+        dataStore.RenameFile("followed_fixtable", "followed");
         com.gmt2001.Console.out.println("FixFollowedTable: Pulled followers into the followed table, loaded " + insertCtr + "/" + followerCount + " records.");
     }
 


### PR DESCRIPTION
**DataStore.java**
    - Generic implementation for DataStore.RenameFile()

    **IniStore.java**
    - IniStore specific implementation of RenameFile()
    - Changed output indicating when files were saved to debug statements.

    **MySQLStore.java***
    - MySQL specific implementation of RenameFile()

    **SqliteStore.java**
    - SQLite specific implementation of RenameFile()

    **TwitchAPIv3.java**
    - Only put users in the followed table that exist in the time table.
    - Places users into temporary followed table then replaces the followed
    table.
    - This is experimental, as it was before. It is not entirely recommended to
    use this feature of PhantomBot. It may be removed in a future release.