### PR TITLE
Made console classes final and essentially static 

### DIFF
--- a/source/com/gmt2001/Console/debug.java
+++ b/source/com/gmt2001/Console/debug.java
@@ -22,13 +22,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import tv.phantombot.PhantomBot;
 
-public class debug {
-
-    private static final debug instance = new debug();
-
-    public static debug instance() {
-        return instance;
-    }
+public final class debug {
 
     private debug() {
     }

--- a/source/com/gmt2001/Console/err.java
+++ b/source/com/gmt2001/Console/err.java
@@ -24,7 +24,7 @@ import tv.phantombot.PhantomBot;
 
 /**
  *
- * @author Gary Tekulsky
+ * @author gmt2001
  */
 public final class err {
 

--- a/source/com/gmt2001/Console/err.java
+++ b/source/com/gmt2001/Console/err.java
@@ -26,13 +26,7 @@ import tv.phantombot.PhantomBot;
  *
  * @author Gary Tekulsky
  */
-public class err {
-
-    private static final err instance = new err();
-
-    public static err instance() {
-        return instance;
-    }
+public final class err {
 
     private err() {
     }

--- a/source/com/gmt2001/Console/in.java
+++ b/source/com/gmt2001/Console/in.java
@@ -25,14 +25,9 @@ import tv.phantombot.PhantomBot;
  *
  * @author Gary Tekulsky
  */
-public class in {
+public final class in {
 
-    private static final in instance = new in();
     private static final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-
-    public static in instance() {
-        return instance;
-    }
 
     private in() {
     }

--- a/source/com/gmt2001/Console/in.java
+++ b/source/com/gmt2001/Console/in.java
@@ -23,7 +23,7 @@ import tv.phantombot.PhantomBot;
 
 /**
  *
- * @author Gary Tekulsky
+ * @author gmt2001
  */
 public final class in {
 

--- a/source/com/gmt2001/Console/logTimestamp.java
+++ b/source/com/gmt2001/Console/logTimestamp.java
@@ -21,7 +21,11 @@ import java.util.Date;
 import java.util.TimeZone;
 import tv.phantombot.PhantomBot;
 
-public class logTimestamp {
+public final class logTimestamp {
+    
+    private logTimestamp(){
+    }
+    
     public static String log() {
         SimpleDateFormat datefmt = new SimpleDateFormat("MM-dd-yyyy @ HH:mm:ss.SSS z");
         datefmt.setTimeZone(TimeZone.getTimeZone(PhantomBot.timeZone));

--- a/source/com/gmt2001/Console/out.java
+++ b/source/com/gmt2001/Console/out.java
@@ -21,7 +21,7 @@ import tv.phantombot.PhantomBot;
 
 /**
  *
- * @author Gary Tekulsky
+ * @author gmt2001
  */
 public final class out {
 

--- a/source/com/gmt2001/Console/out.java
+++ b/source/com/gmt2001/Console/out.java
@@ -23,13 +23,7 @@ import tv.phantombot.PhantomBot;
  *
  * @author Gary Tekulsky
  */
-public class out {
-
-    private static final out instance = new out();
-
-    public static out instance() {
-        return instance;
-    }
+public final class out {
 
     private out() {
     }

--- a/source/com/gmt2001/Console/warn.java
+++ b/source/com/gmt2001/Console/warn.java
@@ -22,13 +22,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import tv.phantombot.PhantomBot;
 
-public class warn {
-
-    private static final warn instance = new warn();
-
-    public static warn instance() {
-        return instance;
-    }
+public final class warn {
 
     private warn() {
     }


### PR DESCRIPTION
Removed instances of classes
Made logTimestamp constructor final

I ran usage checks and global searches against all instance() methods for the Console package and determined that they aren't used, which is good since all methods were static anyway. I therefore removed the instance() methods and variables.

I also made them all final classes (prevents extending/subclassing) and added a private constructor to logTimestamp.

This should shave a sliver of memory usage off the bot, as well as shaving a sliver of load off the GC since it wont have to check them.

As an aside, I also fixed my author attribution lines in 3 of the files to use my online name instead of my real name.