### PR TITLE
fix auction vulnerability

### DIFF
--- a/javascript-source/systems/auctionSystem.js
+++ b/javascript-source/systems/auctionSystem.js
@@ -116,7 +116,7 @@
             return;
         }
 
-        if (!parseInt(amount)) {
+        if (!(amount = parseInt(amount))) {
             $.say($.whisperPrefix(user) + $.lang.get('auctionsystem.bid.usage'));
             return;
         } else if (amount < auction.minimum) {
@@ -131,7 +131,7 @@
         }
 
         auction.topUser = user;
-        auction.topPoints = parseInt(amount);
+        auction.topPoints = amount;
 
         $.inidb.set('auctionresults', 'winner', auction.topUser);
         $.inidb.set('auctionresults', 'amount', auction.topPoints);


### PR DESCRIPTION
Steps to reproduce: 
1. Start an auction
2. Somebody bids fairly
3. Someone sends in chat `!bid 3-0` or something else that can be successfully parsed by `parseInt()`
3. Regardless of anything, the person now is the `auction.topUser` and `auction.topPoints` now holds the parsed value from his message. `auction.topPoints === 3`



p.s. I'm glad to see you're using NodeBB, thank you for the choice ![](http://smayly.ru/gallery/anime/RedFox/30.gif)