### PR TITLE
Fixed (@name) Tag for Discord Greeting System

### DIFF
--- a/javascript-source/discord/systems/greetingsSystem.js
+++ b/javascript-source/discord/systems/greetingsSystem.js
@@ -31,13 +31,12 @@
 		    s = joinMessage;
 
 		if (s.match(/\(@name\)/)) {
-			s = $.replace(s, '(@name)', mention.getAsMention());
+			s = $.replace(s, '(@name)', mention);
 		}
 
 		if (s.match(/\(name\)/)) {
 			s = $.replace(s, '(name)', username);
 		}
-
 		$.discord.say(channelName, s);
 	});
 
@@ -54,7 +53,7 @@
 		    s = partMessage;
 
 		if (s.match(/\(@name\)/)) {
-			s = $.replace(s, '(@name)', mention.getAsMention());
+			s = $.replace(s, '(@name)', mention);
 		}
 
 		if (s.match(/\(name\)/)) {


### PR DESCRIPTION
**greetingsSystem.js**
- The mention object was trying to be used as an DiscordAPI object and calling a method invalid for the String class of the mention.
- Tested by generating a JOIN event everytime a message was received for a user in my Discord chat

[12:23 PM] BOTIllusionaryBot: @IllusionaryOne IllusionaryOne just joined the server!
[12:23 PM] BOTIllusionaryBot: @IllusionaryBot IllusionaryBot just joined the server!
[12:23 PM] BOTIllusionaryBot: @IllusionaryBot IllusionaryBot just joined the server!
[12:23 PM] BOTIllusionaryBot: @IllusionaryBot IllusionaryBot just joined the server!
[12:23 PM] BOTIllusionaryBot: @IllusionaryBot IllusionaryBot just joined the server!