### PR TITLE
- Removed multiple threads handling messages

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -316,16 +316,20 @@
     function timeoutUserFor(username, time, reason) {
         $.session.sayNow('.timeout ' + username + ' ' + time + ' ' + reason);
 
-        // Testing with this, to be removed later on.
+        // Testing with this; might be removed later.
         if ($.getMessageWrites() < 25) {
-            $.session.sayNow('.timeout ' + username + ' ' + time + ' ' + reason);
+            var firstTimeout = setTimeout(function() {
+                $.session.sayNow('.timeout ' + username + ' ' + time + ' ' + reason);
+                clearInterval(firstTimeout);
+            }, 150);
         }
-        var timeout = setTimeout(function() {
+
+        var lastTimeout = setTimeout(function() {
             if ($.getMessageWrites() < 50) {
                 $.session.sayNow('.timeout ' + username + ' ' + time + ' ' + reason);
             }
-            clearInterval(timeout);
-        }, 1500, 'scripts::core::chatModerator.js::timeout');
+            clearInterval(lastTimeout);
+        }, 1000, 'scripts::core::chatModerator.js::timeout');
     }
 
     /**

--- a/source/tv/phantombot/twitchwsirc/Session.java
+++ b/source/tv/phantombot/twitchwsirc/Session.java
@@ -266,7 +266,7 @@ public class Session implements Runnable {
      *
      * @param {String} message
      */
-    public void send(String message) {
+    private void send(String message) {
         twitchWSIRC.send("PRIVMSG #" + channelName + " :" + message);
         com.gmt2001.Console.out.println("[CHAT] " + message);
     }

--- a/source/tv/phantombot/twitchwsirc/TwitchWSIRC.java
+++ b/source/tv/phantombot/twitchwsirc/TwitchWSIRC.java
@@ -58,7 +58,7 @@ import tv.phantombot.PhantomBot;
 public class TwitchWSIRC extends WebSocketClient {
 
     private static final Map<String, TwitchWSIRC> instances = Maps.newHashMap();
-    private final ThreadPoolExecutor threads = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
+    //private final ThreadPoolExecutor threads = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
     private final String channelName;
     private final String login;
     private final String oAuth;
@@ -238,15 +238,16 @@ public class TwitchWSIRC extends WebSocketClient {
             sentPing = false;
             return;
         } else {
-            try {
-                if (threads.getActiveCount() < 4) {
-                    threads.execute(new MessageRunnable(message));
-                } else {
-                    twitchWSIRCParser.parseData(message);
-                }
-            } catch (Exception ex) {
-                twitchWSIRCParser.parseData(message);
-            }
+            twitchWSIRCParser.parseData(message);
+            //try {
+            //    if (threads.getActiveCount() < 4) {
+            //        threads.execute(new MessageRunnable(message));
+            //    } else {
+            //        twitchWSIRCParser.parseData(message);
+            //    }
+            //} catch (Exception ex) {
+            //    twitchWSIRCParser.parseData(message);
+            //}
         }
     }
 


### PR DESCRIPTION
**TwitchWSIRC.java:**
- This is a test, however after some testing it seems like handling
messages on one thread is faster, it also uses less resources.

**chatModerator.js:**
- Made the last timeout wait 1 second and not 1.5 seconds.

**Session.java:**
- Made the `send` method private