### PR TITLE
Fix (writefile) tag for Discord !addcom

### DIFF
--- a/javascript-source/discord/commands/customCommands.js
+++ b/javascript-source/discord/commands/customCommands.js
@@ -118,7 +118,7 @@
             s = $.replace(s, '(count)', $.inidb.get('discordCommandCount', event.getCommand()));
         }
 
-        if (s.match(/\(writefile (.+), ([a-z]), (.+)\)/)) {
+        if (s.match(/\(writefile ([\w\W^,]+), ([\w^,]+), ([\w\W^,]+)\)/)) {
             var file = s.match(/\(writefile (.+), (.+), (.+)\)/)[1], append = (s.match(/\(writefile (.+), (.+), (.+)\)/)[2] == 'true' ? true : false), string = s.match(/\(writefile (.+), (.+), (.+)\)/)[3];
             $.writeToFile(string, './addons/' + file, append);
             return null;


### PR DESCRIPTION
**customCommands.js**
- The regular expression was too greedy, had to instruct to select \w\W and NOT a comma in each field