### PR TITLE
- Changed log.error to log.warn when a command is already registerd

### DIFF
--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -71,7 +71,7 @@
         }
 
         if ($.commandExists(command)) {
-            $.log.error('Failed to register command as already registered: ' + command + ' Script: ' + script + ' Original Script: ' + commandScriptTable[command]);
+            $.log.warn('Failed to register command as already registered: ' + command + ' Script: ' + script + ' Original Script: ' + commandScriptTable[command]);
             return;
         }
 


### PR DESCRIPTION
**commandRegister.js:**
- Changed the error logging to a warning when a command already exists since it't not really an error.