### PR TITLE
BETA - Detect Clips

### DIFF
--- a/javascript-source/handlers/clipHandler.js
+++ b/javascript-source/handlers/clipHandler.js
@@ -1,0 +1,85 @@
+/**
+ * Script  : clipHandler.js
+ * Purpose : Configures the automatic display of clips in chat and captures the events from Twitch.
+ */
+(function() {
+	var toggle = $.getSetIniDbBoolean('clipsSettings', 'toggle', false),
+	    message = $.getIniDbString('clipsSettings', 'message', '(name) created a clip: (url)');
+
+	/*
+	 * @function reloadClips
+	 */
+	function reloadClips() {
+		toggle = $.getIniDbBoolean('clipsSettings', 'toggle', false);
+	    message = $.getIniDbString('clipsSettings', 'message', '(name) created a clip: (url)');
+	}
+
+	/*
+	 * @event BitsEvent
+	 */
+	$.bind('twitchClip', function(event) {
+		var creator = event.getCreator(),
+            url = event.getClipURL(),
+		    s = message;
+
+        /* Even though the Core won't even query the API if this is false, we still check here. */
+		if (toggle === false) {
+			return;
+		}
+
+		if (s.match(/\(name\)/g)) {
+			s = $.replace(s, '(name)', creator);
+		}
+
+		if (s.match(/\(url\)/g)) {
+			s = $.replace(s, '(url)', url);
+		}
+
+        $.say(s);
+	});
+
+	/*
+	 * @event command
+	 */
+	$.bind('command', function(event) {
+		var sender = event.getSender(),
+		    command = event.getCommand(),
+		    args = event.getArgs(),
+		    argsString = event.getArguments(),
+		    action = args[0];
+
+		/*
+		 * @commandpath clipstoggle - Toggles the clips announcements.
+		 */
+		if (command.equalsIgnoreCase('clipstoggle')) {
+			toggle = !toggle;
+			$.setIniDbBoolean('clipsSettings', 'toggle', toggle);
+			$.say($.whisperPrefix(sender) + (toggle ? $.lang.get('cliphandler.toggle.on') : $.lang.get('cliphandler.toggle.off')))
+		}
+		
+
+		/*
+		 * @commandpath clipsmessage - Sets a message for when someone creates a clip.
+		 */
+		if (command.equalsIgnoreCase('clipsmessage')) {
+			if (action === undefined) {
+				$.say($.whisperPrefix(sender) + $.lang.get('cliphandler.message.usage'));
+				return;
+			}
+
+			message = argsString;
+			$.setIniDbString('clipsSettings', 'message', message);
+			$.say($.whisperPrefix(sender) + $.lang.get('bitshandler.message.set', message));
+		}
+	});
+
+    /*
+     * @event initReady
+     */
+    $.bind('initReady', function() {
+        $.registerChatCommand('./handlers/clipHandler.js', 'clipstoggle', 1);
+        $.registerChatCommand('./handlers/clipHandler.js', 'clipsmessage', 1);
+    });
+
+    $.reloadClips = reloadClips;
+})();

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -809,6 +809,13 @@
         });
 
         /*
+         * @event twitchClipEvent
+         */
+        $api.on($script, 'twitchClip', function(event) {
+            callHook('twitchClip', event, false);
+        });
+
+        /*
          * @event newSubscriber
          */
         $api.on($script, 'newSubscriber', function(event) {

--- a/javascript-source/lang/english/handlers/handlers-clipHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-clipHandler.js
@@ -1,0 +1,4 @@
+$.lang.register('cliphandler.toggle.off', 'Clips announcements have been disabled.');
+$.lang.register('cliphandler.toggle.on', 'Clips announcements have been enabled.');
+$.lang.register('cliphandler.message.usage', 'Usage: !clipsmessage (message) - Tags: (name), (url)');
+$.lang.register('cliphandler.message.set', 'Clips message has been set to: $1.');

--- a/source/com/gmt2001/TwitchAPIv5.java
+++ b/source/com/gmt2001/TwitchAPIv5.java
@@ -563,6 +563,17 @@ public class TwitchAPIv5 {
     }
 
     /**
+     * Get the clips from today for a channel.
+     *
+     * @param channel
+     * @return JSONObject  clips object.
+     */
+    public JSONObject getClipsToday(String channel) {
+        /* Yes, the v5 endpoint for this does use the Channel Name and not the ID. */
+        return GetData(request_type.GET, base_url + "/clips/top?channel=" + channel + "&limit=100&period=day", false);
+    }
+
+    /**
      * Populates the followed table from a JSONArray. The database auto commit is disabled
      * as otherwise the large number of writes in a row can cause some delay.  We only
      * update the followed table if the user has an entry in the time table. This way we

--- a/source/tv/phantombot/event/twitch/clip/TwitchClipEvent.java
+++ b/source/tv/phantombot/event/twitch/clip/TwitchClipEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2017 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package tv.phantombot.event.twitch.clip;
+
+import tv.phantombot.event.twitch.TwitchEvent;
+import tv.phantombot.twitchwsirc.Channel;
+
+public class TwitchClipEvent extends TwitchEvent {
+
+    private final String clipURL;
+    private final String creator;
+    private final Channel channel;
+
+    public TwitchClipEvent(String clipURL, String creator) {
+        this.clipURL = clipURL;
+        this.creator = creator;
+        this.channel = null;
+    }
+
+    public TwitchClipEvent(String clipURL, String creator, Channel channel) {
+        this.clipURL = clipURL;
+        this.creator = creator;
+        this.channel = channel;
+    }
+
+    public String getClipURL() {
+        return clipURL;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+}


### PR DESCRIPTION
There are restrictions on this due to the Twitch API.  Twitch allows us to poll the
clips from the "day" (assuming this is the current day, not sure if it is last 24 hours
or not though).  We poll 100 of the clips.  We then scan over all of the clips for the
newest one.  If this is newer than the last one in the database, then an event will be
sent and a message presented in chat.

Keep in mind that if you have over 100 clips in the "day" period, that the newest one
will only bubble up if it has more views than the last newest clip.  This, unfortunately,
is what Twitch returns and we hope they provide a better endpoint in the future.

This endpoint will be polled every 60 seconds.

**clipHandler.js**
- Handles the event from Twitch and displays a message in chat
- Supports !clipstoggle and !clipsmessage
- !clipsmessage supports (name) and (url) tag
- Disabled by default

**init.js**
- Hook the twitchClip event

**handlers-clipHandler.js**
- Language entries, the usage and output for !clipstoggle and !clipsmessage

**TwitchAPIv5.java**
- Added new method for grabbing the clips from the "day" with a limit of 100 (max)

**TwitchCache.java**
- If !clipstoggle is enabled, will query the clips API every 60 seconds and return an event if applicable

**TwitchClipEvent.java**
- Event definition