### PR TITLE
Fixes to Retweet Reward Handling

### DIFF
--- a/javascript-source/handlers/twitterHandler.js
+++ b/javascript-source/handlers/twitterHandler.js
@@ -68,15 +68,16 @@
         }
 
         var userNameArray = event.getUserNameArray(),
+            i,
             twitterUserName,
             rewardNameArray = [],
             lastRetweet,
             reward = $.getIniDbNumber('twitter', 'reward_points'),
-            cooldown = $.getIniDbNumber('twitter', 'reward_cooldown') * 3.6e6,
+            cooldown = $.getIniDbFloat('twitter', 'reward_cooldown') * 3.6e6,
             now = $.systemTime();
 
-        for (twitterUserName in userNameList) {
-            twitterUserName = twitterUserName.toLowerCase();
+        for (i in userNameArray) {
+            twitterUserName = userNameArray[i].toLowerCase();
             userName = $.inidb.GetKeyByValue('twitter_mapping', '', twitterUserName);
             if (userName === null) {
                 continue;
@@ -91,7 +92,7 @@
         } 
 
         if (rewardNameArray.length > 0 && $.getIniDbBoolean('twitter', 'reward_announce')) {
-            $.say($.lang.get('twitter.reward.announcement', rewardNameArray.join(', '), reward, $.getPointsString(reward)));
+            $.say($.lang.get('twitter.reward.announcement', rewardNameArray.join(', '), $.getPointsString(reward)));
         }
     });
 
@@ -217,7 +218,7 @@
                             setCommandVal = $.getIniDbBoolean('twitter', 'reward_' + setCommandArg, false);
                             setCommandVal = setCommandVal ? 'on' : 'off';
                         } else {
-                            setCommandVal = $.getIniDbNumber('twitter', 'reward_' + setCommandArg);
+                            setCommandVal = $.getIniDbFloat('twitter', 'reward_' + setCommandArg);
                         }
                         $.say($.whisperPrefix(sender) + $.lang.get('twitter.set.reward.' + setCommandArg + '.usage', setCommandVal));
                         return;

--- a/javascript-source/lang/english/handlers/handlers-twitterHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-twitterHandler.js
@@ -1,6 +1,6 @@
 $.lang.register('twitter.tweet', '[Twitter Feed From @(twitterid)] $1');
 $.lang.register('twitter.tweet.mention', '[Twitter Feed From @(twitterid)] @$1: $2');
-$.lang.register('twitter.reward.announcement', 'Retweets from $1! Each earned $2 $3!');
+$.lang.register('twitter.reward.announcement', 'Retweets from $1! Reward of $2 given!');
 $.lang.register('twitter.usage', 'usage: !twitter [lasttweet | lastmention | lastretweet | set | post | id]');
 $.lang.register('twitter.id', '$1 is on Twitter @$2 [twitter.com/$2]');
 $.lang.register('twitter.usage.id', '(!twitter usage for usage)');

--- a/source/me/mast3rplan/phantombot/PhantomBot.java
+++ b/source/me/mast3rplan/phantombot/PhantomBot.java
@@ -102,6 +102,7 @@ import me.mast3rplan.phantombot.event.twitch.follower.TwitchFollowEvent;
 import me.mast3rplan.phantombot.event.twitch.host.TwitchHostedEvent;
 import me.mast3rplan.phantombot.event.twitch.offline.TwitchOfflineEvent;
 import me.mast3rplan.phantombot.event.twitch.online.TwitchOnlineEvent;
+import me.mast3rplan.phantombot.event.twitter.TwitterRetweetEvent;
 import me.mast3rplan.phantombot.httpserver.HTTPServer;
 import me.mast3rplan.phantombot.httpserver.NEWHTTPSServer;
 import me.mast3rplan.phantombot.httpserver.NEWHTTPServer;
@@ -1322,6 +1323,16 @@ public final class PhantomBot implements Listener {
             message = messageString.substring(0, messageString.indexOf(" "));
             arguments = messageString.substring(messageString.indexOf(" ") + 1);
             argument = arguments.split(" ");
+        }
+
+        if (message.equalsIgnoreCase("retweettest")) {
+            if (argument == null) {
+                com.gmt2001.Console.out.println(">> retweettest requires a Twitter ID (or Twitter IDs)");
+                return;
+            }
+            com.gmt2001.Console.out.println(">> Sending retweet test event");
+            EventBus.instance().postAsync(new TwitterRetweetEvent(argument, this.channel));
+            return;
         }
 
         if (message.equalsIgnoreCase("faketwitchmsg")) {


### PR DESCRIPTION
**twitterHandler.js**
- Was treating Float values as Numbers (integers).
- Was not accessing the list of Twitter IDs properly.

**handlers-twitterHandler.js**
- Changed the announce message.

**PhantomBot.java**
- Added command from console to test event: retweettest twitterID1 twitterID2 twitterID3 ...