### PR TITLE
- Switched back to unlimited message parsing threads

### DIFF
--- a/source/tv/phantombot/twitchwsirc/TwitchWSIRC.java
+++ b/source/tv/phantombot/twitchwsirc/TwitchWSIRC.java
@@ -37,9 +37,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ScheduledExecutorService;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;

--- a/source/tv/phantombot/twitchwsirc/TwitchWSIRC.java
+++ b/source/tv/phantombot/twitchwsirc/TwitchWSIRC.java
@@ -58,7 +58,6 @@ import tv.phantombot.PhantomBot;
 public class TwitchWSIRC extends WebSocketClient {
 
     private static final Map<String, TwitchWSIRC> instances = Maps.newHashMap();
-    private final ThreadPoolExecutor threads = (ThreadPoolExecutor) Executors.newFixedThreadPool(5);
     private final String channelName;
     private final String login;
     private final String oAuth;
@@ -236,8 +235,12 @@ public class TwitchWSIRC extends WebSocketClient {
             sentPing = false;
             return;
         } else {
+        	// Do not change this.
+        	// After a lot of testing, a thread pool can slow down when Twitch sends burst of messages. 
+        	// The event bus can take a bit of time to queue in async, which causes the small delay.
+        	// This also happens in sync.
             try {
-                threads.execute(new MessageRunnable(message));
+                new Thread(new MessageRunnable(message)).start();
             } catch (Exception ex) {
                 twitchWSIRCParser.parseData(message);
             }


### PR DESCRIPTION
**TwitchWSIRC.java:**
- After a few weeks of trying to find the root cause of the bot slowdown
in larger channels, I pinned down the issue to the thread pool running out
of threads when Twitch sends bursts of messages. The eventbus can take
some time to queue events in async (600ms at times), which could cause all threads in the
pool to be active, thus slowing down message processing. This was tested
with a custom IRC server to make sure this was the real issue.