### PR TITLE
- Allow users to run custom code via custom commands.

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -53,6 +53,17 @@
             message = $.replace(message, '(adminonlyedit)', '');
         }
 
+        if (message.match(/\(runcode/)) {
+            var code = message.match(/\(runcode (.*)\)/)[1];
+
+            try {
+                eval(code);
+            } catch (ex) {
+                $.log.error('Failed to run custom code: ' + ex.message);
+            }
+            return null;
+        }
+
         if (message.match(/\(pointtouser\)/)) {
             if (event.getArgs()[0] !== undefined) {
                 message = $.replace(message, '(pointtouser)', (event.getArguments().split(' ')[0] + ' -> '));


### PR DESCRIPTION
**customCommands.js:**
- Added a new command variable that will allow users to use our basic
functions to run code for custom commands. This seems to allow every
function that Rhino has and our global functions as well. `(runcode
CODE_HERE)`