### PR TITLE
fixed css in the panel on the tabs

### DIFF
--- a/resources/web/panel/css/style.css
+++ b/resources/web/panel/css/style.css
@@ -503,6 +503,9 @@ td {
     outline:none;
     background: rgb(28, 28, 36);
 }
+.ui-tabs .ui-tabs-nav .ui-tabs-anchor {
+    float: none;
+}
 
 .ui-draggable .ui-dialog-titlebar {
     background: transparent;


### PR DESCRIPTION
the whole button of the tab is now clickable rather than just the text inside the button of the tabs.

Before: 
![before](https://cloud.githubusercontent.com/assets/28994096/26603927/93570aae-4556-11e7-85f6-66ff5bd8a50f.png)

After:
![after](https://cloud.githubusercontent.com/assets/28994096/26603933/988dac6c-4556-11e7-8b40-d8b1940d80bc.png)

