### PR TITLE
Url Replacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Additional functionality is enabled through the use of third-party modules.
 * [Community Forums](https://community.phantombot.tv)
 * [Documentation & Installation Instructions](https://docs.phantombot.tv)
 * [PhantomBot Blog](https://blog.phantombot.tv)
-* [Follow us on Twitter](https://www.twitter.com/PhantomBotApp/ "PhantomBot Twitter")
+* [Follow us on Twitter](https://www.twitter.com/PhantomBotApp "PhantomBot Twitter")
 
 ## Screenshots
 
@@ -37,9 +37,11 @@ PhantomBot requires the following software to be installed:
 
 ## Installation
 Please refer to platform-specific installation documentation.
-* [Windows](https://docs.phantombot.tv/kb/setup-guide-windows)
-* [Linux](https://docs.phantombot.tv/kb/linux)
-* [macOS](https://docs.phantombot.tv/kb/macos)
+* [Windows](https://community.phantombot.tv/t/windows-setup-guide/60)
+* Linux:
+  * [Ubuntu 16.04](https://community.phantombot.tv/t/ubuntu-16-04-lts-setup-guide/61)
+  * [CentOS 7](https://community.phantombot.tv/t/centos-7-setup-guide/62)
+* [macOS](https://community.phantombot.tv/t/macos-setup-guide/63)
 
 ## Upgrading PhantomBot
 

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -1359,7 +1359,7 @@
         if ($.isNightly) {
             consoleLn('PhantomBot Nightly Build - No Support is Provided');
             consoleLn('Please report bugs including the date of the Nightly Build and Repo Version to:');
-            consoleLn('https://community.phantombot.tv/category/23/bug-reports');
+            consoleLn('https://community.phantombot.tv/c/support/bug-reports');
         } else {
             consoleLn('For support please visit: https://community.phantombot.tv');
         }

--- a/javascript-source/lang/german/BITTE_LESEN.txt
+++ b/javascript-source/lang/german/BITTE_LESEN.txt
@@ -1,22 +1,22 @@
 Guten Tag lieber PhantomBot Benutzer!
 
-Die deutsche Übersetzung für PhantomBot findest Du unter
+Die deutsche ï¿½bersetzung fï¿½r PhantomBot findest Du unter
 
 https://github.com/X00LA/PhantomBot-German-Translation
 
 den PhantomBot Forumsbeitrag findest Du unter
 
-https://community.phantombot.tv/topic/797/german-translation-github/11
+https://community.phantombot.tv/t/german-translation-github/217
 
 
-Sollten Probleme, Fragen, Fehler oder Verbesserungsvorschläge auftauchen,
+Sollten Probleme, Fragen, Fehler oder Verbesserungsvorschlï¿½ge auftauchen,
 kannst Du diese im Forum oder auf GitHub posten.
 
-Du bist auch herzlichst eingeladen, Dich an der Übersetzung zu beteiligen.
+Du bist auch herzlichst eingeladen, Dich an der ï¿½bersetzung zu beteiligen.
 
-Viel Spaß beim Streamen und mit PhantomBot!
+Viel Spaï¿½ beim Streamen und mit PhantomBot!
 
 X00LA
 
-Hier auch noch ein großes Dankeschön an die Devs von PhantomBot für diesen
-großartigen Twitch-Chat-Bot!
+Hier auch noch ein groï¿½es Dankeschï¿½n an die Devs von PhantomBot fï¿½r diesen
+groï¿½artigen Twitch-Chat-Bot!

--- a/javascript-source/lang/german/PLEASE_READ.txt
+++ b/javascript-source/lang/german/PLEASE_READ.txt
@@ -6,7 +6,7 @@ https://github.com/X00LA/PhantomBot-German-Translation
 
 the PhantomBot forum post, you can find under
 
-https://community.phantombot.tv/topic/797/german-translation-github/11
+https://community.phantombot.tv/t/german-translation-github/217
 
 
 If any problems, questions, errors or suggestions for improvement emerge,


### PR DESCRIPTION
When you starting migrate to the new forum system, some url's have a little bit changes. Including documentations.

* `README.md` - I added booth distribution installation on linux in `README.md` at lines [40-44] (two lines added)
* `javascript-source\init.js` - Bug reports url changed at line [1362]
* `javascript-source\lang\german\*.txt` - inside the text, url replaced to new url.

That's is all changes.

EDIT: If you wish centering your logo on `README.MD` just put `<center>` HTML tag between your logo.