### PR TITLE
- Changed Journal mode to WAL

### DIFF
--- a/source/com/gmt2001/datastore/SqliteStore.java
+++ b/source/com/gmt2001/datastore/SqliteStore.java
@@ -165,7 +165,7 @@ public class SqliteStore extends DataStore {
             config.setCacheSize(cache_size);
             config.setSynchronous(safe_write ? SQLiteConfig.SynchronousMode.FULL : SQLiteConfig.SynchronousMode.NORMAL);
             config.setTempStore(SQLiteConfig.TempStore.MEMORY);
-            config.setJournalMode(journal ? SQLiteConfig.JournalMode.TRUNCATE : SQLiteConfig.JournalMode.OFF);
+            config.setJournalMode(journal ? SQLiteConfig.JournalMode.WAL : SQLiteConfig.JournalMode.OFF);
             connection = DriverManager.getConnection("jdbc:sqlite:" + dbname.replaceAll("\\\\", "/"), config.toProperties());
             connection.setAutoCommit(autocommit);
         } catch (SQLException ex) {


### PR DESCRIPTION
**SqliteStore.java:**
- Changing the journal to WAL allows us to do writes and reads at the
same time and not have writes lock the database for a few seconds. This
will help bot speed in larger channels.