### PR TITLE
Hide GameWisp Oauth Token in Debug Statement

### DIFF
--- a/javascript-source/handlers/gameWispHandler.js
+++ b/javascript-source/handlers/gameWispHandler.js
@@ -178,7 +178,7 @@
         var jsonString = $.gamewisp.getUserSubInfoString(username) + '',
             jsonData = JSON.parse(jsonString);
 
-        $.consoleDebug('checkGameWispSub(' + username + '): ' + jsonString);
+        $.consoleDebug('checkGameWispSub(' + username + '): ' + jsonString.replace(/access_token=\w+&/, ''));
 
         if (jsonData['error_description'] !== undefined) {
             if (jsonData['error_description'].equals('The resource owner or authorization server denied the request.')) {


### PR DESCRIPTION
**gameWispHandler.js**
- Removes the access token from the debug output for security purposes in the debug file.