### PR TITLE
- Channel class removal start

### DIFF
--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1273,7 +1273,7 @@ public final class PhantomBot implements Listener {
 
         joined = true;
 
-        this.chanName = event.getChannel().getName();
+        this.chanName = this.channelName;
         this.session = event.getSession();
 
         com.gmt2001.Console.debug.println("ircJoinComplete::" + this.chanName);
@@ -1284,7 +1284,7 @@ public final class PhantomBot implements Listener {
         }
 
         /* Add the channel/session in the array for later use */
-        PhantomBot.addChannel(this.chanName, event.getChannel());
+        PhantomBot.addChannel(this.chanName, this.channel);
         PhantomBot.addSession(this.chanName, this.session);
 
         /* Load the caches for each channels */
@@ -1353,7 +1353,7 @@ public final class PhantomBot implements Listener {
                 /* Check to see if the bot is a moderator */
                 for (String moderator : moderators) {
                     if (moderator.equalsIgnoreCase(this.botName)) {
-                        EventBus.instance().postAsync(new IrcChannelUserModeEvent(this.session, this.channel, this.session.getNick(), "O", true));
+                        EventBus.instance().postAsync(new IrcChannelUserModeEvent(this.session, this.session.getNick(), "O", true));
                         /* Allow the bot to sends message to this session */
                         event.getSession().setAllowSendMessages(true);
                     }
@@ -1399,7 +1399,7 @@ public final class PhantomBot implements Listener {
      */
     @Subscribe
     public void consoleInput(ConsoleInputEvent event) {
-        String message = event.getMsg();
+        String message = event.getMessage();
         Boolean changed = false;
         Boolean reset = false;
         String arguments = "";
@@ -1551,7 +1551,7 @@ public final class PhantomBot implements Listener {
         if (message.equalsIgnoreCase("jointest")) {
             print("[CONSOLE] Executing jointest");
             for (int i = 0 ; i < 30; i++) {
-                EventBus.instance().postAsync(new IrcChannelJoinEvent(this.session, this.channel, generateRandomString(8)));
+                EventBus.instance().postAsync(new IrcChannelJoinEvent(this.session, generateRandomString(8)));
             }
         }
 
@@ -1956,12 +1956,12 @@ public final class PhantomBot implements Listener {
         }
 
         /* handle any other commands */
-        handleCommand(botName, event.getMsg(), PhantomBot.getChannel(this.channelName));
+        handleCommand(botName, event.getMessage());
         // Need to support channel here. command (channel) argument[1]
 
         /* Handle dev commands */
-        if (event.getMsg().startsWith("!debug !dev")) {
-            devDebugCommands(event.getMsg(), "no_id", botName, true);
+        if (event.getMessage().startsWith("!debug !dev")) {
+            devDebugCommands(event.getMessage(), "no_id", botName, true);
         }
     }
 
@@ -1975,7 +1975,7 @@ public final class PhantomBot implements Listener {
             command = commandString.substring(0, commandString.indexOf(" "));
             arguments = commandString.substring(commandString.indexOf(" ") + 1);
         }
-        ScriptEventManager.instance().onEvent(new CommandEvent(username, command, arguments, null, channel));
+        ScriptEventManager.instance().onEvent(new CommandEvent(username, command, arguments));
     }
 
     /* Handle commands */

--- a/source/tv/phantombot/cache/EmotesCache.java
+++ b/source/tv/phantombot/cache/EmotesCache.java
@@ -202,7 +202,7 @@ public class EmotesCache implements Runnable {
         }
 
         com.gmt2001.Console.debug.println("Pushing Emote JSON Objects to EventBus");
-        EventBus.instance().post(new EmotesGetEvent(twitchJsonResult, bttvJsonResult, bttvLocalJsonResult, ffzJsonResult, ffzLocalJsonResult, PhantomBot.getChannel(this.channel)));
+        EventBus.instance().post(new EmotesGetEvent(twitchJsonResult, bttvJsonResult, bttvLocalJsonResult, ffzJsonResult, ffzLocalJsonResult));
         System.gc();
 
         /* Set these to null to save memory */

--- a/source/tv/phantombot/event/command/CommandEvent.java
+++ b/source/tv/phantombot/event/command/CommandEvent.java
@@ -16,61 +16,59 @@
  */
 package tv.phantombot.event.command;
 
-import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import tv.phantombot.event.Event;
-import tv.phantombot.twitchwsirc.Channel;
 
 public class CommandEvent extends Event {
-
     private final String sender;
+    private final String command;
     private final String arguments;
     private final Map<String, String> tags;
-    private final Channel channel;
-    private String command;
-    private String[] args;
+    private final String[] args;
 
+    /*
+     * Class constructor for this event without tags. Always send tags if you can.
+     *
+     * @param {String} sender
+     * @param {String} command
+     * @param {String} arguments
+     * @param {Map}    tags
+     */
     public CommandEvent(String sender, String command, String arguments) {
         this.sender = sender;
         this.command = command;
         this.arguments = arguments;
-        this.tags = new HashMap<>();
-        this.channel = null;
-        parse();
+        this.args = parse();
+        this.tags = new HashMap<String, String>();
     }
 
+    /*
+     * Class constructor for this event.
+     *
+     * @param {String} sender
+     * @param {String} command
+     * @param {String} arguments
+     * @param {Map}    tags
+     */
     public CommandEvent(String sender, String command, String arguments, Map<String, String> tags) {
         this.sender = sender;
         this.command = command;
         this.arguments = arguments;
-        this.channel = null;
-
-        if (tags == null) {
-            this.tags = new HashMap<>();
-        } else {
-            this.tags = tags;
-        }
-        parse();
+        this.args = parse();
+        this.tags = (tags == null ? new HashMap<String, String>() : tags);
     }
 
-    public CommandEvent(String sender, String command, String arguments, Map<String, String> tags, Channel channel) {
-        this.sender = sender;
-        this.command = command;
-        this.arguments = arguments;
-        this.channel = channel;
-
-        if (tags == null) {
-            this.tags = new HashMap<>();
-        } else {
-            this.tags = tags;
-        }
-        parse();
-    }
-
-    private void parse() {
-        List<String> tmpArgs = new LinkedList<>();
+    /*
+     * Method that parses the command arguments.
+     *
+     * @return {String[]}
+     */
+    private String[] parse() {
+        List<String> tmpArgs = new LinkedList<String>();
         boolean inquote = false;
         String tmpStr = "";
         
@@ -86,46 +84,66 @@ public class CommandEvent extends Event {
                 tmpStr += c;
             }
         }
+
         if (tmpStr.length() > 0) {
             tmpArgs.add(tmpStr);
         }
-        args = new String[tmpArgs.size()];
-        int i = 0;
-        for (String s : tmpArgs) {
-            args[i] = s;
-            ++i;
-        }
+        
+        return tmpArgs.toArray(new String[tmpArgs.size()]);
     }
 
+    /*
+     * Method that will return the sender of this command.
+     *
+     * @return {String} sender
+     */
     public String getSender() {
-        return sender;
+        return this.sender;
     }
 
+    /*
+     * Method that will return the command name.
+     *
+     * @return {String}
+     */
     public String getCommand() {
-        return command.toLowerCase();
+        return this.command;
     }
 
-    public void setCommand(String command) {
-        this.command = command;
-    }
-
-    public String[] getArgs() {
-        return args;
-    }
-
+    /*
+     * Method that will return the string of arguments.
+     *
+     * @return {String} arguments
+     */
     public String getArguments() {
-        return arguments;
+        return this.arguments;
     }
 
+    /*
+     * Method that will return the array of arguments.
+     *
+     * @return {String[]} args
+     */
+    public String[] getArgs() {
+        return this.args;
+    }
+
+    /*
+     * Method that returns the IRCv3 tags in a map.
+     *
+     * @return {Map} tags
+     */
     public Map<String, String> getTags() {
-        return tags;
+        return this.tags;
     }
 
-    public Channel getChannel() {
-        return channel;
-    }
-
-    public String toEventSocket() {
-        return (this.getSender() + "|" + this.getCommand() + "|" + this.getArguments() + "|" + this.getChannel());
+    /*
+     * Method that returns this object as a string.
+     *
+     * @return {String}
+     */
+    @Override
+    public String toString() {
+    	return "CommandEvent -> { command: [" + this.command + "] sender: [" + this.sender + "] arguments: [" + this.arguments + "] tags: [" + this.tags + "] }";
     }
 }

--- a/source/tv/phantombot/event/console/ConsoleEvent.java
+++ b/source/tv/phantombot/event/console/ConsoleEvent.java
@@ -19,4 +19,5 @@ package tv.phantombot.event.console;
 import tv.phantombot.event.Event;
 
 public class ConsoleEvent extends Event {
+	
 }

--- a/source/tv/phantombot/event/console/ConsoleInputEvent.java
+++ b/source/tv/phantombot/event/console/ConsoleInputEvent.java
@@ -17,14 +17,33 @@
 package tv.phantombot.event.console;
 
 public class ConsoleInputEvent extends ConsoleEvent {
+    private final String message;
 
-    String msg;
-
-    public ConsoleInputEvent(String msg) {
-        this.msg = msg;
+    /*
+     * Class constructor for this event.
+     *
+     * @param {String} message
+     */
+    public ConsoleInputEvent(String message) {
+        this.message = message;
     }
 
-    public String getMsg() {
-        return msg;
+    /*
+     * Method that will return the message said in the console.
+	 *
+	 * @return {String} message
+     */
+    public String getMessage() {
+        return this.message;
+    }
+
+    /*
+     * Method that returns this object as a string.
+     *
+     * @return {String}
+     */
+    @Override
+    public String toString() {
+    	return "ConsoleInputEvent -> { message: [" + this.message + "] }";
     }
 }

--- a/source/tv/phantombot/event/discord/DiscordEvent.java
+++ b/source/tv/phantombot/event/discord/DiscordEvent.java
@@ -33,6 +33,11 @@ public class DiscordEvent extends Event {
 	private final String channelId;
 	private final String discrim;
 
+	/*
+	 * Class constructor for this event.
+	 *
+	 * @param {IUser} user
+	 */
 	protected DiscordEvent(IUser user) {
 		this.user = user;
 		this.channel = null;
@@ -45,6 +50,12 @@ public class DiscordEvent extends Event {
 		this.mention = user.mention();
 	}
 
+	/*
+	 * Class constructor for this event.
+	 *
+	 * @param {IUser}    user
+	 * @param {IChannel} channel
+	 */
 	protected DiscordEvent(IUser user, IChannel channel) {
 		this.user = user;
 		this.channel = channel;
@@ -57,38 +68,83 @@ public class DiscordEvent extends Event {
 		this.mention = user.mention();
 	}
 
+	/*
+	 * Method that returns the sender of the event with their discrim.
+	 *
+	 * @return {String}
+	 */
 	public String getSender() {
 		return this.sender.toLowerCase();
 	}
 
+	/*
+	 * Method that returns just the username of the event.
+	 *
+	 * @return {String}
+	 */
 	public String getUsername() {
 		return this.username;
 	}
 
+	/*
+	 * Method that returns the mention string for this user.
+	 *
+	 * @return {String}
+	 */
 	public String getMention() {
 		return this.mention;
 	}
 
+	/*
+	 * Method that returns the channel name.
+	 *
+	 * @return {String}
+	 */
 	public String getChannel() {
 		return this.channelName;
 	}
 
+	/*
+	 * Method that returns the channel ID.
+	 *
+	 * @return {String}
+	 */
 	public String getChannelId() {
 		return this.channelId;
 	}
 
+	/*
+	 * Method that returns the user's discriminator.
+	 *
+	 * @return {String}
+	 */
 	public String getDiscriminator() {
 		return this.discrim;
 	}
 
+	/*
+	 * Method that returns the user's ID.
+	 *
+	 * @return {String}
+	 */
 	public String getSenderId() {
 		return this.senderId;
 	}
 
+	/*
+	 * Method that returns the user's object for Discord4J.
+	 *
+	 * @return {IUser}
+	 */
 	public IUser getDiscordUser() {
 		return this.user;
 	}
 
+	/*
+	 * Method that returns the channel's object for Discord4J.
+	 *
+	 * @return {IChannel}
+	 */
 	public IChannel getDiscordChannel() {
 		return this.channel;
 	}

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelCommandEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelCommandEvent.java
@@ -26,20 +26,34 @@ import java.util.List;
 public class DiscordChannelCommandEvent extends DiscordChannelEvent {
     private final String arguments;
     private final boolean isAdmin;
+    private final String[] args;
     private String command;
-    private String[] args;
-
+    
+    /*
+     * Class constructor for this event.
+     *
+     * @param {IUser}    user
+     * @param {IChannel} channel
+     * @param {String}   command
+     * @param {String}   arguments
+     * @param {boolean}  isAdmin
+     */
     public DiscordChannelCommandEvent(IUser user, IChannel channel, String command, String arguments, boolean isAdmin) {
         super(user, channel);
 
         this.command = command;
         this.arguments = arguments;
         this.isAdmin = isAdmin;
-        parse();
+        this.args = parse();
     }
 
-    private void parse() {
-        List<String> tempArgs = new LinkedList<>();
+    /*
+     * Method that parses the command arguments.
+     *
+     * @return {String[]}
+     */
+    private String[] parse() {
+        List<String> tempArgs = new LinkedList<String>();
         Boolean hasQuote = false;
         String tempString = "";
 
@@ -60,33 +74,62 @@ public class DiscordChannelCommandEvent extends DiscordChannelEvent {
             tempArgs.add(tempString);
         }
 
-        this.args = new String[tempArgs.size()];
-        int i = 0;
-
-        for (String s : tempArgs) {
-            this.args[i] = s;
-            ++i;
-        }
+        return tempArgs.toArray(new String[tempArgs.size()]);
     }
 
+    /*
+     * Method that sets the command for this class. Mostly used for aliases.
+     *
+     * @return {String} command
+     */
     public String setCommand(String command) {
         this.command = command;
         return this.command;
     }
 
+    /*
+     * Method that returns the command.
+     *
+     * @return {String} command
+     */
     public String getCommand() {
         return this.command.toLowerCase();
     }
 
+    /*
+     * Method that returns the string of arguments.
+     *
+     * @return {String} arguments
+     */
     public String getArguments() {
         return this.arguments;
     }
 
+    /*
+     * Method that returns the array of arguments
+     *
+     * @return {String[]} args
+     */
     public String[] getArgs() {
         return this.args;
     }
 
+    /*
+     * Method that returns if the user a admin in the server.
+     *
+     * @retrun {boolean}
+     */
     public boolean isAdmin() {
         return this.isAdmin;
+    }
+
+    /*
+     * Method that returns this object as a string.
+     *
+     * @return {String}
+     */
+    @Override
+    public String toString() {
+        return "DiscordChannelCommandEvent -> { command: [" + this.command + "] arguments: [" + this.arguments + "] isAdmin: [" + this.isAdmin + "] }";
     }
 }

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelMessageEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelMessageEvent.java
@@ -26,6 +26,14 @@ public class DiscordChannelMessageEvent extends DiscordChannelEvent {
 	private final String messageContent;
 	private final boolean isAdmin;
 
+	/*
+     * Class constructor for this event.
+     *
+     * @param {IUser}    user
+     * @param {IChannel} channel
+     * @param {IMessage} message
+     * @param {boolean}  isAdmin
+     */
 	public DiscordChannelMessageEvent(IUser user, IChannel channel, IMessage message, boolean isAdmin) {
 		super(user, channel);
 
@@ -34,15 +42,40 @@ public class DiscordChannelMessageEvent extends DiscordChannelEvent {
 		this.isAdmin = isAdmin;
 	}
 
+	/*
+	 * Method that returns the message from the user.
+	 *
+	 * @return {String} messageContent
+	 */
 	public String getMessage() {
 		return this.messageContent;
 	}
 
+	/*
+	 * Method that returns if the user a admin in the server.
+	 *
+	 * @return {boolean} isAdmin
+	 */
 	public boolean isAdmin() {
 		return this.isAdmin;
 	}
 
+	/*
+	 * Method that returns the message object for Discord4J.
+	 *
+	 * @return {IMessage} message
+	 */
 	public IMessage getDiscordMessage() {
 		return this.message;
 	}
+
+	/*
+     * Method that returns this object as a string.
+     *
+     * @return {String}
+     */
+    @Override
+    public String toString() {
+        return "DiscordChannelMessageEvent -> { messageContent: [" + this.messageContent + "] isAdmin: [" + this.isAdmin + "] }";
+    }
 }

--- a/source/tv/phantombot/event/emotes/EmotesEvent.java
+++ b/source/tv/phantombot/event/emotes/EmotesEvent.java
@@ -20,18 +20,7 @@ import tv.phantombot.event.Event;
 import tv.phantombot.twitchwsirc.Channel;
 
 public class EmotesEvent extends Event {
-
-    private final Channel channel;
-
     protected EmotesEvent() {
-        this.channel = null;
-    }
-
-    protected EmotesEvent(Channel channel) {
-        this.channel = channel;
-    }
-
-    public Channel getChannel() {
-        return this.channel;
+        
     }
 }

--- a/source/tv/phantombot/event/emotes/EmotesGetEvent.java
+++ b/source/tv/phantombot/event/emotes/EmotesGetEvent.java
@@ -16,17 +16,24 @@
  */
 package tv.phantombot.event.emotes;
 
-import tv.phantombot.twitchwsirc.Channel;
 import org.json.JSONObject;
 
 public class EmotesGetEvent extends EmotesEvent {
-
     private final JSONObject twitchEmotes;
     private final JSONObject bttvEmotes;
     private final JSONObject bttvLocalEmotes;
     private final JSONObject ffzEmotes;
     private final JSONObject ffzLocalEmotes;
 
+    /*
+     * Class constructor
+     *
+     * @param {JSONObject} twitchEmotes
+     * @param {JSONObject} bttvEmotes
+     * @param {JSONObject} bttvLocalEmotes
+     * @param {JSONObject} ffzEmotes
+     * @param {JSONObject} ffzLocalEmotes
+     */
     public EmotesGetEvent(JSONObject twitchEmotes, JSONObject bttvEmotes, JSONObject bttvLocalEmotes, JSONObject ffzEmotes, JSONObject ffzLocalEmotes) {
         this.twitchEmotes = twitchEmotes;
         this.bttvEmotes = bttvEmotes;
@@ -35,29 +42,48 @@ public class EmotesGetEvent extends EmotesEvent {
         this.ffzLocalEmotes = ffzLocalEmotes;
     }
 
-    public EmotesGetEvent(JSONObject twitchEmotes, JSONObject bttvEmotes, JSONObject bttvLocalEmotes, JSONObject ffzEmotes, JSONObject ffzLocalEmotes, Channel channel) {
-        super(channel);
-        this.twitchEmotes = twitchEmotes;
-        this.bttvEmotes = bttvEmotes;
-        this.bttvLocalEmotes = bttvLocalEmotes;
-        this.ffzEmotes = ffzEmotes;
-        this.ffzLocalEmotes = ffzLocalEmotes;
+    /*
+     * Method that returns the JSONObject emotes from Twitch.
+     *
+     * @param {JSONObject} twitchEmotes
+     */
+    public JSONObject getTwitchEmotes() {
+        return this.twitchEmotes;
     }
 
-    public JSONObject getTwitchEmotes() {
-        return twitchEmotes;
-    }
+    /*
+     * Method that returns the JSONObject emotes from bttv.
+     *
+     * @param {JSONObject} bttvEmotes
+     */
     public JSONObject getBttvEmotes() {
-        return bttvEmotes;
+        return this.bttvEmotes;
     }
+
+    /*
+     * Method that returns the JSONObject emotes from bttv local emotes.
+     *
+     * @param {JSONObject} bttvLocalEmotes
+     */
     public JSONObject getBttvLocalEmotes() {
-        return bttvLocalEmotes;
+        return this.bttvLocalEmotes;
     }
+
+    /*
+     * Method that returns the JSONObject emotes from ffz.
+     *
+     * @param {JSONObject} ffzEmotes
+     */
     public JSONObject getFfzEmotes() {
-        return ffzEmotes;
+        return this.ffzEmotes;
     }
+
+    /*
+     * Method that returns the JSONObject emotes from ffz local emotes.
+     *
+     * @param {JSONObject} ffzLocalEmotes
+     */
     public JSONObject getFfzLocalEmotes() {
-        return ffzLocalEmotes;
+        return this.ffzLocalEmotes;
     }
 }
-

--- a/source/tv/phantombot/event/gamewisp/GameWispAnniversaryEvent.java
+++ b/source/tv/phantombot/event/gamewisp/GameWispAnniversaryEvent.java
@@ -16,20 +16,11 @@
  */
 package tv.phantombot.event.gamewisp;
 
-import tv.phantombot.twitchwsirc.Channel;
-
 public class GameWispAnniversaryEvent extends GameWispEvent {
-
     private final String username;
     private final int months;
 
     public GameWispAnniversaryEvent(String username, int months) {
-        this.username = username;
-        this.months = months;
-    }
-
-    public GameWispAnniversaryEvent(String username, int months, Channel channel) {
-        super(channel);
         this.username = username;
         this.months = months;
     }

--- a/source/tv/phantombot/event/gamewisp/GameWispBenefitsEvent.java
+++ b/source/tv/phantombot/event/gamewisp/GameWispBenefitsEvent.java
@@ -16,30 +16,36 @@
  */
 package tv.phantombot.event.gamewisp;
 
-import tv.phantombot.twitchwsirc.Channel;
-
 public class GameWispBenefitsEvent extends GameWispEvent {
-
     private final String username;
     private final int tier;
 
+    /*
+     * Class constructor
+     *
+     * @param {String} username
+     * @param {int}    tier
+     */
     public GameWispBenefitsEvent(String username, int tier) {
         this.username = username;
         this.tier = tier;
     }
 
-    public GameWispBenefitsEvent(String username, int tier, Channel channel) {
-        super(channel);
-        this.username = username;
-        this.tier = tier;
-    }
-
+    /*
+     * Method that returns the subscriber's name.
+     *
+     * @return {String} username
+     */
     public String getUsername() {
-        return username;
+        return this.username;
     }
 
+    /*
+     * Method that returns the user's tier.
+     *
+     * @return {int} tier
+     */
     public int getTier() {
-        return tier;
+        return this.tier;
     }
 }
-

--- a/source/tv/phantombot/event/gamewisp/GameWispChangeEvent.java
+++ b/source/tv/phantombot/event/gamewisp/GameWispChangeEvent.java
@@ -16,30 +16,37 @@
  */
 package tv.phantombot.event.gamewisp;
 
-import tv.phantombot.twitchwsirc.Channel;
-
 public class GameWispChangeEvent extends GameWispEvent {
-
     private final String username;
     private final String status;
 
+    /*
+     * Class constructor
+     *
+     * @param {String} username
+     * @param {String} status
+     */
     public GameWispChangeEvent(String username, String status) {
         this.username = username;
         this.status = status;
     }
 
-    public GameWispChangeEvent(String username, String status, Channel channel) {
-        super(channel);
-        this.username = username;
-        this.status = status;
-    }
-
+    /*
+     * Method that returns the subscriber's name.
+     *
+     * @return {String} username
+     */
     public String getUsername() {
-        return username;
+        return this.username;
     }
 
+    /*
+     * Method that returns the subscriber's status.
+     *
+     * @return {String} status
+     */
     public String getStatus() {
-        return status;
+        return this.status;
     }
 }
 

--- a/source/tv/phantombot/event/gamewisp/GameWispEvent.java
+++ b/source/tv/phantombot/event/gamewisp/GameWispEvent.java
@@ -17,21 +17,9 @@
 package tv.phantombot.event.gamewisp;
 
 import tv.phantombot.event.Event;
-import tv.phantombot.twitchwsirc.Channel;
 
 public class GameWispEvent extends Event {
-
-    private final Channel channel;
-
     protected GameWispEvent() {
-        this.channel = null;
-    }
 
-    protected GameWispEvent(Channel channel) {
-        this.channel = channel;
-    }
-
-    public Channel getChannel() {
-        return this.channel;
     }
 }

--- a/source/tv/phantombot/event/gamewisp/GameWispSubscribeEvent.java
+++ b/source/tv/phantombot/event/gamewisp/GameWispSubscribeEvent.java
@@ -16,30 +16,36 @@
  */
 package tv.phantombot.event.gamewisp;
 
-import tv.phantombot.twitchwsirc.Channel;
-
 public class GameWispSubscribeEvent extends GameWispEvent {
-
     private final String username;
     private final int tier;
 
+    /*
+     * Class constructor
+     *
+     * @param {String} username
+     * @param {int}    tier
+     */
     public GameWispSubscribeEvent(String username, int tier) {
         this.username = username;
         this.tier = tier;
     }
 
-    public GameWispSubscribeEvent(String username, int tier, Channel channel) {
-        super(channel);
-        this.username = username;
-        this.tier = tier;
-    }
-
+    /*
+     * Method that returns the subscriber's name.
+     *
+     * @return {String}
+     */
     public String getUsername() {
-        return username;
+        return this.username;
     }
 
+    /*
+     * Method that returns the user's tier.
+     *
+     * @return {int}
+     */
     public int getTier() {
-        return tier;
+        return this.tier;
     }
 }
-

--- a/source/tv/phantombot/event/irc/IrcEvent.java
+++ b/source/tv/phantombot/event/irc/IrcEvent.java
@@ -17,17 +17,27 @@
 package tv.phantombot.event.irc;
 
 import tv.phantombot.event.Event;
+
 import tv.phantombot.twitchwsirc.Session;
 
 public abstract class IrcEvent extends Event {
-
     private final Session session;
 
+    /*
+     * Class constructor
+     *
+     * @param {Session} session
+     */
     protected IrcEvent(Session session) {
         this.session = session;
     }
 
+    /*
+     * Method that returns the session.
+     *
+     * @param {Session} session
+     */
     public Session getSession() {
-        return session;
+        return this.session;
     }
 }

--- a/source/tv/phantombot/event/irc/channel/IrcChannelEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelEvent.java
@@ -17,19 +17,17 @@
 package tv.phantombot.event.irc.channel;
 
 import tv.phantombot.event.irc.IrcEvent;
-import tv.phantombot.twitchwsirc.Channel;
+
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelEvent extends IrcEvent {
 
-    private final Channel channel;
-
-    protected IrcChannelEvent(Session session, Channel channel) {
+	/*
+     * Class constructor
+     *
+     * @param {Session} session
+     */
+    protected IrcChannelEvent(Session session) {
         super(session);
-        this.channel = channel;
-    }
-
-    public Channel getChannel() {
-        return channel;
     }
 }

--- a/source/tv/phantombot/event/irc/channel/IrcChannelJoinEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelJoinEvent.java
@@ -16,24 +16,40 @@
  */
 package tv.phantombot.event.irc.channel;
 
-import tv.phantombot.twitchwsirc.Channel;
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelJoinEvent extends IrcChannelEvent {
-
     private final String user;
 
-    public IrcChannelJoinEvent(Session session, Channel channel, String user) {
-        super(session, channel);
+    /*
+     * Class constructor
+     *
+     * @param {Session} session
+     * @param {String}  user
+     */
+    public IrcChannelJoinEvent(Session session, String user) {
+        super(session);
+
         this.user = user;
     }
 
+    /*
+     * Class constructor
+     *
+     * @param {String}  user
+     */
     public IrcChannelJoinEvent(String user) {
-        super(null, null);
+        super(null);
+        
         this.user = user;
     }
 
+    /*
+     * Method that returns the user who joined the channel.
+     *
+     * @return {String} user
+     */
     public String getUser() {
-        return user;
+        return this.user;
     }
 }

--- a/source/tv/phantombot/event/irc/channel/IrcChannelLeaveEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelLeaveEvent.java
@@ -16,37 +16,40 @@
  */
 package tv.phantombot.event.irc.channel;
 
-import tv.phantombot.twitchwsirc.Channel;
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelLeaveEvent extends IrcChannelEvent {
-
     private final String user;
-    private final String message;
 
-    public IrcChannelLeaveEvent(Session session, Channel channel, String user, String message) {
-        super(session, channel);
+    /*
+     * Class constructor
+     *
+     * @param {Session} session
+     * @param {String} user
+     */
+    public IrcChannelLeaveEvent(Session session, String user) {
+        super(session);
+
         this.user = user;
-        this.message = message;
     }
 
-    public IrcChannelLeaveEvent(String user, String message) {
-        super(null, null);
-        this.user = user;
-        this.message = message;
-    }
-
+    /*
+     * Class constructor
+     *
+     * @param {String} user
+     */
     public IrcChannelLeaveEvent(String user) {
-        super(null, null);
+        super(null);
+        
         this.user = user;
-        this.message = null;
     }
 
+    /*
+     * Method that returns the user who left.
+     *
+     * @return {String} user
+     */
     public String getUser() {
-        return user;
-    }
-
-    public String getMessage() {
-        return message;
+        return this.user;
     }
 }

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUserModeEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUserModeEvent.java
@@ -16,31 +16,53 @@
  */
 package tv.phantombot.event.irc.channel;
 
-import tv.phantombot.twitchwsirc.Channel;
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelUserModeEvent extends IrcChannelEvent {
-
     private final String user;
     private final String mode;
-    private final Boolean add;
+    private final boolean add;
 
-    public IrcChannelUserModeEvent(Session session, Channel channel, String user, String mode, Boolean add) {
-        super(session, channel);
+    /*
+     * Class constructor
+     *
+     * @param {Session} session
+     * @param {String}  user
+     * @param {String}  mode
+     * @param {boolean} add
+     */
+    public IrcChannelUserModeEvent(Session session, String user, String mode, boolean add) {
+        super(session);
+
         this.user = user;
         this.mode = mode;
         this.add = add;
     }
 
+    /*
+     * Method that returns the user whose mode changed
+     *
+     * @return {String} user
+     */
     public String getUser() {
-        return user;
+        return this.user;
     }
 
+    /*
+     * Method that returns the user's mode.
+     *
+     * @return {String} mode
+     */
     public String getMode() {
-        return mode;
+        return this.mode;
     }
 
-    public Boolean getAdd() {
-        return add;
+    /*
+     * Method that returns if the user got OP or not.
+     *
+     * @return {boolean} add
+     */
+    public boolean getAdd() {
+        return this.add;
     }
 }

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
@@ -16,38 +16,68 @@
  */
 package tv.phantombot.event.irc.channel;
 
-import tv.phantombot.twitchwsirc.Channel;
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
-
     private final String[] users;
     private final String[] joins;
     private final String[] parts;
 
-    public IrcChannelUsersUpdateEvent(Session session, Channel channel, String[] users, String[] joins, String[] parts) {
-        super(session, channel);
+    /*
+     * Class constructor.
+     *
+     * @param {Session}  session
+     * @param {String[]} users
+     * @param {String[]} joins
+     * @param {String[]} parts
+     */
+    public IrcChannelUsersUpdateEvent(Session session, String[] users, String[] joins, String[] parts) {
+        super(session);
+
         this.users = users;
         this.joins = joins;
         this.parts = parts;
     }
 
+    /*
+     * Class constructor.
+     *
+     * @param {String[]} users
+     * @param {String[]} joins
+     * @param {String[]} parts
+     */
     public IrcChannelUsersUpdateEvent(String[] users, String[] joins, String[] parts) {
-        super(null, null);
+        super(null);
+
         this.users = users;
         this.joins = joins;
         this.parts = parts;
     }
 
+    /*
+     * Method that returns the current array of users in the channel.
+     *
+     * @return {String[]} users
+     */
     public String[] getUsers() {
-        return users;
+        return this.users;
     }
 
+    /*
+     * Method that returns the current array of users who joined the channel in the last 10 minutes.
+     *
+     * @return {String[]} joins
+     */
     public String[] getJoins() {
-        return joins;
+        return this.joins;
     }
 
+    /*
+     * Method that returns the current array of users who left the channel in the last 10 minutes.
+     *
+     * @return {String[]} parts
+     */
     public String[] getParts() {
-        return parts;
+        return this.parts;
     }
 }

--- a/source/tv/phantombot/event/irc/clearchat/IrcClearchatEvent.java
+++ b/source/tv/phantombot/event/irc/clearchat/IrcClearchatEvent.java
@@ -17,37 +17,54 @@
 package tv.phantombot.event.irc.clearchat;
 
 import tv.phantombot.event.irc.IrcEvent;
-import tv.phantombot.twitchwsirc.Channel;
+
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcClearchatEvent extends IrcEvent {
-
-    private final String user;
+    private final String username;
     private final String reason;
     private final String duration;
-    private final Channel channel;
 
-    public IrcClearchatEvent(Session session, Channel channel, String user, String reason, String duration) {
+    /*
+     * Class constructor
+     *
+     * @param {Session} session
+     * @param {String}  username
+     * @param {String}  reason
+     * @param {String}  duration
+     */
+    public IrcClearchatEvent(Session session, String username, String reason, String duration) {
         super(session);
-        this.channel = channel;
-        this.user = user;
+
+        this.username = username;
         this.reason = reason;
         this.duration = duration;
     }
 
-    public Channel getChannel() {
-        return channel;
+    /*
+     * Method that returns the user who was timed-out
+     *
+     * @return {String} username
+     */
+    public String getUsername() {
+        return this.username;
     }
 
-    public String getUser() {
-        return user;
-    }
-
+    /*
+     * Method that returns the reason the user was timed-out
+     *
+     * @return {String} reason
+     */
     public String getReason() {
-        return reason;
+        return this.reason;
     }
 
+    /*
+     * Method that returns the length the user was timed-out
+     *
+     * @return {String} duration
+     */
     public String getDuration() {
-        return duration;
+        return this.duration;
     }
 }

--- a/source/tv/phantombot/event/irc/complete/IrcCompleteEvent.java
+++ b/source/tv/phantombot/event/irc/complete/IrcCompleteEvent.java
@@ -17,10 +17,16 @@
 package tv.phantombot.event.irc.complete;
 
 import tv.phantombot.event.irc.IrcEvent;
+
 import tv.phantombot.twitchwsirc.Session;
 
 public abstract class IrcCompleteEvent extends IrcEvent {
 
+	/*
+	 * Class constructor
+	 *
+	 * @param {Session} session
+	 */
     protected IrcCompleteEvent(Session session) {
         super(session);
     }

--- a/source/tv/phantombot/event/irc/complete/IrcConnectCompleteEvent.java
+++ b/source/tv/phantombot/event/irc/complete/IrcConnectCompleteEvent.java
@@ -20,6 +20,11 @@ import tv.phantombot.twitchwsirc.Session;
 
 public class IrcConnectCompleteEvent extends IrcCompleteEvent {
 
+	/*
+	 * Class constructor
+	 *
+	 * @param {Session} session
+	 */
     public IrcConnectCompleteEvent(Session session) {
         super(session);
     }

--- a/source/tv/phantombot/event/irc/complete/IrcJoinCompleteEvent.java
+++ b/source/tv/phantombot/event/irc/complete/IrcJoinCompleteEvent.java
@@ -16,19 +16,16 @@
  */
 package tv.phantombot.event.irc.complete;
 
-import tv.phantombot.twitchwsirc.Channel;
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcJoinCompleteEvent extends IrcCompleteEvent {
 
-    private final Channel channel;
-
-    public IrcJoinCompleteEvent(Session session, Channel channel) {
-        super(session);
-        this.channel = channel;
-    }
-
-    public Channel getChannel() {
-        return channel;
+	/*
+	 * Class constructor
+	 *
+	 * @param {Session} session
+	 */
+    public IrcJoinCompleteEvent(Session session) {
+    	super(session);
     }
 }

--- a/source/tv/phantombot/event/irc/message/IrcChannelMessageEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcChannelMessageEvent.java
@@ -17,16 +17,31 @@
 package tv.phantombot.event.irc.message;
 
 import java.util.Map;
-import tv.phantombot.twitchwsirc.Channel;
+
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelMessageEvent extends IrcMessageEvent {
 
-    public IrcChannelMessageEvent(Session session, String sender, String message, Channel channel) {
-        super(session, sender, message, null, channel);
+	/*
+	 * Class constructor.
+	 *
+	 * @param {Session} session
+	 * @param {String}  sender
+	 * @param {String}  message
+	 */
+    public IrcChannelMessageEvent(Session session, String sender, String message) {
+        super(session, sender, message);
     }
 
-    public IrcChannelMessageEvent(Session session, String sender, String message, Channel channel, Map<String, String> tags) {
-        super(session, sender, message, tags, channel);
+    /*
+	 * Class constructor.
+	 *
+	 * @param {Session} session
+	 * @param {String}  sender
+	 * @param {String}  message
+	 * @param {Map}     tags
+	 */
+    public IrcChannelMessageEvent(Session session, String sender, String message, Map<String, String> tags) {
+        super(session, sender, message, tags);
     }
 }

--- a/source/tv/phantombot/event/irc/message/IrcMessageEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcMessageEvent.java
@@ -18,75 +18,71 @@ package tv.phantombot.event.irc.message;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import tv.phantombot.event.irc.IrcEvent;
-import tv.phantombot.twitchwsirc.Channel;
+
 import tv.phantombot.twitchwsirc.Session;
-import org.apache.commons.lang3.CharUtils;
 
 public abstract class IrcMessageEvent extends IrcEvent {
-
     private final String sender;
     private final String message;
     private final Map<String, String> tags;
-    private final Channel channel;
 
+    /*
+     * Class constructor.
+     *
+     * @param {Session} session
+     * @param {String}  sender
+     * @param {String}  message
+     */
     protected IrcMessageEvent(Session session, String sender, String message) {
         super(session);
+
         this.sender = sender;
         this.message = message;
-        this.tags = new HashMap<>();
-        this.channel = null;
+        this.tags = new HashMap<String, String>();
     }
 
+    /*
+     * Class constructor.
+     *
+     * @param {Session} session
+     * @param {String}  sender
+     * @param {String}  message
+     * @param {Map}     tags
+     */
     protected IrcMessageEvent(Session session, String sender, String message, Map<String, String> tags) {
         super(session);
+
         this.sender = sender;
         this.message = message;
-        this.channel = null;
-
-        if (tags == null) {
-            this.tags = new HashMap<>();
-        } else {
-            this.tags = tags;
-        }
+        this.tags = (tags == null ? new HashMap<String, String>() : tags);
     }
 
-    protected IrcMessageEvent(Session session, String sender, String message, Map<String, String> tags, Channel channel) {
-        super(session);
-        this.sender = sender;
-        this.message = message;
-        this.channel = channel;
-
-        if (tags == null) {
-            this.tags = new HashMap<>();
-        } else {
-            this.tags = tags;
-        }
-    }
-
+    /*
+     * Method that returns the sender.
+     *
+     * @return {String} sender
+     */
     public String getSender() {
-        return sender;
+        return this.sender;
     }
 
+    /*
+     * Method that returns the message.
+     *
+     * @return {String} sender
+     */
     public String getMessage() {
-        return message;
+        return this.message;
     }
 
+    /*
+     * Method that returns the IRCv3 tags.
+     *
+     * @return {Map} tags
+     */
     public Map<String, String> getTags() {
-        return tags;
-    }
-
-    public int getCapsCount() {
-        int count = 0;
-        for (int i = 0, l = message.length(); i < l; ++i) {
-            if (CharUtils.isAsciiAlphaUpper(message.charAt(i))) {
-                ++count;
-            }
-        }
-        return count;
-    }
-
-    public Channel getChannel() {
-        return channel;
+        return this.tags;
     }
 }

--- a/source/tv/phantombot/event/irc/message/IrcModerationEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcModerationEvent.java
@@ -17,16 +17,31 @@
 package tv.phantombot.event.irc.message;
 
 import java.util.Map;
-import tv.phantombot.twitchwsirc.Channel;
+
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcModerationEvent extends IrcMessageEvent {
 
-    public IrcModerationEvent(Session session, String sender, String message, Channel channel) {
-        super(session, sender, message, null, channel);
+	/*
+	 * Class constructor.
+	 *
+	 * @param {Session} session
+	 * @param {String}  sender
+	 * @param {String}  message
+	 */
+    public IrcModerationEvent(Session session, String sender, String message) {
+        super(session, sender, message);
     }
 
-    public IrcModerationEvent(Session session, String sender, String message, Channel channel, Map<String, String> tags) {
-        super(session, sender, message, tags, channel);
+    /*
+	 * Class constructor.
+	 *
+	 * @param {Session} session
+	 * @param {String}  sender
+	 * @param {String}  message
+	 * @param {Map}     tags
+	 */
+    public IrcModerationEvent(Session session, String sender, String message, Map<String, String> tags) {
+        super(session, sender, message, tags);
     }
 }

--- a/source/tv/phantombot/event/irc/message/IrcPrivateMessageEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcPrivateMessageEvent.java
@@ -17,7 +17,7 @@
 package tv.phantombot.event.irc.message;
 
 import java.util.Map;
-import tv.phantombot.twitchwsirc.Channel;
+
 import tv.phantombot.twitchwsirc.Session;
 
 /**
@@ -26,15 +26,26 @@ import tv.phantombot.twitchwsirc.Session;
  */
 public class IrcPrivateMessageEvent extends IrcMessageEvent {
 
+	/*
+	 * Class constructor.
+	 *
+	 * @param {Session} session
+	 * @param {String}  sender
+	 * @param {String}  message
+	 */
     public IrcPrivateMessageEvent(Session session, String sender, String message) {
-        super(session, sender, message, null, null);
+        super(session, sender, message);
     }
 
+    /*
+	 * Class constructor.
+	 *
+	 * @param {Session} session
+	 * @param {String}  sender
+	 * @param {String}  message
+	 * @param {Map}     tags
+	 */
     public IrcPrivateMessageEvent(Session session, String sender, String message, Map<String, String> tags) {
-        super(session, sender, message, tags, null);
-    }
-
-    public IrcPrivateMessageEvent(Session session, String sender, String message, Map<String, String> tags, Channel channel) {
-        super(session, sender, message, tags, channel);
+        super(session, sender, message, tags);
     }
 }

--- a/source/tv/phantombot/twitchwsirc/TwitchWSIRCParser.java
+++ b/source/tv/phantombot/twitchwsirc/TwitchWSIRCParser.java
@@ -235,7 +235,7 @@ public class TwitchWSIRCParser {
 
         com.gmt2001.Console.out.println("Channel Joined [#" + channelName + "]");
 
-        eventBus.postAsync(new IrcJoinCompleteEvent(session, channel));
+        eventBus.postAsync(new IrcJoinCompleteEvent(session));
     }
 
     /*
@@ -253,7 +253,7 @@ public class TwitchWSIRCParser {
         }
 
         /* Send the command event with the ircv3 tags from Twitch. */
-        scriptEventManager.onEvent(new CommandEvent(username, command, arguments, tagsMap));
+        scriptEventManager.onEvent(new CommandEvent(username, command.toLowerCase(), arguments, tagsMap));
     }
 
     /*
@@ -299,7 +299,7 @@ public class TwitchWSIRCParser {
         }
 
         /* Send the moderation event. */
-        scriptEventManager.onEvent(new IrcModerationEvent(session, username, message, channel, tagsMap));
+        scriptEventManager.onEvent(new IrcModerationEvent(session, username, message, tagsMap));
 
 
         /* Check to see if the user is a channel subscriber. */
@@ -311,18 +311,18 @@ public class TwitchWSIRCParser {
         if (tagsMap.containsKey("user-type")) {
             if (tagsMap.get("user-type").length() > 0) {
                 if (!moderators.containsKey(username)) {
-                    eventBus.postAsync(new IrcChannelUserModeEvent(session, channel, username, "O", true));
+                    eventBus.postAsync(new IrcChannelUserModeEvent(session, username, "O", true));
                     moderators.put(username, true);
                 }
             } else {
                 if (channelName.equalsIgnoreCase(username)) {
                     if (!moderators.containsKey(username)) {
-                        eventBus.postAsync(new IrcChannelUserModeEvent(session, channel, username, "O", true));
+                        eventBus.postAsync(new IrcChannelUserModeEvent(session, username, "O", true));
                         moderators.put(username, true);
                     }
                 } else {
                     if (moderators.containsKey(username)) {
-                        eventBus.postAsync(new IrcChannelUserModeEvent(session, channel, username, "O", false));
+                        eventBus.postAsync(new IrcChannelUserModeEvent(session, username, "O", false));
                         moderators.remove(username);
                     }
                 }
@@ -330,7 +330,7 @@ public class TwitchWSIRCParser {
         }
 
         /* Send the message to the scripts. */
-        eventBus.postAsync(new IrcChannelMessageEvent(session, username, message, channel, tagsMap));
+        eventBus.postAsync(new IrcChannelMessageEvent(session, username, message, tagsMap));
 
         /* Print the IRCv3 tags if debug mode is on, this is last so it doesn't slow down the code above. */
         com.gmt2001.Console.debug.println("IRCv3 Tags: " + tagsMap);
@@ -361,7 +361,7 @@ public class TwitchWSIRCParser {
         if (tagsMap.containsKey("ban-reason")) {
             banReason = "Reason: " + tagsMap.get("ban-reason").replaceAll("\\\\s", " ");
         }
-        eventBus.postAsync(new IrcClearchatEvent(session, channel, username, banReason, banDuration));
+        eventBus.postAsync(new IrcClearchatEvent(session, username, banReason, banDuration));
     }
 
     /*
@@ -413,7 +413,7 @@ public class TwitchWSIRCParser {
      * @param Map<String, String> tagsMap
      */
     private void joinUser(String message, String username, Map<String, String> tagMaps) {
-        eventBus.postAsync(new IrcChannelJoinEvent(session, channel, username));
+        eventBus.postAsync(new IrcChannelJoinEvent(session, username));
         com.gmt2001.Console.debug.println("User Joined Channel [" + username + "#" + channelName + "]");
     }
 
@@ -425,7 +425,7 @@ public class TwitchWSIRCParser {
      * @param Map<String, String> tagsMap
      */
     private void partUser(String message, String username, Map<String, String> tagMaps) {
-        eventBus.postAsync(new IrcChannelLeaveEvent(session, channel, username, message));
+        eventBus.postAsync(new IrcChannelLeaveEvent(session, username));
         com.gmt2001.Console.debug.println("User Left Channel [" + username + "#" + channelName + "]");
     }
 
@@ -466,13 +466,13 @@ public class TwitchWSIRCParser {
             if (tagMaps.get("user-type").length() > 0) {
                 if (!moderators.containsKey(session.getNick())) {
                     moderators.put(session.getNick(), true);
-                    eventBus.postAsync(new IrcChannelUserModeEvent(session, channel, session.getNick(), "O", true));
+                    eventBus.postAsync(new IrcChannelUserModeEvent(session, session.getNick(), "O", true));
                 }
             } else { 
                 if (this.channelName.equalsIgnoreCase(session.getNick())) {
                     if (!moderators.containsKey(session.getNick())) {
                         moderators.put(session.getNick(), true);
-                        eventBus.postAsync(new IrcChannelUserModeEvent(session, channel, session.getNick(), "O", true));
+                        eventBus.postAsync(new IrcChannelUserModeEvent(session, session.getNick(), "O", true));
                     }
                 } else if (tagMaps.containsKey("display-name") && !tagMaps.get("display-name").equalsIgnoreCase(session.getNick())) {
                     com.gmt2001.Console.out.println();
@@ -490,7 +490,7 @@ public class TwitchWSIRCParser {
                     this.session.setAllowSendMessages(false);
                     if (moderators.containsKey(session.getNick())) {
                         moderators.remove(session.getNick());
-                        eventBus.postAsync(new IrcChannelUserModeEvent(session, channel, session.getNick(), "O", false));
+                        eventBus.postAsync(new IrcChannelUserModeEvent(session, session.getNick(), "O", false));
                     }
                 }
             }


### PR DESCRIPTION
- This commit removes the use for the Channel.java class in a lot of
events, since PhantomBot is only made for one channel, this class is not
needed a all.
- During this process, I will be adding a lot of comments to our event
classes.
- A lot of things may break during this, please don't use the nightly as
your main bot.