### PR TITLE
Allow specific commands to have explicitly chosen cooldown types

### DIFF
--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -178,14 +178,13 @@
         var cooldownInfo = getCooldownInfo(command),
             commandHasGlobalCooldown = cooldownInfo[0],
             commandHasPerUserCooldown = cooldownInfo[1],
-            commandCooldownTypeOverriden = cooldownInfo[3],
             commandHasNoCooldown = cooldownInfo[4];
         
         if (commandHasNoCooldown) {
             $.consoleDebug('Did not push command !' + command + ' to cooldown because its cooldown type is set to none.');
         } else {
             if (!command.equals('adventure')) {
-                if (commandHasGlobalCooldown && (commandCooldownTypeOverriden || !hasCooldown)) {
+                if (commandHasGlobalCooldown && !hasCooldown) {
                     cooldown[command] = {time: time};
                     $.consoleDebug('Pushed command !' + command + ' to global cooldown.');
                     return;
@@ -217,7 +216,6 @@
         var cooldownInfo = getCooldownInfo(command),
             commandHasGlobalCooldown = cooldownInfo[0],
             commandHasPerUserCooldown = cooldownInfo[1],
-            commandCooldownTypeOverriden = cooldownInfo[3],
             commandHasNoCooldown = cooldownInfo[4];
 
         if (commandHasNoCooldown) {
@@ -231,7 +229,7 @@
                 }
             }
             return 0;
-        } else if (commandHasGlobalCooldown && (commandCooldownTypeOverriden || !hasCooldown)) {
+        } else if (commandHasGlobalCooldown && !hasCooldown) {
             if (cooldown[command] !== undefined){
                 if (cooldown[command].time - $.systemTime() >= 0) {
                     if (permCheck(username, isMod)) return 0;

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -14,11 +14,11 @@
         modCooldown = $.getSetIniDbBoolean('cooldown', 'modCooldown', false),
         cooldown = [],
         cooldowns = [],
-		cooldowntypes = ["default","per-user","global","none"],
+        cooldowntypes = ["default","per-user","global","none"],
         i;
-		for(var l = 0;l < cooldowntypes.length;l++){
-			cooldowntypes[cooldowntypes[l]] = l;
-		}
+        for(var l = 0;l < cooldowntypes.length;l++){
+            cooldowntypes[cooldowntypes[l]] = l;
+        }
     /**
      * @function reloadCooldown 
      */
@@ -58,30 +58,30 @@
         }
         return 0;
     };
-	
-	function getCooldownType(command){
-		var typeNum = 0;
-		if ($.inidb.exists('cooldowntype', command.toLowerCase())) {
+    
+    function getCooldownType(command){
+        var typeNum = 0;
+        if ($.inidb.exists('cooldowntype', command.toLowerCase())) {
             typeNum = parseInt($.inidb.get('cooldowntype', command.toLowerCase()));
         }
         return cooldowntypes[typeNum];
-	}
-	
-	function setCooldownType(command,type){
-		var typeNum,typeString;
-		if(typeof type === "number"){
-			typeNum = type;
-			typeString = cooldowntypes[type];
-		}else{
-			typeString = type.toLowerCase();
-			typeNum = cooldowntypes[typeString];
-		}
-		var curString = getCooldownType(command);
-		if(curString !== typeString){
-			$.inidb.set('cooldowntype', command.toLowerCase(), typeNum);
-		}
-		return typeString;
-	}
+    }
+    
+    function setCooldownType(command,type){
+        var typeNum,typeString;
+        if(typeof type === "number"){
+            typeNum = type;
+            typeString = cooldowntypes[type];
+        }else{
+            typeString = type.toLowerCase();
+            typeNum = cooldowntypes[typeString];
+        }
+        var curString = getCooldownType(command);
+        if(curString !== typeString){
+            $.inidb.set('cooldowntype', command.toLowerCase(), typeNum);
+        }
+        return typeString;
+    }
 
     /**
      * @function set 
@@ -98,35 +98,35 @@
         time = ((time * 1000) + $.systemTime());
         command = command.toLowerCase();
 
-		var local_globalCooldown = globalCooldown;
-		var local_perUserCooldown = perUserCooldown;
-		var local_type = getCooldownType(command);
-		var local_override = local_type !== "default";
-		var local_none = local_type === "none";
-		if(local_override){
-			if(local_none){
-				local_globalCooldown = local_perUserCooldown = false;
-			}else{
-				local_globalCooldown = !(local_perUserCooldown = local_type === "per-user");
-			}
-		}
-		
-		if (!command.equals('adventure')) {
-			if (local_globalCooldown && (local_override || !hasCooldown)) {
-				cooldown[command] = {time: time};
-				$.consoleDebug('Pushed command !' + command + ' to global cooldown.');
-				return;
-			} else {
-				if (local_perUserCooldown) {
-					cooldowns.push({username: username, time: time, command: command});
-					$.consoleDebug('Pushed command !' + command + ' to user cooldown with username: ' + username + '.');
-					return;
-				}
-			}
-		}
-		
-		cooldown[command] = {time: time};
-		$.consoleDebug('Pushed command !' + command + ' to cooldown.');
+        var local_globalCooldown = globalCooldown;
+        var local_perUserCooldown = perUserCooldown;
+        var local_type = getCooldownType(command);
+        var local_override = local_type !== "default";
+        var local_none = local_type === "none";
+        if(local_override){
+            if(local_none){
+                local_globalCooldown = local_perUserCooldown = false;
+            }else{
+                local_globalCooldown = !(local_perUserCooldown = local_type === "per-user");
+            }
+        }
+        
+        if (!command.equals('adventure')) {
+            if (local_globalCooldown && (local_override || !hasCooldown)) {
+                cooldown[command] = {time: time};
+                $.consoleDebug('Pushed command !' + command + ' to global cooldown.');
+                return;
+            } else {
+                if (local_perUserCooldown) {
+                    cooldowns.push({username: username, time: time, command: command});
+                    $.consoleDebug('Pushed command !' + command + ' to user cooldown with username: ' + username + '.');
+                    return;
+                }
+            }
+        }
+        
+        cooldown[command] = {time: time};
+        $.consoleDebug('Pushed command !' + command + ' to cooldown.');
     };
 
      /**
@@ -137,22 +137,22 @@
      * @return number
      */
     function get(command, username, isMod) {
-		command = command.toLowerCase();
-		
+        command = command.toLowerCase();
+        
         var hasCooldown = $.inidb.exists('cooldown', command);
-		
-		var local_globalCooldown = globalCooldown;
-		var local_perUserCooldown = perUserCooldown;
-		var local_type = getCooldownType(command);
-		var local_override = local_type !== "default";
-		var local_none = local_type === "none";
-		if(local_override){
-			if(local_none){
-				return 0;
-			}else{
-				local_globalCooldown = !(local_perUserCooldown = local_type === "per-user");
-			}
-		}
+        
+        var local_globalCooldown = globalCooldown;
+        var local_perUserCooldown = perUserCooldown;
+        var local_type = getCooldownType(command);
+        var local_override = local_type !== "default";
+        var local_none = local_type === "none";
+        if(local_override){
+            if(local_none){
+                return 0;
+            }else{
+                local_globalCooldown = !(local_perUserCooldown = local_type === "per-user");
+            }
+        }
 
         if (commandCheck(command)) {
             if (command.equals('adventure')) {
@@ -185,13 +185,13 @@
             }
         }
 
-		if (cooldown[command] !== undefined) {
-			if (cooldown[command].time - $.systemTime() >= 0) {
-				if (permCheck(username, isMod)) return 0;
-				return parseInt(cooldown[command].time - $.systemTime());
-			}
-		}
-		set(command, hasCooldown, getCooldown(command)); return 0;
+        if (cooldown[command] !== undefined) {
+            if (cooldown[command].time - $.systemTime() >= 0) {
+                if (permCheck(username, isMod)) return 0;
+                return parseInt(cooldown[command].time - $.systemTime());
+            }
+        }
+        set(command, hasCooldown, getCooldown(command)); return 0;
     };
 
     /**
@@ -218,7 +218,7 @@
             command = event.getCommand(),
             args = event.getArgs(),
             cmd = args[0],
-			arg2 = args[1],
+            arg2 = args[1],
             time = parseInt(arg2);
 
         /**
@@ -297,24 +297,24 @@
             $.setIniDbBoolean('cooldown', 'modCooldown', modCooldown);
             $.say($.whisperPrefix(sender) + $.lang.get('cooldown.set.togglemodcooldown', (modCooldown ? $.lang.get('common.enabled') : $.lang.get('common.disabled'))));
         }
-		
-		/**
+        
+        /**
          * @commandpath cooltype [command] [type] - Set the cooldown type for a specific command (default, per-user, global or none)
-		 */
-		if (command.equalsIgnoreCase('cooltype')){
-			if(cmd === undefined || arg2 === undefined || !cooldowntypes.hasOwnProperty(arg2.toLowerCase())){
-				$.say($.whisperPrefix(sender) + '!cooltype [command] [type] - Set the cooldown type for a specific command (types: default, per-user, global or none)');
-				return;
-			}
-			
-			if (cmd.startsWith('!')) {
+         */
+        if (command.equalsIgnoreCase('cooltype')){
+            if(cmd === undefined || arg2 === undefined || !cooldowntypes.hasOwnProperty(arg2.toLowerCase())){
+                $.say($.whisperPrefix(sender) + '!cooltype [command] [type] - Set the cooldown type for a specific command (types: default, per-user, global or none)');
+                return;
+            }
+            
+            if (cmd.startsWith('!')) {
                 cmd = cmd.substring(1);
             }
-			
-			setCooldownType(cmd,arg2);
-			
-			$.say($.whisperPrefix(sender) + 'The cooldown type for !' + cmd.toLowerCase() + ' has been set to ' + arg2.toLowerCase() + '!');
-		}
+            
+            setCooldownType(cmd,arg2);
+            
+            $.say($.whisperPrefix(sender) + 'The cooldown type for !' + cmd.toLowerCase() + ' has been set to ' + arg2.toLowerCase() + '!');
+        }
 
         /**
         * Used for the panel
@@ -336,7 +336,7 @@
             $.registerChatCommand('./core/commandCoolDown.js', 'toggleperusercooldown', 1);
             $.registerChatCommand('./core/commandCoolDown.js', 'togglemodcooldown', 1);
             $.registerChatCommand('./core/commandCoolDown.js', 'reloadcooldown', 1);
-			$.registerChatCommand('./core/commandCoolDown.js', 'cooltype', 1);
+            $.registerChatCommand('./core/commandCoolDown.js', 'cooltype', 1);
         }
     });
     

--- a/javascript-source/lang/english/main.js
+++ b/javascript-source/lang/english/main.js
@@ -260,6 +260,8 @@ $.lang.register('cooldown.per.user.toggle', 'per-user cooldown has been $1.');
 $.lang.register('cooldown.global.set', 'global cooldown set to $1 seconds.');
 $.lang.register('cooldown.removed', 'cooldown for command !$1 has been removed.');
 $.lang.register('cooldown.set', 'cooldown for command !$1 has been set to $2 seconds.');
+$.lang.register('cooldown.type', 'cooldown type for command !$1 has been set to $2.');
+$.lang.register('cooldown.type.usage', 'Usage: !cooltype [command] [default|per-user|global|none]');
 $.lang.register('init.cmsgset', 'Connected message set!');
 $.lang.register('init.module.404', 'That module does not exist or is not loaded!');
 $.lang.register('init.module.check.disabled', 'Module $1 is currently disabled!');

--- a/resources/web/panel/commands.html
+++ b/resources/web/panel/commands.html
@@ -249,8 +249,21 @@
             </div>
         </form>
         <br>
-        <strong>Commands with Cooldowns</strong>
+        <strong>Commands with cooldowns</strong>
         <div id="cooldownList" style="height: 200px; overflow: auto;" />
+		
+		<br>
+        <form role="form">
+            <div class="form-group" onkeypress="return event.keyCode != 13">
+                <label for="cooldownTypeCmd">Command cooldown type</label>
+                <button type="button" class="btn btn-primary inline pull-right" onclick="$.addCooldownType()">Submit</button>
+                <input type="text" class="form-control" id="cooldownTypeCmdInputCommand" placeholder="Command name" />
+                <input type="text" class="form-control" id="cooldownTypeCmdInput" placeholder="Type" />
+            </div>
+        </form>
+        <br>
+        <strong>Commands with cooldown types</strong>
+        <div id="cooldownTypeList" style="height: 200px; overflow: auto;" />
     </div>
 </div>
 

--- a/resources/web/panel/cooldown.html
+++ b/resources/web/panel/cooldown.html
@@ -74,8 +74,22 @@
             </div>
         </form>
 
-        <strong>Commands with Cooldowns</strong>
+        <strong>Commands with cooldowns</strong>
         <div id="cooldownList" style="height: 300px; overflow: auto;" />
+    </div>
+    
+    <h3>Command Cooldown Types</h3>
+    <div>
+        <form role="form">
+            <div class="form-group" onkeypress="return event.keyCode != 13">
+                <label for="cooldownTypeCmd">Cooldown Type Command</label>
+                <button type="button" class="btn btn-primary inline pull-right" onclick="$.addCooldownType()">Submit</button>
+                <input type="text" class="form-control" id="cooldownTypeCmdInput" placeholder="command_name type" />
+            </div>
+        </form>
+        
+        <strong>Commands with cooldown types</strong>
+        <div id="cooldownTypeList" style="height: 300px; overflow: auto;">
     </div>
 </div>
 

--- a/resources/web/panel/js/commandsPanel.js
+++ b/resources/web/panel/js/commandsPanel.js
@@ -33,7 +33,8 @@
         cooldownMsg = "false",
         permcomMsg = "true",
         disabledCommands = [],
-        commands = [];
+        commands = [],
+        cooldownTypeEnum = ['default','per-user','global','none'];
 
         modeIcon['false'] = "<i style=\"color: #6136b1\" class=\"fa fa-circle-o\" />";
         modeIcon['true'] = "<i style=\"color: #6136b1\" class=\"fa fa-circle\" />";
@@ -66,9 +67,11 @@
                 commandValue = "",
                 html = "<table>",
                 time = "",
-                foundData = false;
+                foundData = false,
+                isCooldownType = false;
 
-            if (panelCheckQuery(msgObject, 'commands_cooldown')) {
+            if (panelCheckQuery(msgObject, 'commands_cooldown') || (isCooldownType = panelCheckQuery(msgObject, 'commands_cooldownType'))) {
+                var cooldownTypeText = (isCooldownType ? 'Type' : '');
                 html = "<table>";
                 for (idx in msgObject['results']) {
                     commandName = msgObject['results'][idx]['key'];
@@ -96,10 +99,10 @@
                     '    <td style="width: 10%">!' + commandName + '</td>' +
                     '    <td style="vertical-align: middle">' +
                     '        <form onkeypress="return event.keyCode != 13">' +
-                    '            <input style="width: 60%" type="text" id="editCommandCooldown_' + commandName + '"' +
-                    '                   value="' + time + '" />' +
-                    '              <button type="button" class="btn btn-default btn-xs" onclick="$.editCooldown(\'' + commandName + '\')"><i class="fa fa-pencil" /> </button> ' +
-                    '              <button type="button" class="btn btn-default btn-xs" id="deleteCooldown_' + commandName + '" onclick="$.deleteCooldown(\'' + commandName + '\')"><i class="fa fa-trash" /> </button>' +
+                    '            <input style="width: 60%" type="text" id="editCommandCooldown' + cooldownTypeText + '_' + commandName + '"' +
+                    '                   value="' + (isCooldownType ? cooldownTypeEnum[time] : time) + '" />' +
+                    '              <button type="button" class="btn btn-default btn-xs" onclick="$.editCooldown' + cooldownTypeText + '(\'' + commandName + '\')"><i class="fa fa-pencil" /> </button> ' +
+                    '              <button type="button" class="btn btn-default btn-xs" id="deleteCooldown' + cooldownTypeText + '_' + commandName + '" onclick="$.deleteCooldown' + cooldownTypeText + '(\'' + commandName + '\')"><i class="fa fa-trash" /> </button>' +
                     '             </form>' +
                     '        </form>' +
                     '    </td>' +
@@ -111,7 +114,7 @@
                     html = "<i>No entries in cooldown table.</i>";
                 }
 
-                $("#cooldownList").html(html);
+                $("#cooldown" + cooldownTypeText + "List").html(html);
                 $("#toggleGlobalCooldown").html(modeIcon[globalCooldown]);
                 $("#togglePerUserCooldown").html(modeIcon[perUserCooldown]);
                 $("#toggleModCooldown").html(modeIcon[modCooldown]);
@@ -315,6 +318,7 @@
         sendDBKeys("commands_pricecom", "pricecom");
         sendDBKeys("commands_payment", "paycom");
         sendDBKeys("commands_cooldown", "cooldown");
+        sendDBKeys("commands_cooldownType", "cooldownType");
         sendDBKeys("commands_disabled", "disabledCommands");
         sendDBQuery("commands_cooldownmsg", "settings", "coolDownMsgEnabled");
         sendDBQuery("commands_permcommsg", "settings", "permComMsgEnabled");
@@ -425,9 +429,19 @@
     function editCooldown(command) {
         var value = $('#editCommandCooldown_' + command).val();
         if (value > 0) {
-            sendDBUpdate("commands_cooldown_edit", "cooldown", command.toLowerCase(), value);
+            sendCommand("silentcooldown " + command + " " + value);
             setTimeout(function() { doQuery(); }, TIMEOUT_WAIT_TIME * 2);
         }
+    };
+    
+    /**
+     * @function editCooldownType
+     * @param {String} command
+     */
+    function editCooldownType(command) {
+        var value = $('#editCommandCooldownType_' + command).val();
+        sendCommand("silentcooltype " + command + " " + value);
+        setTimeout(function() { doQuery(); }, TIMEOUT_WAIT_TIME * 2);
     };
 
     /** 
@@ -454,7 +468,8 @@
 
         if (main.startsWith('!')) {
             main = main.replace('!', '');
-        } else if (alias.startsWith('!')) {
+        }
+        if (alias.startsWith('!')) {
             alias = alias.replace('!', '');
         }
 
@@ -671,6 +686,36 @@
             setTimeout(function() { $("#cooldownCmdInputCommand").val(""); $("#cooldownCmdInput").val(""); }, TIMEOUT_WAIT_TIME);
         }
     }
+	
+	/**
+     * @function deleteCooldownType
+     * @param {String} command
+     */
+    function deleteCooldownType(command) {
+        $("#deleteCooldownType_" + command).html("<i style=\"color: #6136b1\" class=\"fa fa-spinner fa-spin\" />");
+        sendCommand("silentcooltype " + command + " default");
+        setTimeout(function() { doQuery(); }, TIMEOUT_WAIT_TIME);
+    }
+
+    /**
+     * @function addCooldownType
+     */
+    function addCooldownType() {
+        var input = $("#cooldownTypeCmdInput").val();
+        var command = $("#cooldownTypeCmdInputCommand").val();
+
+        if (command.startsWith('!')) {
+            command = command.replace('!', '');
+        }
+        
+        if (input.length != 0 && command.length != 0) {
+            sendCommand("silentcooltype " + command + " " + input);
+            $("#cooldownTypeCmdInput").val("Submitted");
+            $("#cooldownTypeCmdInputCommand").val("Submitted");
+            setTimeout(function() { doQuery(); }, TIMEOUT_WAIT_TIME);
+            setTimeout(function() { $("#cooldownTypeCmdInputCommand").val(""); $("#cooldownTypeCmdInput").val(""); }, TIMEOUT_WAIT_TIME);
+        }
+    }
 
     /**
      * @function commandEnable
@@ -744,6 +789,8 @@
     $.updateCommandPay = updateCommandPay;
     $.addCooldown = addCooldown;
     $.deleteCooldown = deleteCooldown;
+	$.addCooldownType = addCooldownType;
+	$.deleteCooldownType = deleteCooldownType;
     $.toggleGlobalCooldown = toggleGlobalCooldown;
     $.toggleModCooldown = toggleModCooldown;
     $.togglePerUserCooldown = togglePerUserCooldown;
@@ -752,6 +799,7 @@
     $.deleteCommandPrice = deleteCommandPrice;
     $.deleteCommandPay = deleteCommandPay;
     $.editCooldown = editCooldown;
+	$.editCooldownType = editCooldownType;
     $.commands = commands;
     $.runCommand = runCommand;
     $.toggleCooldownMsg = toggleCooldownMsg;

--- a/resources/web/panel/js/cooldownPanel.js
+++ b/resources/web/panel/js/cooldownPanel.js
@@ -168,6 +168,28 @@
             setTimeout(function() { $("#cooldownCmdInput").val(""); doQuery(); }, 1000);
         }
     }
+	
+	/**
+	 * @function deleteCooldownType
+	 * @param {String} command
+	 */
+	function deleteCooldownType(command){
+		$("#deleteCooldownType_" + command).html("<i style=\"color: #6136b1\" class=\"fa fa-spinner fa-spin\" />");
+        sendCommand("cooltype " + command + " default");
+        setTimeout(function() { doQuery(); }, 500);
+	}
+	
+	/**
+     * @function addCooldownType
+     */
+	function addCooldownType(){
+		var input = $("#cooldownCmdTypeInput").val();
+        if (input.length > 0) {
+            sendCommand("cooltype " + input);
+            $("#cooldownCmdInput").val("Submitted");
+            setTimeout(function() { $("#cooldownCmdTypeInput").val(""); doQuery(); }, 1000);
+        }
+	}
 
     // Import the HTML file for this panel.
     $("#cooldownPanel").load("/panel/cooldown.html");
@@ -195,6 +217,8 @@
     $.cooldownDoQuery = doQuery;
     $.addCooldown = addCooldown;
     $.deleteCooldown = deleteCooldown;
+	$.addCooldownType = addCooldownType;
+	$.deleteCooldownType = deleteCooldownType;
     $.toggleGlobalCooldown = toggleGlobalCooldown;
     $.toggleModCooldown = toggleModCooldown;
     $.togglePerUserCooldown = togglePerUserCooldown;


### PR DESCRIPTION
!cooltype [command] [type]
This command allows you to override PhantomBot's logic for figuring out which type of cooldown to use for a specific command. This is especially useful for scenarios where you have a global cooldown time but you want to change a few commands to have no cooldown, or if you want to enable both global and per-user cooldowns but you want to specify some commands' global cooldown times.

The four types of cooldown "types" are:
A) default - this is the default setting, and allows PhantomBot's logic to figure out what type of cooldown each command follows
B) per-user - this overrides PhantomBot's logic and enforces per-user cooldowns for whatever commands you give this type to
C) global - this overrides PhantomBot's logic and enforces global cooldowns for whatever commands you give this type to
D) none - this overrides PhantomBot's logic and enforces no cooldowns for whatever commands you give this type to

Example Scenarios:
A)
    !toggleglobalcooldown
    !toggleperusercooldown
    !globalcooldowntime 2
    !cooltype !8ball global
    !coolcom !8ball 30

B)
    !toggleglobalcooldown
    !globalcooldowntime 2
    !coolcom !slot none

C)
    !toggleperusercooldown
    !cooltype !8ball global
    !cooltype !slot global
    !globalcooldowntime 10

The main reason I did this was because I noticed that with the way PhantomBot's logic currently works, it is impossible to specify specific commands to have a specific global cooldown time (AKA not the generic !globalcooldowntime) if you have both per-user and global enabled. There are some other scenarios that this !cooltype concept fixes as well, but I won't get into listing all of them since the above case should be enough to merit this change.