### PR TITLE
Kill Command Loop Potential and Word Counter Language Fix

### DIFF
--- a/javascript-source/games/killCommand.js
+++ b/javascript-source/games/killCommand.js
@@ -34,9 +34,11 @@
     };
 
     function kill(sender, user) {
+        var tries = 0;
         do {
+            tries++;
             rand = $.randRange(1, otherMessageCount);
-        } while (rand == lastRandom);
+        } while (rand == lastRandom && tries < 5);
         lang = $.lang.get('killcommand.other.' + rand, $.resolveRank(sender), $.resolveRank(user), jailTimeout, $.botName);
         if (lang.startsWith('(jail)')) {
             lang = $.replace(lang, '(jail)', '');

--- a/javascript-source/lang/english/handlers/handlers-wordCounter.js
+++ b/javascript-source/lang/english/handlers/handlers-wordCounter.js
@@ -1,7 +1,7 @@
 $.lang.register('wordcounter.usage', 'Usage: !wordcounter [add / remove] !count [word]');
 $.lang.register('wordcounter.add.usage', 'Usage: !wordcounter add [word]');
-$.lang.register('wordcounter.added', 'Has been added to the word counter list!');
+$.lang.register('wordcounter.added', ' has been added to the word counter list!');
 $.lang.register('wordcounter.remove.usage', 'Usage: !wordcounter remove [word]');
 $.lang.register('wordcounter.err.404', 'That word is not in the counter list.');
-$.lang.register('wordcounter.removed', 'Has been removed to the word counter list!');
+$.lang.register('wordcounter.removed', ' has been removed to the word counter list!');
 $.lang.register('wordcounter.count', '$1 has been said $2 times.');


### PR DESCRIPTION
**killCommand.js**
- It was remotely possible for an infinite loop to start with !kill.  Now break the random loop after 5 tries.

**handlers-wordCounter.js**
- Put a space before 'added' and 'removed' language entries.