### PR TITLE
- Fixed infinite reconnect loop that happens like once a month

### DIFF
--- a/source/me/mast3rplan/phantombot/twitchwsirc/TwitchWSIRCParser.java
+++ b/source/me/mast3rplan/phantombot/twitchwsirc/TwitchWSIRCParser.java
@@ -520,12 +520,7 @@ public class TwitchWSIRCParser {
      *
      */
     private void reconnect() {
-        try {
-            Thread.sleep(30000);// wait 30 seconds to give time to the irc servers to reboot.
-            this.session.reconnect();
-        } catch (InterruptedException ex) {
-            com.gmt2001.Console.err.printStackTrace(ex);
-        }
+        com.gmt2001.Console.debug.println("Got the RECONNECT event from Twitch.");
     }
 
     /*


### PR DESCRIPTION
This will fix the infinite reconnect loop that happens when a Twitch's IRC servers reboot.

![](https://i.zelakto.tv/A5k9lu2.png)