### PR TITLE
- Viewer list cache optimization and Discord stream alerts

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -608,6 +608,46 @@
     }
 
     /**
+     * @event ircChannelJoinUpdate
+     *
+     * @info Event that is sent when a large amount of people join/leave. This is done on a new thread.
+     */
+    $.bind('ircChannelUsersUpdate', function(event) {
+        setTimeout(function() {
+            var usernames = event.getUsers(),
+                joins = event.getJoins(),
+                parts = event.getParts(),
+                now = $.systemTime(),
+                newUsers = [];
+
+            // Handle parts
+            for (var i in parts) {
+                restoreSubscriberStatus(parts[i], true);
+                $.username.removeUser(parts[i]);
+            }
+
+            // Handle joins.
+            $.inidb.setAutoCommit(false);
+            for (var i in joins) {
+                if (!$.user.isKnown(joins[i])) {
+                    $.setIniDbBoolean('visited', joins[i], true);
+                }
+                $.checkGameWispSub(username);
+            }
+            $.inidb.setAutoCommit(true);
+            $.inidb.SaveAll(true);
+
+            // Set the new users array.
+            for (var i in usernames) {
+                newUsers.push([usernames[i], now]);
+            }
+            // Set the new array.
+            users = newUsers;
+            lastJoinPart = $.systemTime();
+        }, 0);
+    });
+
+    /**
      * @event ircChannelJoin
      */
     $.bind('ircChannelJoin', function(event) {

--- a/javascript-source/discord/handlers/streamHandler.js
+++ b/javascript-source/discord/handlers/streamHandler.js
@@ -74,6 +74,7 @@
         		// Get max chatters.
         		var maxChatters = Math.max.apply(null, chatters);
 
+                $.discord.say(channelName, offlineMessage.replace('\(name\)', $.username.resolve($.channelName)));
         		// Send the message as an embed.
         		$.discordAPI.sendMessageEmbed(channelName, new Packages.sx.blah.discord.util.EmbedBuilder()
         			.withColor(100, 65, 164)
@@ -108,6 +109,7 @@
 				    s = $.replace(s, '(name)', $.username.resolve($.channelName));
 			    }
 
+                $.discord.say(channelName, s);
 			    $.discordAPI.sendMessageEmbed(channelName, new Packages.sx.blah.discord.util.EmbedBuilder()
         		    .withColor(100, 65, 164)
         		    .withThumbnail($.twitchcache.getLogoLink())
@@ -139,6 +141,7 @@
 			s = $.replace(s, '(name)', $.username.resolve($.channelName));
 		}
 
+        $.discord.say(channelName, s);
 		$.discordAPI.sendMessageEmbed(channelName, new Packages.sx.blah.discord.util.EmbedBuilder()
         	.withColor(100, 65, 164)
         	.withThumbnail($.twitchcache.getLogoLink())

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -604,6 +604,13 @@
         });
 
         /*
+         * @event ircChannelUsersUpdate
+         */
+        $api.on($script, 'ircChannelUsersUpdate', function(event) {
+            callHook('ircChannelUsersUpdate', event, false);
+        });
+
+        /*
          * @event ircChannelLeave
          */
         $api.on($script, 'ircChannelLeave', function(event) {

--- a/source/tv/phantombot/cache/ViewerListCache.java
+++ b/source/tv/phantombot/cache/ViewerListCache.java
@@ -26,8 +26,6 @@ import org.json.JSONObject;
 import org.json.JSONArray;
 
 import tv.phantombot.event.irc.channel.IrcChannelUsersUpdateEvent;
-import tv.phantombot.event.irc.channel.IrcChannelJoinEvent;
-import tv.phantombot.event.irc.channel.IrcChannelLeaveEvent;
 import tv.phantombot.event.EventBus;
 
 public class ViewerListCache implements Runnable {
@@ -96,9 +94,9 @@ public class ViewerListCache implements Runnable {
 	 */
 	private void updateCache() throws Exception {
 		String[] types = new String[] { "moderators", "staff", "admins", "global_mods", "viewers" };
-		List<String> cache = new ArrayList<>();
-		List<String> joins = new ArrayList<>();
-		List<String> parts = new ArrayList<>();
+		List<String> cache = new ArrayList<String>();
+		List<String> joins = new ArrayList<String>();
+		List<String> parts = new ArrayList<String>();
 		EventBus bus = EventBus.instance();
 
 		com.gmt2001.Console.debug.println("ViewerListCache::updateCache");

--- a/source/tv/phantombot/cache/ViewerListCache.java
+++ b/source/tv/phantombot/cache/ViewerListCache.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.json.JSONObject;
 import org.json.JSONArray;
 
+import tv.phantombot.event.irc.channel.IrcChannelUsersUpdateEvent;
 import tv.phantombot.event.irc.channel.IrcChannelJoinEvent;
 import tv.phantombot.event.irc.channel.IrcChannelLeaveEvent;
 import tv.phantombot.event.EventBus;
@@ -33,7 +34,7 @@ public class ViewerListCache implements Runnable {
 	private static ViewerListCache instance = null;
 	private final String channelName;
 	private final Thread thread;
-	private List<String> cache = new ArrayList<>();
+	private List<String> cache = new ArrayList<String>();
 	private boolean isKilled = false;
 
 	/*
@@ -66,7 +67,7 @@ public class ViewerListCache implements Runnable {
 	}
 
 	/*
-	 * Method that updates the cache every 5 minutes.
+	 * Method that updates the cache every 10 minutes.
 	 */
 	@Override
 	@SuppressWarnings("SleepWhileInLoop")
@@ -96,6 +97,8 @@ public class ViewerListCache implements Runnable {
 	private void updateCache() throws Exception {
 		String[] types = new String[] { "moderators", "staff", "admins", "global_mods", "viewers" };
 		List<String> cache = new ArrayList<>();
+		List<String> joins = new ArrayList<>();
+		List<String> parts = new ArrayList<>();
 		EventBus bus = EventBus.instance();
 
 		com.gmt2001.Console.debug.println("ViewerListCache::updateCache");
@@ -121,21 +124,24 @@ public class ViewerListCache implements Runnable {
 				// Check for new users that joined.
 				for (int i = 0; i < cache.size(); i++) {
 					if (!this.cache.contains(cache.get(i))) {
-						bus.postAsync(new IrcChannelJoinEvent(cache.get(i)));
-						com.gmt2001.Console.debug.println("User Joined Channel [" + cache.get(i) + "#" + channelName + "]");
+						joins.add(cache.get(i));
 					}
 				}
 
 				// Check for old users that left.
 				for (int i = 0; i < this.cache.size(); i++) {
 					if (!cache.contains(this.cache.get(i))) {
-						bus.postAsync(new IrcChannelLeaveEvent(this.cache.get(i)));
-						com.gmt2001.Console.debug.println("User Left Channel [" + this.cache.get(i) + "#" + channelName + "]");
+						parts.add(this.cache.get(i));
 					}
 				}
 
+				bus.post(new IrcChannelUsersUpdateEvent(cache.toArray(new String[cache.size()]), joins.toArray(new String[joins.size()]), parts.toArray(new String[parts.size()])));
 				// Set the new cache.
 				this.cache = cache;
+				// Delete the temp caches.
+				cache = null;
+				parts = null;
+				joins = null;
 			} else {
 				com.gmt2001.Console.debug.println("Failed to update viewers cache: " + object);
 			}

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2017 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package tv.phantombot.event.irc.channel;
+
+import tv.phantombot.twitchwsirc.Channel;
+import tv.phantombot.twitchwsirc.Session;
+
+public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
+
+    private final String[] users;
+    private final String[] joins;
+    private final String[] parts;
+
+    public IrcChannelUsersUpdateEvent(Session session, Channel channel, String[] users, String[] joins, String[] parts) {
+        super(session, channel);
+        this.users = users;
+        this.joins = joins;
+        this.parts = parts;
+    }
+
+    public IrcChannelUsersUpdateEvent(String[] users, String[] joins, String[] parts) {
+        super(null, null);
+        this.users = users;
+        this.joins = joins;
+        this.parts = parts;
+    }
+
+    public String[] getUsers() {
+        return users;
+    }
+
+    public String[] getJoins() {
+        return joins;
+    }
+
+    public String[] getParts() {
+        return parts;
+    }
+}


### PR DESCRIPTION
**ViewerListCache.java, init.js, permissions.js:**
- Changed the logic of getting viewers from TMI. The core will now send
one event with all joins and parts and new users list to a new event
called `IrcChannelUsersUpdate` every 10 minutes, which will run on a new
thread in Rhino to update the lists. This can take 3 minutes to run with
36,000 viewers but doesn't slow down events like the old method did. The
old method would queue all events which would cause the bot to slow
down.

**streamHandler.js:**
- You can now ping people with a role on the live messages.