### PR TITLE
Fix !editquote

### DIFF
--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -15,7 +15,10 @@
      */
     function updateQuote(quoteid, quote) {
         // Specify String() for objects as they were being treated as an object rather than a String on stringify().
-        quote = String(quote).replace(/"/g, '\'\'');
+        quote[0] = String(quote[0]).replace(/"/g, '\'\'');
+        quote[1] = String(quote[1]).replace(/"/g, '\'\'');
+        quote[3] = String(quote[3]).replace(/"/g, '\'\'');
+
         $.inidb.set('quotes', quoteid, JSON.stringify([String(quote[0]), String(quote[1]), String(quote[2]), String(quote[3])]));
     }
 


### PR DESCRIPTION
**quoteSystem.js**
- The updateQuote() function was converting a JSON object to a string to try to strip out double quotes.
- This was then trying to convert a String to a JSON, which resulted in the first 4 character of any update storing in the DB.
- Now, update each individual string element of the quote JSON object