### PR TITLE
Fix Auto-Backups for Raspberry Pi     **PhantomBot.java**     - Due to the OS on Pi (even Pi3b) being 32-bit, the calculation used for     the dates to keep backup files for was rolling over.     - Example: when using 30 days, the calculation resulted in -1,702,967,296     -- rolled over at the 32-bit signed boundary.     - Fixed by switching to using seconds as the calculation period instead of     milliseconds.

### DIFF
--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -2707,7 +2707,7 @@ public final class PhantomBot implements Listener {
                 Iterator dirIterator = FileUtils.iterateFiles(new File("./dbbackup"), new WildcardFileFilter("phantombot.auto.*"), null);
                 while (dirIterator.hasNext()) {
                     File backupFile = (File) dirIterator.next();
-                    if (FileUtils.isFileOlder(backupFile, System.currentTimeMillis() - (86400000 * backupSQLiteKeepDays))) {
+                    if (FileUtils.isFileOlder(backupFile, (System.currentTimeMillis() / 1000) - (86400 * backupSQLiteKeepDays))) {
                         FileUtils.deleteQuietly(backupFile);
                     }
                 }


### PR DESCRIPTION
    **PhantomBot.java**     

- Due to the OS on Pi (even Pi3b) being 32-bit, the calculation used for     the dates to keep backup files for was rolling over.     
- Example: when using 30 days, the calculation resulted in -1,702,967,296 -- rolled over at the 32-bit signed boundary.     
- Fixed by switching to using seconds as the calculation period instead of     milliseconds.