### PR TITLE
Patch to Chat Moderator

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -155,7 +155,7 @@
         emotesLimit = $.getIniDbNumber('chatModerator', 'emotesLimit');
 
         longMessageToggle = $.getIniDbBoolean('chatModerator', 'longMessageToggle');
-        longMessageMessage = $.getIniDbBoolean('chatModerator', 'longMessageMessage');
+        longMessageMessage = $.getIniDbString('chatModerator', 'longMessageMessage');
         longMessageLimit = $.getIniDbNumber('chatModerator', 'longMessageLimit');
 
         colorsToggle = $.getIniDbBoolean('chatModerator', 'colorsToggle');


### PR DESCRIPTION
**chatModerator.js**
- Call to getIniDBBoolean was to be getIniDBString for longMessageMessage in the reload function.