### PR TITLE
Patch to Updates for 2.3.7

### DIFF
--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -623,7 +623,7 @@
         $.inidb.setAutoCommit(false);
         for (i in keys) {
             if (keys[i].match(/[A-Z]/)) {
-                $.inidb.incr('points', keys[i].toLowerCase(), $.inidb.get('points', keys[i]));
+                $.inidb.incr('points', keys[i].toLowerCase(), parseInt($.inidb.get('points', keys[i])));
                 $.inidb.del('points', keys[i]);
                 $.consoleLn('[points] ' + keys[i] + ' -> ' + keys[i].toLowerCase() + '::' + $.inidb.get('points', keys[i].toLowerCase()));
             } else if (keys[i].match(/[^a-zA-Z0-9_]/)) {


### PR DESCRIPTION
**updates.js**
- Cast an $.inidb.get() with parseInt() to resolve Java error with a String() being passed in to DataStore.incr()