### PR TITLE
- Fixed consoleDebug function in JavaScript

### DIFF
--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -62,7 +62,7 @@
      * @param {String} message
      */
     function consoleDebug(message) {
-        if (Packages.me.mast3rplan.phantombot.PhantomBot.enableDebugging) {
+        if (Packages.tv.phantombot.PhantomBot.enableDebugging) {
             try {
                 throw new Error();
             } catch (ex) {


### PR DESCRIPTION
**init.js:**
- The `consoleDebug` was still calling `me.mast3rplan` to get the debug
status from the core, which was changed to `tv` a while back. Strangely
enough, Rhino doesn't throw any errors for this, it only returns
`[JavaPackage me.mast3rplan.phantombot.PhantomBot.enableDebugging]`