### PR TITLE
Remove !account bind from Twitch

### DIFF
--- a/javascript-source/discord/core/accountLink.js
+++ b/javascript-source/discord/core/accountLink.js
@@ -126,7 +126,11 @@
         $.discord.registerSubCommand('accountlink', 'link', 0);
         $.discord.registerSubCommand('accountlink', 'remove', 0);
 
-        $.registerChatCommand('./discord/core/accountLink.js', 'account', 7);
+        /* Not sure why this was here, leaving in case it is intentional but the command needs
+         * to be smarter.
+         *
+         * $.registerChatCommand('./discord/core/accountLink.js', 'account', 7);
+         */
 
         // Interval to clear our old codes that have not yet been registered.
         interval = setInterval(function() {


### PR DESCRIPTION
**accountLink.js**
- The Discord !account command was also registered to Twitch yet the function only uses Discord methods.  Removed.