### PR TITLE
- Removed thumbnail from online message in Discord

### DIFF
--- a/javascript-source/discord/handlers/streamHandler.js
+++ b/javascript-source/discord/handlers/streamHandler.js
@@ -116,8 +116,7 @@
         		    .withTitle(s)
         		    .appendField($.lang.get('discord.streamhandler.common.game'), $.getGame($.channelName), false)
         		    .appendField($.lang.get('discord.streamhandler.common.title'), $.getStatus($.channelName), false)
-        		    .withUrl('https://twitch.tv/' + $.channelName)
-        		    .withImage($.twitchcache.getPreviewLink()).build());
+        		    .withUrl('https://twitch.tv/' + $.channelName).build());
 
                 $.setIniDbNumber('discordSettings', 'lastOnlineEvent', $.systemTime());
 		    }


### PR DESCRIPTION
**streamHandler.js:**
- Due to Twitch caching, most of the time an old thumbnail would be
returned when going live.