### PR TITLE
- Force the GC to run after the viewer list is queried

### DIFF
--- a/source/tv/phantombot/cache/ViewerListCache.java
+++ b/source/tv/phantombot/cache/ViewerListCache.java
@@ -97,7 +97,6 @@ public class ViewerListCache implements Runnable {
 		List<String> cache = new ArrayList<String>();
 		List<String> joins = new ArrayList<String>();
 		List<String> parts = new ArrayList<String>();
-		EventBus bus = EventBus.instance();
 
 		com.gmt2001.Console.debug.println("ViewerListCache::updateCache");
 		try {
@@ -133,13 +132,15 @@ public class ViewerListCache implements Runnable {
 					}
 				}
 
-				bus.post(new IrcChannelUsersUpdateEvent(cache.toArray(new String[cache.size()]), joins.toArray(new String[joins.size()]), parts.toArray(new String[parts.size()])));
+				EventBus.instance().post(new IrcChannelUsersUpdateEvent(joins.toArray(new String[joins.size()]), parts.toArray(new String[parts.size()])));
 				// Set the new cache.
 				this.cache = cache;
 				// Delete the temp caches.
 				cache = null;
 				parts = null;
 				joins = null;
+				// Run the GC to clear memory,
+				System.gc();
 			} else {
 				com.gmt2001.Console.debug.println("Failed to update viewers cache: " + object);
 			}

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
@@ -19,7 +19,6 @@ package tv.phantombot.event.irc.channel;
 import tv.phantombot.twitchwsirc.Session;
 
 public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
-    private final String[] users;
     private final String[] joins;
     private final String[] parts;
 
@@ -27,14 +26,12 @@ public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
      * Class constructor.
      *
      * @param {Session}  session
-     * @param {String[]} users
      * @param {String[]} joins
      * @param {String[]} parts
      */
-    public IrcChannelUsersUpdateEvent(Session session, String[] users, String[] joins, String[] parts) {
+    public IrcChannelUsersUpdateEvent(Session session, String[] joins, String[] parts) {
         super(session);
 
-        this.users = users;
         this.joins = joins;
         this.parts = parts;
     }
@@ -42,25 +39,14 @@ public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
     /*
      * Class constructor.
      *
-     * @param {String[]} users
      * @param {String[]} joins
      * @param {String[]} parts
      */
-    public IrcChannelUsersUpdateEvent(String[] users, String[] joins, String[] parts) {
+    public IrcChannelUsersUpdateEvent(String[] joins, String[] parts) {
         super(null);
 
-        this.users = users;
         this.joins = joins;
         this.parts = parts;
-    }
-
-    /*
-     * Method that returns the current array of users in the channel.
-     *
-     * @return {String[]} users
-     */
-    public String[] getUsers() {
-        return this.users;
     }
 
     /*


### PR DESCRIPTION
**ViewerListCache.java:**
- Forced the GC to run once we get the user list.

**IrcChannelUsersUpdateEvent.java:**
- Removed a method that isn't needed anymore