### PR TITLE
Update last follower if follower announcements are disabled

### DIFF
--- a/javascript-source/handlers/followHandler.js
+++ b/javascript-source/handlers/followHandler.js
@@ -134,8 +134,8 @@
         }
 
         if ($.bot.isModuleEnabled('./handlers/followHandler.js')) {
-            if (!$.inidb.exists('followed', follower) && followToggle) {
-                if (announceFollows) {
+            if (!$.inidb.exists('followed', follower)) {
+                if (announceFollows && followToggle) {
                     runFollow(s.replace('(name)', $.username.resolve(follower)).replace('(reward)', $.getPointsString(followReward)));
                     followTrain++;
 
@@ -146,13 +146,13 @@
                         }, 8e3);
                     }
                     lastFollowTime = $.systemTime();
-                    $.inidb.set('streamInfo', 'lastFollow', $.username.resolve(follower));
                 }
                 
                 if (followReward > 0) {
                     $.inidb.incr('points', follower, followReward);
                 }
 
+                $.inidb.set('streamInfo', 'lastFollow', $.username.resolve(follower));
                 $.writeToFile($.username.resolve(follower) + ' ', './addons/followHandler/latestFollower.txt', false);
             }
         }


### PR DESCRIPTION
Makes the streamInfo table (web panel latest follower) and latestFollower.txt file update on a new follow if followHandler is enabled, but followToggle (announce to chat) is false.

Also allows giving points to new followers in the same situation.