### PR TITLE
Check if 'message' is null in getGame

### DIFF
--- a/javascript-source/core/streamInfo.js
+++ b/javascript-source/core/streamInfo.js
@@ -134,7 +134,10 @@
             if (!channelData.isNull('game') && channelData.getInt('_http') == 200) {
                 return channelData.getString("game");
             }
-            $.log.error('Failed to get the current game: ' + channelData.getString('message'));
+            
+            if (!channelData.isNull('message')) {
+                $.log.error('Failed to get the current game: ' + channelData.getString('message'));
+            }
             return '';
         }
     }


### PR DESCRIPTION
If the streamer was playing something, but the game name came back as 'null' (currently .twitch.tv/thespanishpresident), channelData.getString('message') will fail, throwing the error up to init.js and exiting out of the shoutout code.  This means that the user will not get the shoutout.

The proposed change checks for a null message, but results in followhandler.shoutout.no.game being printed to the channel, which is the intended result.