### PR TITLE
Discord Host Handler - autohostmessage

### DIFF
--- a/javascript-source/discord/handlers/hostHandler.js
+++ b/javascript-source/discord/handlers/hostHandler.js
@@ -145,9 +145,9 @@
                     return;
                 }
 
-                autohostMessage = args.slice(1).join(' ');
+                autoHostMessage = args.slice(1).join(' ');
                 $.inidb.set('discordSettings', 'autohostMessage', autohostMessage);
-                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.hosthandler.autohost.message.set', autohostMessage));
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.hosthandler.autohost.message.set', autoHostMessage));
             }
 
             /**


### PR DESCRIPTION
**hostHandler.js**
- The autohostmessage command had a typo referencing the variable that was storing the autoHostMessage