### PR TITLE
- Fixes

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -206,7 +206,7 @@
         }
 
         if (message.match(/\(touser\)/g)) {
-            message = $.replace(message, '(touser)', (event.getArgs()[0] === undefined ? $.username.resolve(event.getSender()) : event.getArguments().split(' ')[0].replace(/\./, '')));
+            message = $.replace(message, '(touser)', (event.getArgs()[0] === undefined ? $.username.resolve(event.getSender()) : String(event.getArgs()[0]).replace(/[^a-z1-9_@]/ig, '')));
         }
 
         if (message.match(/\(echo\)/g)) {

--- a/javascript-source/systems/queueSystem.js
+++ b/javascript-source/systems/queueSystem.js
@@ -91,7 +91,7 @@
          * @commandpath joinqueue [gamertag] - Adds you to the current queue
          */
         if (command.equalsIgnoreCase('joinqueue')) {
-        	joinQueue($.username.resolve(sender), action);
+        	joinQueue($.username.resolve(sender), args.join(' '));
         }
 
         if (command.equalsIgnoreCase('queue')) {


### PR DESCRIPTION
**customCommands.js:**
- Fixed `(touser)` not working and giving an error.
- `(touser)` will only allow characters from `[a-z1-9_@]` now.

**queueSystem.js:**
- Allowed spaces to be said in the gamertag.