### PR TITLE
- Moved verified check to debug-only-mode

### DIFF
--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1112,8 +1112,11 @@ public final class PhantomBot implements Listener {
             com.gmt2001.Console.err.printStackTrace(ex);
         }
 
-        /* Check for bot verification. */
-        print("Bot Verification Status: " + (TwitchAPIv5.instance().getBotVerified(this.botName) ? "" : " NOT ") + "Verified.");
+        // Moved this to debug only. People are already asking questions.
+        if (PhantomBot.enableDebugging) {
+            /* Check for bot verification. */
+            print("Bot Verification Status: " + (TwitchAPIv5.instance().getBotVerified(this.botName) ? "" : " NOT ") + "Verified.");
+        }
 
         /* Check for a update with PhantomBot */
         doCheckPhantomBotUpdate();


### PR DESCRIPTION
**PhantomBot.java:**
- Moved this console log to debug only mode because users that use the
nightly are already asking about this, once we push it to stable we'll
get a lot more. Plus, for every basic user they do not need to get their
bot's verified, it changes nothing to them. 20 messages for one channel
is more than enough. Plus, Twitch hasn't been accepting new bots for a
few weeks now, so this will lead to more confusion.