### PR TITLE
Space at End of currentsong.txt

### DIFF
--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -675,10 +675,12 @@
         /**
          * @function updateCurrentSongFile
          * @param {YoutubeVideo} youtubeVideo
+         * Note that the trailing space is for any broadcasting software which is "wrapping"
+         * the text constantly in a loop.
          */
         this.updateCurrentSongFile = function(youtubeVideo) {
             $.writeToFile(
-                youtubeVideo.getVideoTitle(),
+                youtubeVideo.getVideoTitle() + ' ',
                 baseFileOutputPath + 'currentsong.txt',
                 false
             );


### PR DESCRIPTION
**youtubePlayer.js**
- When the currentsong.txt file is written out, a trailing space is written out.  This is for streamers that are displaying the file in a loop.