### PR TITLE
Fix Deleting Blacklists with \b in a Regex

### DIFF
--- a/resources/web/panel/js/moderationPanel.js
+++ b/resources/web/panel/js/moderationPanel.js
@@ -580,6 +580,11 @@
     function deleteBlacklist(key) {
         /* this was giving errors if it contained a symbol other then _ */
         var newkey = key.replace(/[^a-z1-9]/ig, '_');
+
+        /* Properly handle \b from regex patterns. */
+        var wordBoundaryRegEx = new RegExp('\b', 'g');
+        key = key.replace(wordBoundaryRegEx, '\\b');
+
         $("#delete_blackList_" + newkey).html("<i style=\"color: #6136b1\" class=\"fa fa-spinner fa-spin\" />");
 
         sendDBDelete("commands_delblacklist_" + key, "blackList", key);


### PR DESCRIPTION
**moderationPanel.js**
- \b is interpreted as a control character and was not being passed correctly back to the WebSocket
- A regex is now used to translate \b to \\b