### PR TITLE
Fix Issue with Custom Commands with JavaScript Array Method Names not Working

### DIFF
--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -9,8 +9,8 @@
 (function() {
     var defaultCooldownTime = $.getSetIniDbNumber('cooldownSettings', 'defaultCooldownTime', 5),
         modCooldown = $.getSetIniDbBoolean('cooldownSettings', 'modCooldown', false),
-        defaultCooldowns = [],
-        cooldowns = [];
+        defaultCooldowns = {},
+        cooldowns = {};
 
     $.raffleCommand = null;
 

--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -10,7 +10,7 @@
 (function() {
     var commands = {},
         commandScriptTable = {},
-        aliases = [];
+        aliases = {};
 
     /**
      * @function getCommandScript


### PR DESCRIPTION
**commandCooldown.js, commandRegister.js**
- Changed the arrays for handling aliases and cooldowns over to objects.
- Previously, Rhino was passing 'map' and 'index' and other methods as actual methods and this was causing errors.