### PR TITLE
Fix $.users Object Misassignment

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -641,6 +641,12 @@
             for (var i in usernames) {
                 newUsers.push(usernames[i]);
             }
+
+            // Sometimes TMI has not seen the bot yet, this can happen at startup.
+            if (!hasKey(newUsers, $.botName)) {
+                newUsers.push($.botName);
+            }
+
             // Set the new array.
             updateUsersObject(newUsers);
             lastJoinPart = $.systemTime();

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -639,10 +639,10 @@
 
             // Set the new users array.
             for (var i in usernames) {
-                newUsers.push([usernames[i] + '', now]);
+                newUsers.push(usernames[i]);
             }
             // Set the new array.
-            users = newUsers;
+            updateUsersObject(newUsers);
             lastJoinPart = $.systemTime();
         }, 0);
     });


### PR DESCRIPTION
**permissions.js**
- The users object was being assigned to newUsers which was then losing the scope on $.users
- Switched to using the previously created updateUsersObject() method which properly "resets" the users object.