### PR TITLE
Added ability to reconnect to Discord via chat command

### DIFF
--- a/javascript-source/discord/core/misc.js
+++ b/javascript-source/discord/core/misc.js
@@ -237,6 +237,31 @@
 			say(channel, userPrefix(mention) + $.lang.get('discord.misc.game.removed'));
 		}
 	});
+        
+        /**
+        * @event command
+        */
+        $.bind('command', function (event) {
+            var sender = event.getSender(),
+                command = event.getCommand(),
+                args = event.getArgs(),
+                action = args[0];
+
+            if (command.equalsIgnoreCase('discord')) {
+                if (action === undefined) {
+                    return;
+                }
+            
+                /**
+                * @commandpath discord reconnect - Attempts to reconnect the bot to discord
+                */
+                if (action.equalsIgnoreCase('reconnect')) {
+                    $.discordAPI.reconnect();
+
+                    $.say($.whisperPrefix(sender) + $.lang.get('discord.misc.reconnect'));
+                }
+            }
+        });
 
 	/**
 	 * @event initReady
@@ -249,6 +274,8 @@
 		$.discord.registerSubCommand('module', 'list', 1);
 		$.discord.registerSubCommand('module', 'enable', 1);
 		$.discord.registerSubCommand('module', 'disable', 1);
+                $.registerChatCommand('./discord/core/misc.js', 'discord', 1);
+                $.registerChatSubcommand('discord', 'reconnect', 1);
 	});
 
 	/* Export the function to the $.discord api. */

--- a/javascript-source/discord/core/misc.js
+++ b/javascript-source/discord/core/misc.js
@@ -274,8 +274,8 @@
 		$.discord.registerSubCommand('module', 'list', 1);
 		$.discord.registerSubCommand('module', 'enable', 1);
 		$.discord.registerSubCommand('module', 'disable', 1);
-                $.registerChatCommand('./discord/core/misc.js', 'discord', 1);
-                $.registerChatSubcommand('discord', 'reconnect', 1);
+		$.registerChatCommand('./discord/core/misc.js', 'discord', 1);
+		$.registerChatSubcommand('discord', 'reconnect', 1);
 	});
 
 	/* Export the function to the $.discord api. */

--- a/javascript-source/lang/english/discord/core/core-misc.js
+++ b/javascript-source/lang/english/discord/core/core-misc.js
@@ -8,3 +8,4 @@ $.lang.register('discord.misc.game.set', 'Bot game updated to: $1');
 $.lang.register('discord.misc.game.stream.set.usage', 'Usage: !setstream [twitch url] [game name]');
 $.lang.register('discord.misc.game.stream.set', 'Bot stream changed to: $1 and game to: $2');
 $.lang.register('discord.misc.game.removed', 'Bot game has been removed.');
+$.lang.register('discord.misc.reconnect', 'A Discord reconnect is being attempted.');

--- a/source/tv/phantombot/discord/DiscordAPI.java
+++ b/source/tv/phantombot/discord/DiscordAPI.java
@@ -83,6 +83,18 @@ public class DiscordAPI extends DiscordUtil {
             com.gmt2001.Console.err.println("Failed to authenticate with Discord: [" + ex.getClass().getSimpleName() + "] " + ex.getMessage());
         }
     }
+    
+    /*
+     * Method to reconnect to Discord.
+     */
+    public void reconnect() {
+        try {
+            DiscordAPI.client.logout();
+            DiscordAPI.client.login();
+        } catch (DiscordException ex) {
+            com.gmt2001.Console.err.println("Failed to authenticate with Discord: [" + ex.getClass().getSimpleName() + "] " + ex.getMessage());
+        }
+    }
 
     /*
      * Method that will return the current shard.


### PR DESCRIPTION
Added reconnect() method to DiscordAPI
Added Twitch chat command to reconnect (permissions for admin)
Added lang string for response

I looked through the source code of Discord4J and determined this to be the appropriate way to reconnect as a program importing the library.

The call to logout() will perform a clean logout and tear down of all shard connections that are working and discard any shard connections that have failed.

The call to login() will then perform a fresh connection to the shards and authenticate.

As far as PhantomBot's implementation of DiscordAPI goes, this is essentially the same thing as destroying and re-creating the DiscordAPI object, but eliminates some of the overheads that may be caused by doing so.

Here are the relevant references:
- [ClientBuilder.login()#L471](https://github.com/austinv11/Discord4J/blob/master/src/main/java/sx/blah/discord/api/ClientBuilder.java#L471) The method really does the same thing as calling build() yourself, then calling login() on the returned object.
- [DiscordClientImpl.login()#L387](https://github.com/austinv11/Discord4J/blob/master/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java#L387) -> [ShardImpl.login()#L101](https://github.com/austinv11/Discord4J/blob/master/src/main/java/sx/blah/discord/api/internal/ShardImpl.java#L101) Creates a RequestBuilder which then performs the actual connection and login. Throws an exception if a connection exists or has not been cleaned up for any shard.
- [DiscordClientImpl.logout()#L433](https://github.com/austinv11/Discord4J/blob/master/src/main/java/sx/blah/discord/api/internal/DiscordClientImpl.java#L433) -> [ShardImpl.login()#L108](https://github.com/austinv11/Discord4J/blob/master/src/main/java/sx/blah/discord/api/internal/ShardImpl.java#L108)  Makes all IShard objects logout (leave voice channels), then tear down their websockets.