### PR TITLE
Fix setconnectmessage command from including itsetlf in message

### DIFF
--- a/javascript-source/core/initCommands.js
+++ b/javascript-source/core/initCommands.js
@@ -40,12 +40,12 @@
              * @commandpath botName setconnectmessage [message] - Sets a message that will be said once the bot joins the channel.
              */
             if (action.equalsIgnoreCase('setconnectmessage')) {
-                if (action === undefined) {
+                if (subAction === undefined) {
                     $.say($.whisperPrefix(sender) + $.lang.get('init.connected.msg.usage', bot));
                     return;
                 }
 
-                var message = args.slice(0).join(' ');
+                var message = args.slice(1).join(' ');
 
                 $.setIniDbString('settings', 'connectedMsg', message);
                 $.say($.whisperPrefix(sender) + $.lang.get('init.connected.msg', message));


### PR DESCRIPTION
This fixes the !botname setconnectmessage command from including 'setconnectmessage' in the message.

action was changed to subAction since action is already being checked in the main if-statement, and subAction will ensure there's a word after setconnectmessage.