### PR TITLE
Data Service Handler: Split for command description on only one comma

### DIFF
--- a/javascript-source/handlers/dataServiceHandler.js
+++ b/javascript-source/handlers/dataServiceHandler.js
@@ -31,7 +31,7 @@
             if (!commandHelpFileData[idx].includes(',')) {
                 continue;
             }
-            parts = commandHelpFileData[idx].split(', ');
+            parts = commandHelpFileData[idx].split(', ', 2);
             commandHelpData[parts[0]] = parts[1];
         }
 


### PR DESCRIPTION
**dataServiceHandler.js**
- Was splitting on all comma-spaces instead of just first one.