### PR TITLE
Fix for message limits

### DIFF
--- a/source/me/mast3rplan/phantombot/PhantomBot.java
+++ b/source/me/mast3rplan/phantombot/PhantomBot.java
@@ -451,6 +451,8 @@ public class PhantomBot implements Listener {
         PhantomBot.messageLimit = Double.parseDouble(this.pbProperties.getProperty("msglimit30", "18.75"));
         if (PhantomBot.messageLimit > 80.0) {
             PhantomBot.messageLimit = 80.0;
+        } else if (PhantomBot.messageLimit < 18.75) {
+            PhantomBot.messageLimit = 18.75;
         }
 
         /* Set the whisper limit for session.java to use. -- Currently Not Used -- */


### PR DESCRIPTION
**PhantomBot.java:**
- Before the Java properties the message limit in 30 seconds could be set to 0. This now would cause messages to not be sent. This check will allow a minimum of 18.75 messages allowed in 30 seconds, not less.