### PR TITLE
Fix Paycom

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -563,9 +563,10 @@
                 if ($.getUserPoints(username) < getCommandPrice(command, subCommand, '')) {
                     return 1;
                 }
+                return 0;
             }
         }
-        return 0;
+        return -1;
     }
 
      /*

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -477,7 +477,7 @@
             } else 
 
             // Check the command cost.
-            if ($.priceCom(sender, command, subCommand, isMod) !== 0) {
+            if ($.priceCom(sender, command, subCommand, isMod) === 1) {
                 $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('cmd.needpoints', $.getPointsString($.getCommandPrice(command, subCommand, ''))), $.getIniDbBoolean('settings', 'priceComMsgEnabled', false));
                 return;
             }


### PR DESCRIPTION
**customCommands.js**
- Adjust priceCom() to return -1 when no price is found
- This resolves the issue in init.js that was not hitting the payCom() check logic

**init.js**
- Adjust the check to priceCom() when the user does not have enough points from !==0 to ===1