### PR TITLE
- Always save new followers in the db

### DIFF
--- a/javascript-source/handlers/followHandler.js
+++ b/javascript-source/handlers/followHandler.js
@@ -148,8 +148,7 @@
                     lastFollowTime = $.systemTime();
                     $.inidb.set('streamInfo', 'lastFollow', $.username.resolve(follower));
                 }
-
-                $.setIniDbBoolean('followed', follower, true);
+                
                 if (followReward > 0) {
                     $.inidb.incr('points', follower, followReward);
                 }
@@ -157,6 +156,10 @@
                 $.writeToFile($.username.resolve(follower), './addons/followHandler/latestFollower.txt', false);
             }
         }
+        
+        $.inidb.setAutoCommit(false);
+        $.setIniDbBoolean('followed', follower, true);
+        $.inidb.setAutoCommit(true);
     });
 
     /*


### PR DESCRIPTION
**followHandler.js:**
- Always save new followers, this will limit the amount of times we need to call the API if a user opens a raffle for followers only.