### PR TITLE
- Fixed messages getting cut from some setting commands

### DIFF
--- a/javascript-source/discord/handlers/bitsHandler.js
+++ b/javascript-source/discord/handlers/bitsHandler.js
@@ -78,7 +78,7 @@
         			return;
         		}
 
-        		message = args.slice(2).join(' ');
+        		message = args.slice(1).join(' ');
         		$.inidb.set('discordSettings', 'bitsMessage', message);
         		$.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.bitshandler.bits.message.set', message));
         	}

--- a/javascript-source/discord/handlers/hostHandler.js
+++ b/javascript-source/discord/handlers/hostHandler.js
@@ -131,7 +131,7 @@
                     return;
                 }
 
-                hostMessage = args.slice(2).join(' ');
+                hostMessage = args.slice(1).join(' ');
                 $.inidb.set('discordSettings', 'hostMessage', hostMessage);
                 $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.hosthandler.host.message.set', hostMessage));
             }


### PR DESCRIPTION
**bitsHandler.js:**
- Fixed the first argument of the message always getting cut off.

**hostHandler.js:**
- Fixed the first argument of the message always getting cut off.