### PR TITLE
- Only return the mention user if it has an @ at the start

### DIFF
--- a/source/com/illusionaryone/DiscordAPI.java
+++ b/source/com/illusionaryone/DiscordAPI.java
@@ -172,7 +172,7 @@ public class DiscordAPI {
      * @reutrn {String}
      */
     public String getUserMention(String username) {
-        if (userCache.containsKey(username.replace("@", "").toLowerCase())) {
+        if (userCache.containsKey(username.replace("@", "").toLowerCase()) && username.startsWith("@")) {
             return "<@" + userCache.get(username.replace("@", "").toLowerCase()) + ">";
         }
         return username;


### PR DESCRIPTION
**discordAPI.java:**
- Changed the `getMentionUser` function to only return the mention if the username starts with an `@`.