### PR TITLE
Fix clearing the timer after close a bet and fixed bet close with no args not working properly

### DIFF
--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -81,6 +81,7 @@
 	 */
 	function close(sender, option) {
 		if (option === undefined && bet.opened === true) {
+			clearInterval(timeout);
 			bet.opened = false;
 			$.say($.whisperPrefix(sender) + $.lang.get('bettingsystem.close.error.usage'));
 			return;
@@ -88,7 +89,7 @@
 			if (sender == $.botName) return;
 			$.say($.whisperPrefix(sender) + $.lang.get('bettingsystem.close.usage'));
 			return;
-		} else if (bet.options[option] === undefined) {
+		} else if (bet.options[option.toLowerCase()] === undefined) {
 			$.say($.whisperPrefix(sender) + $.lang.get('bettingsystem.bet.null'));
 			return;
 		}
@@ -130,7 +131,6 @@
 	 *
 	 */
 	function stop() {
-		clearInterval(timeout);
 		bet.opened = false;
 		$.say($.lang.get('bettingsystem.close.semi.success'));
 	}
@@ -254,17 +254,10 @@
 				return;
 
 			/**
-			 * @commandpath bet stop - Stop the current bet.
-			 */
-			} else if (action.equalsIgnoreCase('stop')) {
-				stop();
-				return;
-
-			/**
 			 * @commandpath bet close ["winning option"] - Closes the current bet.
 			 */
 			} else if (action.equalsIgnoreCase('close')) {
-				close(sender, args.slice(1).join(' ').toLowerCase());
+				close(sender, args[1]);
 				return;
 
 			/**
@@ -355,7 +348,6 @@
             $.registerChatSubcommand('bet', 'current', 7);
             $.registerChatSubcommand('bet', 'results', 7);
             $.registerChatSubcommand('bet', 'open', 2);
-            $.registerChatSubcommand('bet', 'stop', 2);
             $.registerChatSubcommand('bet', 'close', 2);
             $.registerChatSubcommand('bet', 'save', 1);
             $.registerChatSubcommand('bet', 'saveformat', 1);

--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -57,7 +57,7 @@
 		
 		if (timer !== undefined && !isNaN(parseInt(timer)) && timer > 0) {
 			bet.timer = timer;
-			setTimeout(function() {
+			timeout = setTimeout(function() {
 				stop();
 			}, timer * 6e4);
 		}
@@ -130,6 +130,7 @@
 	 *
 	 */
 	function stop() {
+		clearInterval(timeout);
 		bet.opened = false;
 		$.say($.lang.get('bettingsystem.close.semi.success'));
 	}
@@ -253,6 +254,13 @@
 				return;
 
 			/**
+			 * @commandpath bet stop - Stop the current bet.
+			 */
+			} else if (action.equalsIgnoreCase('stop')) {
+				stop();
+				return;
+
+			/**
 			 * @commandpath bet close ["winning option"] - Closes the current bet.
 			 */
 			} else if (action.equalsIgnoreCase('close')) {
@@ -347,6 +355,7 @@
             $.registerChatSubcommand('bet', 'current', 7);
             $.registerChatSubcommand('bet', 'results', 7);
             $.registerChatSubcommand('bet', 'open', 2);
+            $.registerChatSubcommand('bet', 'stop', 2);
             $.registerChatSubcommand('bet', 'close', 2);
             $.registerChatSubcommand('bet', 'save', 1);
             $.registerChatSubcommand('bet', 'saveformat', 1);


### PR DESCRIPTION
1. timeout variable was not being used and it was needed to prevent bugs related to the timer.
2. When you use join there is not possible undefined option variable, there will have blank content or blank space