### PR TITLE
Added option to allow bits rewards to be a multiplicative factor of the number of bits

### DIFF
--- a/javascript-source/handlers/bitsHandler.js
+++ b/javascript-source/handlers/bitsHandler.js
@@ -48,7 +48,7 @@
 		/** Match (reward) if it is in the message to replace it with the reward the owner has set when someone cheers. */
 		if (s.match(/\(reward\)/g)) {
 			if (rewardMultToggle) {
-				s = $.replace(s, '(reward)', $.getPointsString(event.getBits() * reward));
+				s = $.replace(s, '(reward)', $.getPointsString(parseInt(event.getBits()) * reward));
 			} else {
 				s = $.replace(s, '(reward)', $.getPointsString(reward));
 			}
@@ -59,7 +59,7 @@
 			$.say(s);
 			if (reward > 0) {//Check if the owner set a reward for when someone cheers. Default is non.
 				if (rewardMultToggle) {
-					$.inidb.incr('points', event.getUsername(), event.getBits() * parseInt(reward));
+					$.inidb.incr('points', event.getUsername(), parseInt(event.getBits()) * parseInt(reward));
 				} else {
 					$.inidb.incr('points', event.getUsername(), parseInt(reward));
 				}

--- a/javascript-source/lang/english/handlers/handlers-bitsHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-bitsHandler.js
@@ -1,5 +1,7 @@
 $.lang.register('bitshandler.toggle.off', 'Bits announcements have been disabled.');
 $.lang.register('bitshandler.toggle.on', 'Bits announcements have been enabled.');
+$.lang.register('bitshandler.rewardmulttoggle.off', 'Bits reward is now a constant value.');
+$.lang.register('bitshandler.rewardmulttoggle.on', 'Bits reward is now a multiplicative factor of the number of bits.');
 $.lang.register('bitshandler.message.usage', 'Usage: !bitsmessage (message) - Tags: (name), (amount), (reward)');
 $.lang.register('bitshandler.message.set', 'Bits message has been set to: $1.');
 $.lang.register('bitshandler.reward.usage', 'Usage: !bitsreward (amount)');

--- a/resources/web/panel/greetings.html
+++ b/resources/web/panel/greetings.html
@@ -322,7 +322,7 @@
             <div class="form-group" onkeypress="return event.keyCode != 13">
                 <label for="resubEmote">Resubscriber Custom Emote</label>
                 <button type="button" class="btn btn-primary inline pull-right"  
-                        onclick="$.updateGreetingData('resubGreetingInput', 'subscribeHandler', 'resubEmote')">Submit</button>
+                        onclick="$.updateGreetingData('resubEmoteInput', 'subscribeHandler', 'resubEmote')">Submit</button>
                 <input type="text" class="form-control" id="resubEmoteInput" placeholder="Emote name"
                        data-toggle="tooltip" title="Emote that the (customemote) that will be replaced with. The emote will be added the amount of months the user subscribed for." />
             </div>

--- a/resources/web/panel/greetings.html
+++ b/resources/web/panel/greetings.html
@@ -322,7 +322,7 @@
             <div class="form-group" onkeypress="return event.keyCode != 13">
                 <label for="resubEmote">Resubscriber Custom Emote</label>
                 <button type="button" class="btn btn-primary inline pull-right"  
-                        onclick="$.updateGreetingData('resubEmoteInput', 'subscribeHandler', 'resubEmote')">Submit</button>
+                        onclick="$.updateGreetingData('resubGreetingInput', 'subscribeHandler', 'resubEmote')">Submit</button>
                 <input type="text" class="form-control" id="resubEmoteInput" placeholder="Emote name"
                        data-toggle="tooltip" title="Emote that the (customemote) that will be replaced with. The emote will be added the amount of months the user subscribed for." />
             </div>
@@ -341,6 +341,15 @@
                 <td style="width: 25px">
                     <div data-toggle="tooltip" title="Toggle" class="button"
                          onclick="$.toggleGreetings('bitsSettings', 'toggle');"><i class="fa fa-refresh" />
+                     </div>
+                </td>
+            </tr>
+			<tr class="textList">
+                <td>Toggle Bits Rewards To Become a Multiplicative Factor Of Number of Bits</td>
+                <td style="width: 25px"><div id="bitsRewardMultToggle" /></td>
+                <td style="width: 25px">
+                    <div data-toggle="tooltip" title="Toggle" class="button"
+                         onclick="$.toggleGreetings('bitsSettings', 'rewardMultToggle');"><i class="fa fa-refresh" />
                      </div>
                 </td>
             </tr>

--- a/resources/web/panel/js/greetingsPanel.js
+++ b/resources/web/panel/js/greetingsPanel.js
@@ -42,6 +42,7 @@
         gameWhispToggle = false,
         primeSubToggle = false;
         bitsToggle = false;
+		bitsRewardMultToggle = false;
 
     /*
      * onMessage
@@ -222,6 +223,10 @@
                         bitsToggle = value;
                         $('#bitsToggle').html(settingIcon[value]);
                     }
+					if (panelMatch(key, 'rewardMultToggle')) {
+						bitsRewardMultToggle = value;
+                        $('#bitsRewardMultToggle').html(settingIcon[value]);
+					}
                     if (panelMatch(key, 'message')) {
                         $('#bitsMessage').val(value);
                     }
@@ -392,6 +397,15 @@
                 sendDBUpdate('greetings_bits', 'bitsSettings', 'toggle', 'false');
             } else {
                 sendDBUpdate('greetings_bits', 'bitsSettings', 'toggle', 'true');
+            }
+            setTimeout(function() { sendCommand('reloadbits'); }, TIMEOUT_WAIT_TIME);
+        }
+		if (panelMatch(table, 'bitsSettings') && panelMatch(key, 'rewardMultToggle')) { 
+            $('#bitsRewardMultToggle').html(spinIcon);
+            if (bitsRewardMultToggle == "true") {
+                sendDBUpdate('greetings_bits', 'bitsSettings', 'rewardMultToggle', 'false');
+            } else {
+                sendDBUpdate('greetings_bits', 'bitsSettings', 'rewardMultToggle', 'true');
             }
             setTimeout(function() { sendCommand('reloadbits'); }, TIMEOUT_WAIT_TIME);
         }


### PR DESCRIPTION
- Added !bitsrewardmulttoggle which allows the reward to become a multiplicative factor of the number of bits instead of a constant amount
- Added toggle to web panel
- I think "!isNaN(action)" should have been "isNaN(action)" in the if statements for !bitsreward and !bitsminimum
- Fixed a bug where !bitsreward 0 and !bitsminimum 0 wouldn't work as !parseInt(action) with a value of 0 would cause the usage message to print. Using isNaN(parseInt(action)) instead.