### PR TITLE
Patch launch.sh to resolve issue with BASH under Cygwin

### DIFF
--- a/resources/launch.sh
+++ b/resources/launch.sh
@@ -9,7 +9,7 @@
 
 unset DISPLAY
 
-if [[ $(uname) -eq "Darwin" ]]; then
+if [[ $(uname)=="Darwin" ]]; then
     SOURCE="${BASH_SOURCE[0]}"
     while [ -h "$SOURCE" ]; do
         DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"


### PR DESCRIPTION
**launch.sh**
- When running under BASH in Cygwin, there is a syntax issue that comes up.  This did not effect other operating systems.
- Tested change under macOS High Sierra (Darwin) and Fedora Linux as well.