### PR TITLE
Twitch Sub Plan Naming Support

### DIFF
--- a/javascript-source/handlers/subscribeHandler.js
+++ b/javascript-source/handlers/subscribeHandler.js
@@ -16,6 +16,9 @@
         reSubReward = $.getSetIniDbNumber('subscribeHandler', 'reSubscribeReward', 0),
         giftSubReward = $.getSetIniDbNumber('subscribeHandler', 'giftSubReward', 0),
         customEmote = $.getSetIniDbString('subscribeHandler', 'resubEmote', ''),
+        subPlan1000 = $.getSetIniDbString('subscribeHandler', 'subPlan1000', 'Tier 1'),
+        subPlan2000 = $.getSetIniDbString('subscribeHandler', 'subPlan2000', 'Tier 2'),
+        subPlan3000 = $.getSetIniDbString('subscribeHandler', 'subPlan3000', 'Tier 3'),
         announce = false,
         emotes = [],
         i;
@@ -35,7 +38,24 @@
         subReward = $.getIniDbNumber('subscribeHandler', 'subscribeReward');
         reSubReward = $.getIniDbNumber('subscribeHandler', 'reSubscribeReward');
         giftSubReward = $.getIniDbNumber('subscribeHandler', 'giftSubReward');
-        customEmote = $.getSetIniDbString('subscribeHandler', 'resubEmote');
+        customEmote = $.getIniDbString('subscribeHandler', 'resubEmote');
+        subPlan1000 = $.getIniDbString('subscribeHandler', 'subPlan1000');
+        subPlan2000 = $.getIniDbString('subscribeHandler', 'subPlan2000');
+        subPlan3000 = $.getIniDbString('subscribeHandler', 'subPlan3000');
+    }
+
+    /*
+     * @function getPlanName
+     */
+    function getPlanName(plan) {
+        if (plan.equals('1000')) {
+            return subPlan1000;
+        } else if (plan.equals('2000')) {
+            return subPlan2000;
+        } else if (plan.equals('3000')) {
+            return subPlan3000;
+        }
+        return 'Unknown Tier';
     }
 
     /*
@@ -55,7 +75,7 @@
             }
 
             if (message.match(/\(plan\)/g)) {
-                message = $.replace(message, '(plan)', event.getPlan());
+                message = $.replace(message, '(plan)', getPlanName(event.getPlan()));
             }
             $.say(message);
             $.addSubUsersList(subscriber);
@@ -116,7 +136,7 @@
             }
 
             if (message.match(/\(plan\)/g)) {
-                message = $.replace(message, '(plan)', event.getPlan());
+                message = $.replace(message, '(plan)', getPlanName(event.getPlan()));
             }
 
             if (message.match(/\(customemote\)/)) {
@@ -163,7 +183,7 @@
             }
 
             if (message.match(/\(plan\)/g)) {
-                message = $.replace(message, '(plan)', event.getPlan());
+                message = $.replace(message, '(plan)', getPlanName(event.getPlan()));
             }
 
             if (message.match(/\(customemote\)/)) {
@@ -192,7 +212,8 @@
             command = event.getCommand(),
             argsString = event.getArguments(),
             args = event.getArgs(),
-            action = args[0];
+            action = args[0],
+            planId;
     
         /*
          * @commandpath subwelcometoggle - Enable or disable subscription alerts.
@@ -342,6 +363,46 @@
             $.setIniDbString('subscribeHandler', 'resubEmote', customEmote);
             $.say($.whisperPrefix(sender) + $.lang.get('subscribehandler.resubemote.set'));
         }
+
+        /*
+         * @commandpath namesubplan [1|2|3] [name of plan] - Name a subscription plan, Twitch provides three tiers.
+         */
+        if (command.equalsIgnoreCase('namesubplan')) {
+            if (action === undefined) {
+                $.say($.whisperPrefix(sender) + $.lang.get('subscribehandler.namesubplan.usage'));
+                return;
+            }
+
+            if (!action.equals('1') && !action.equals('2') && !action.equals('3')) {
+                $.say($.whisperPrefix(sender) + $.lang.get('subscribehandler.namesubplan.usage'));
+                return;
+            }
+
+            if (action.equals('1')) {
+                planId = 'subPlan1000';
+            } else if (action.equals('2')) {
+                planId = 'subPlan2000';
+            } else if (action.equals('3')) {
+                planId = 'subPlan3000';
+            }
+
+            if (args[1] === undefined) {
+                $.say($.whisperPrefix(sender) + $.lang.get('subscribehandler.namesubplan.show', action, $.getIniDbString('subscribeHandler', planId)));
+                return;
+            }
+
+            argsString = args.splice(1).join(' ');
+            if (planId.equals('subPlan1000')) {
+                subPlan1000 = argsString;
+            } else if (planId.equals('subPlan2000')) {
+                subPlan2000 = argsString;
+            } else if (planId.equals('subPlan3000')) {
+                subPlan3000 = argsString;
+            }
+            $.setIniDbString('subscribeHandler', planId, argsString);
+            $.say($.whisperPrefix(sender) + $.lang.get('subscribehandler.namesubplan.set', action, argsString));
+            return;
+        }
     });
 
     /**
@@ -360,6 +421,7 @@
         $.registerChatCommand('./handlers/subscribeHandler.js', 'primesubmessage', 1);
         $.registerChatCommand('./handlers/subscribeHandler.js', 'resubmessage', 1);
         $.registerChatCommand('./handlers/subscribeHandler.js', 'giftsubmessage', 1);
+        $.registerChatCommand('./handlers/subscribeHandler.js', 'namesubplan', 1);
         announce = true;
     });
 

--- a/resources/web/panel/greetings.html
+++ b/resources/web/panel/greetings.html
@@ -454,6 +454,36 @@
                        data-toggle="tooltip" title="Emote that the (customemote) that will be replaced with. The emote will be added the amount of months the user subscribed for." />
             </div>
         </form>
+
+        <form role="form">
+            <div class="form-group" onkeypress="return event.keyCode != 13">
+                <label for="subPlan1000">Subscriber Plan 1 Name</label>
+                <button type="button" class="btn btn-primary inline pull-right"
+                        onclick="$.updateGreetingData('subPlan1000Input', 'subscribeHandler', 'subPlan1000')">Submit</button>
+                <input type="text" class="form-control" id="subPlan1000Input" placeholder="Plan name"
+                       data-toggle="tooltip" title="Name to give to this subscription plan (4.99). " />
+            </div>
+        </form>
+
+        <form role="form">
+            <div class="form-group" onkeypress="return event.keyCode != 13">
+                <label for="subPlan2000">Subscriber Plan 2 Name</label>
+                <button type="button" class="btn btn-primary inline pull-right"
+                        onclick="$.updateGreetingData('subPlan2000Input', 'subscribeHandler', 'subPlan2000')">Submit</button>
+                <input type="text" class="form-control" id="subPlan2000Input" placeholder="Plan name"
+                       data-toggle="tooltip" title="Name to give to this subscription plan (9.99). " />
+            </div>
+        </form>
+
+        <form role="form">
+            <div class="form-group" onkeypress="return event.keyCode != 13">
+                <label for="subPlan3000">Subscriber Plan 3 Name</label>
+                <button type="button" class="btn btn-primary inline pull-right"
+                        onclick="$.updateGreetingData('subPlan3000Input', 'subscribeHandler', 'subPlan3000')">Submit</button>
+                <input type="text" class="form-control" id="subPlan3000Input" placeholder="Plan name"
+                       data-toggle="tooltip" title="Name to give to this subscription plan (24.99). " />
+            </div>
+        </form>
     </div>
     </div>
 

--- a/resources/web/panel/js/greetingsPanel.js
+++ b/resources/web/panel/js/greetingsPanel.js
@@ -243,6 +243,16 @@
                     if (panelMatch(key, 'resubEmote')) {
                         $('#resubEmoteInput').val(value);
                     }
+                    if (panelMatch(key, 'subPlan1000')) {
+                        $('#subPlan1000Input').val(value);
+                    }
+                    if (panelMatch(key, 'subPlan2000')) {
+                        $('#subPlan2000Input').val(value);
+                    }
+                    if (panelMatch(key, 'subPlan3000')) {
+                        $('#subPlan3000Input').val(value);
+                    }
+                    
                 }
             }
 


### PR DESCRIPTION
Twitch Sub Plan Names

**subscribeHandler.js**
- Added subPlan1000, 2000, 3000 variables
- Added function for naming the plans
- Added !namesubplan

**greetings.html, greetingsPanel.js**
- Updated to allow for plan names to be manipulated via the Panel