### PR TITLE
- Fixed the `(@name)` function using the user id in Discord.

### DIFF
--- a/javascript-source/discord/systems/greetingsSystem.js
+++ b/javascript-source/discord/systems/greetingsSystem.js
@@ -31,7 +31,7 @@
 		    s = joinMessage;
 
 		if (s.match(/\(@name\)/)) {
-			s = $.replace(s, '(@name)', mention);
+			s = $.replace(s, '(@name)', mention.getAsMention());
 		}
 
 		if (s.match(/\(name\)/)) {
@@ -54,7 +54,7 @@
 		    s = partMessage;
 
 		if (s.match(/\(@name\)/)) {
-			s = $.replace(s, '(@name)', mention);
+			s = $.replace(s, '(@name)', mention.getAsMention());
 		}
 
 		if (s.match(/\(name\)/)) {


### PR DESCRIPTION
**discord\greetingsSystem.js:**
- Fixed `(@name)` using the user id and not real name.