### PR TITLE
Add phantombot version, java version, and os info to logs on startup

### DIFF
--- a/source/com/gmt2001/Logger.java
+++ b/source/com/gmt2001/Logger.java
@@ -19,6 +19,7 @@ package com.gmt2001;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -115,6 +116,13 @@ public class Logger implements Runnable {
                             if (this.psCore == null) {
                                 this.fosCore = new FileOutputStream("./logs/core/" + timestamp + ".txt", true);
                                 this.psCore = new PrintStream(this.fosCore);
+                                try {
+                                    if (this.fosCore.getChannel().size() == 0) {
+                                        this.psCore.println(PhantomBot.instance().getBotInformation());
+                                    }
+                                } catch (IOException e) {
+                                    com.gmt2001.Console.err.printStackTrace(e);
+                                }
                             }
                             this.psCore.println(i.s);
                             this.psCore.flush();
@@ -123,6 +131,13 @@ public class Logger implements Runnable {
                             if (this.psCore == null) {
                                 this.fosCore = new FileOutputStream("./logs/core/" + timestamp + ".txt", true);
                                 this.psCore = new PrintStream(this.fosCore);
+                                try {
+                                    if (this.fosCore.getChannel().size() == 0) {
+                                        this.psCore.println(PhantomBot.instance().getBotInformation());
+                                    }
+                                } catch (IOException e) {
+                                    com.gmt2001.Console.err.printStackTrace(e);
+                                }
                             }
                             this.psCore.println(i.s);
                             this.psCore.flush();
@@ -131,6 +146,13 @@ public class Logger implements Runnable {
                             if (this.psError == null) {
                                 this.fosError = new FileOutputStream("./logs/core-error/" + timestamp + ".txt", true);
                                 this.psError = new PrintStream(this.fosError);
+                                try {
+                                    if (this.fosError.getChannel().size() == 0) {
+                                        this.psError.println(PhantomBot.instance().getBotInformation());
+                                    }
+                                } catch (IOException e) {
+                                    com.gmt2001.Console.err.printStackTrace(e);
+                                }
                             }
                             this.psError.println(i.s);
                             this.psError.flush();
@@ -139,6 +161,13 @@ public class Logger implements Runnable {
                             if (this.psDebug == null) {
                                 this.fosDebug = new FileOutputStream("./logs/core-debug/" + timestamp + ".txt", true);
                                 this.psDebug = new PrintStream(this.fosDebug);
+                                try {
+                                    if (this.fosDebug.getChannel().size() == 0) {
+                                        this.psDebug.println(PhantomBot.instance().getBotInformation());
+                                    }
+                                } catch (IOException e) {
+                                    com.gmt2001.Console.err.printStackTrace(e);
+                                }
                             }
                             this.psDebug.println(i.s);
                             this.psDebug.flush();
@@ -147,6 +176,13 @@ public class Logger implements Runnable {
                             if (this.psWarning == null) {
                                 this.fosWarning = new FileOutputStream("./logs/core-warnings/" + timestamp + ".txt", true);
                                 this.psWarning = new PrintStream(this.fosWarning);
+                                try {
+                                    if (this.fosWarning.getChannel().size() == 0) {
+                                        this.psWarning.println(PhantomBot.instance().getBotInformation());
+                                    }
+                                } catch (IOException e) {
+                                    com.gmt2001.Console.err.printStackTrace(e);
+                                }
                             }
                             this.psWarning.println(i.s);
                             this.psWarning.flush();
@@ -163,6 +199,13 @@ public class Logger implements Runnable {
                             if (this.psCore == null) {
                                 this.fosCore = new FileOutputStream("./logs/core/" + timestamp + ".txt", true);
                                 this.psCore = new PrintStream(this.fosCore);
+                                try {
+                                    if (this.fosCore.getChannel().size() == 0) {
+                                        this.psCore.println(PhantomBot.instance().getBotInformation());
+                                    }
+                                } catch (IOException e) {
+                                    com.gmt2001.Console.err.printStackTrace(e);
+                                }
                             }
                             this.psCore.println(i.s);
                             this.psCore.flush();

--- a/source/com/gmt2001/Logger.java
+++ b/source/com/gmt2001/Logger.java
@@ -19,7 +19,6 @@ package com.gmt2001;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -116,13 +115,6 @@ public class Logger implements Runnable {
                             if (this.psCore == null) {
                                 this.fosCore = new FileOutputStream("./logs/core/" + timestamp + ".txt", true);
                                 this.psCore = new PrintStream(this.fosCore);
-                                try {
-                                    if (this.fosCore.getChannel().size() == 0) {
-                                        this.psCore.println(PhantomBot.instance().getBotInformation());
-                                    }
-                                } catch (IOException e) {
-                                    com.gmt2001.Console.err.printStackTrace(e);
-                                }
                             }
                             this.psCore.println(i.s);
                             this.psCore.flush();
@@ -131,13 +123,6 @@ public class Logger implements Runnable {
                             if (this.psCore == null) {
                                 this.fosCore = new FileOutputStream("./logs/core/" + timestamp + ".txt", true);
                                 this.psCore = new PrintStream(this.fosCore);
-                                try {
-                                    if (this.fosCore.getChannel().size() == 0) {
-                                        this.psCore.println(PhantomBot.instance().getBotInformation());
-                                    }
-                                } catch (IOException e) {
-                                    com.gmt2001.Console.err.printStackTrace(e);
-                                }
                             }
                             this.psCore.println(i.s);
                             this.psCore.flush();
@@ -146,13 +131,6 @@ public class Logger implements Runnable {
                             if (this.psError == null) {
                                 this.fosError = new FileOutputStream("./logs/core-error/" + timestamp + ".txt", true);
                                 this.psError = new PrintStream(this.fosError);
-                                try {
-                                    if (this.fosError.getChannel().size() == 0) {
-                                        this.psError.println(PhantomBot.instance().getBotInformation());
-                                    }
-                                } catch (IOException e) {
-                                    com.gmt2001.Console.err.printStackTrace(e);
-                                }
                             }
                             this.psError.println(i.s);
                             this.psError.flush();
@@ -161,13 +139,6 @@ public class Logger implements Runnable {
                             if (this.psDebug == null) {
                                 this.fosDebug = new FileOutputStream("./logs/core-debug/" + timestamp + ".txt", true);
                                 this.psDebug = new PrintStream(this.fosDebug);
-                                try {
-                                    if (this.fosDebug.getChannel().size() == 0) {
-                                        this.psDebug.println(PhantomBot.instance().getBotInformation());
-                                    }
-                                } catch (IOException e) {
-                                    com.gmt2001.Console.err.printStackTrace(e);
-                                }
                             }
                             this.psDebug.println(i.s);
                             this.psDebug.flush();
@@ -176,13 +147,6 @@ public class Logger implements Runnable {
                             if (this.psWarning == null) {
                                 this.fosWarning = new FileOutputStream("./logs/core-warnings/" + timestamp + ".txt", true);
                                 this.psWarning = new PrintStream(this.fosWarning);
-                                try {
-                                    if (this.fosWarning.getChannel().size() == 0) {
-                                        this.psWarning.println(PhantomBot.instance().getBotInformation());
-                                    }
-                                } catch (IOException e) {
-                                    com.gmt2001.Console.err.printStackTrace(e);
-                                }
                             }
                             this.psWarning.println(i.s);
                             this.psWarning.flush();
@@ -199,13 +163,6 @@ public class Logger implements Runnable {
                             if (this.psCore == null) {
                                 this.fosCore = new FileOutputStream("./logs/core/" + timestamp + ".txt", true);
                                 this.psCore = new PrintStream(this.fosCore);
-                                try {
-                                    if (this.fosCore.getChannel().size() == 0) {
-                                        this.psCore.println(PhantomBot.instance().getBotInformation());
-                                    }
-                                } catch (IOException e) {
-                                    com.gmt2001.Console.err.printStackTrace(e);
-                                }
                             }
                             this.psCore.println(i.s);
                             this.psCore.flush();

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -2186,6 +2186,11 @@ public final class PhantomBot implements Listener {
             System.out.println("Detected Java " + System.getProperty("java.version") + ". " + "PhantomBot requires Java 8. Java 9 will not work.");
             System.exit(1);
         }
+        
+        /* Log important info for support tickets */
+        com.gmt2001.Logger.instance().log(Logger.LogType.Output, "PhantomBot Version: " + RepoVersion.getPhantomBotVersion() + " (" + RepoVersion.getRepoVersion() + ")");
+        com.gmt2001.Logger.instance().log(Logger.LogType.Output, "Java Version: " + System.getProperty("java.runtime.version") + "\r\nOS Version: " + System.getProperty("os.name") + " "
+               + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");
 
         /* Properties configuration */
         Properties startProperties = new Properties();

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -2188,7 +2188,8 @@ public final class PhantomBot implements Listener {
         }
         
         /* Log important info for support tickets */
-        com.gmt2001.Logger.instance().log(Logger.LogType.Output, "PhantomBot Version: " + RepoVersion.getPhantomBotVersion() + " (" + RepoVersion.getRepoVersion() + ")");
+        com.gmt2001.Logger.instance().log(Logger.LogType.Output, "PhantomBot Version: " + RepoVersion.getPhantomBotVersion() + " (" + RepoVersion.getRepoVersion() + ") ("
+                + (RepoVersion.getNightlyBuild() ? "nightly" : (RepoVersion.getPrereleaseBuild() ? "prerelease" : "stable")) + ") (Panel: " + RepoVersion.getPanelVersion() + ")");
         com.gmt2001.Logger.instance().log(Logger.LogType.Output, "Java Version: " + System.getProperty("java.runtime.version") + "\r\nOS Version: " + System.getProperty("os.name") + " "
                + System.getProperty("os.version") + " (" + System.getProperty("os.arch") + ")");
 


### PR DESCRIPTION
Since we always ask for this info plus the logs anyway on major errors, added important info to the top of logs/core on every startup

```
PhantomBot Version: 2.3.9.1 (fb4561af) (nightly) (Panel: 1.1)
Java Version: 1.8.0_151-b12
OS Version: Windows 10 10.0 (amd64)
```