### PR TITLE
- Fixed hook call with the (alert) command tag.

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -284,7 +284,7 @@
         if (message.match(/\(alert [,.\w]+\)/g)) {
             var filename = message.match(/\(alert ([,.\w]+)\)/)[1];
             $.panelsocketserver.alertImage(filename);
-            message = message.replaceFirst('\\(alert [,.\\w]+\\)', '');
+            message = (message + '').replace(/\(alert [,.\w]+\)/, '');
             if (message == '') return null;
         }
 


### PR DESCRIPTION
**customCommands.js:**
- Cast the message as a string, also use the JavaScript `replace` method
and not Java's `replaceFirst` one.

Before:
```
lb
[12-31-2017 @ 02:12:47.334 AST] [ERROR] TypeError: Cannot find function replaceFirst in object (alert
 banana.gif,6) Dancetime!!.
```

After:
```
lb
[12-31-2017 @ 02:12:47.334 AST] [CHAT]  Dancetime!!
```