### PR TITLE
Top Command Count Fix

### DIFF
--- a/javascript-source/commands/topCommand.js
+++ b/javascript-source/commands/topCommand.js
@@ -37,7 +37,7 @@
      * @returns {Array}
      */
     function getTop5(iniName) {
-        var keys = $.inidb.GetKeysByOrderValue(iniName, '', 'DESC', (iniName.equals('points') ? amountPoints + 1 : amountTime + 1), 0),
+        var keys = $.inidb.GetKeysByOrderValue(iniName, '', 'DESC', (iniName.equals('points') ? amountPoints + bots.length + 1 : amountTime + bots.length + 1), 0),
             list = [],
             i;
 


### PR DESCRIPTION
**topCommand.js**
- !top and !toptime was pulling back just the number of entries requested by the user from the DB.
- Changed to number of entries plus the number of bots, so that if any bot is in the top list, enough real entries are pulled back as well.