### PR TITLE
Added a coolDownAnnounce function

### DIFF
--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -22,6 +22,7 @@
         maxBet = $.getSetIniDbNumber('adventureSettings', 'maxBet', 1000),
         enterMessage = $.getSetIniDbBoolean('adventureSettings', 'enterMessage', false),
         warningMessage = $.getSetIniDbBoolean('adventureSettings', 'warningMessage', false),
+        coolDownAnnounce = $.getSetIniDbBoolean('adventureSettings', 'coolDownAnnounce', false),
         tgFunIncr = 1,
         tgExpIncr = 0.5,
         tgFoodDecr = 0.25,
@@ -39,6 +40,7 @@
         maxBet = $.getIniDbNumber('adventureSettings', 'maxBet');
         enterMessage = $.getIniDbBoolean('adventureSettings', 'enterMessage');
         warningMessage = $.getIniDbBoolean('adventureSettings', 'warningMessage');
+        coolDownAnnounce = $.getIniDbBoolean('adventureSettings', 'coolDownAnnounce');
     };
 
     /**
@@ -377,6 +379,11 @@
         clearCurrentAdventure();
         temp = "";
         $.coolDown.set('adventure', false, coolDown, false);
+        if (coolDownAnnounce) {
+            setTimeout(function() {
+                $.say($.lang.get('adventuresystem.reset', $.pointNameMultiple));
+            }, coolDown);
+        }
     };
 
     /**
@@ -511,6 +518,15 @@
                     if (args[2].equalsIgnoreCase('true')) enterMessage = true, actionArg2 = $.lang.get('common.enabled');
                     if (args[2].equalsIgnoreCase('false')) enterMessage = false, actionArg2 = $.lang.get('common.disabled');
                     $.inidb.set('adventureSettings', 'enterMessage', enterMessage);
+                }
+                
+                /**
+                 * @commandpath adventure set cooldownannounce [true / false] - Sets the cooldown announcement
+                 */
+                if (actionArg1.equalsIgnoreCase('cooldownannounce')) {
+                    if (args[2].equalsIgnoreCase('true')) coolDownAnnounce = true, actionArg2 = $.lang.get('common.enabled');
+                    if (args[2].equalsIgnoreCase('false')) coolDownAnnounce = false, actionArg2 = $.lang.get('common.disabled');
+                    $.inidb.set('adventureSettings', 'coolDownAnnounce', coolDownAnnounce);
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('adventuresystem.set.success', actionArg1, actionArg2));

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -382,7 +382,7 @@
         if (coolDownAnnounce) {
             setTimeout(function() {
                 $.say($.lang.get('adventuresystem.reset', $.pointNameMultiple));
-            }, coolDown);
+            }, coolDown*1000);
         }
     };
 

--- a/javascript-source/lang/english/games/games-adventureSystem.js
+++ b/javascript-source/lang/english/games/games-adventureSystem.js
@@ -17,6 +17,7 @@ $.lang.register('adventuresystem.start.success', '$1 is trying get a team togeth
 $.lang.register('adventuresystem.tamagotchijoined', '$1 is also joining the adventure.');
 $.lang.register('adventuresystem.top5', 'The top 5 adventurers are: $1.');
 $.lang.register('adventuresystem.top5.empty', 'There haven\'t been any adventure winners recorded yet.');
+$.lang.register('adventuresystem.reset', 'The adventure has now cooled off! Use "!adventure [$1]" to start a new adventure!');
 
 
 $.lang.register('adventuresystem.stories.1.title', 'Time Heist');

--- a/resources/web/panel/games.html
+++ b/resources/web/panel/games.html
@@ -217,6 +217,20 @@
                      </div>
                 </td>
             </tr>
+            <tr>
+                <td>Adventure Cooldown Announcement</td>
+                <td style="width: 25px"><div id="adventurecoolDownAnnounce" /></td>
+                <td style="width: 25px">
+                    <div data-toggle="tooltip" title="Enable" class="button"
+                         onclick="$.adventureUpdateSetting('coolDownAnnounce', 'true');"><i class="fa fa-circle" />
+                     </div>
+                </td>
+                <td style="width: 25px">
+                    <div data-toggle="tooltip" title="Disable" class="button"
+                         onclick="$.adventureUpdateSetting('coolDownAnnounce', 'false');"><i class="fa fa-circle-o" />
+                     </div>
+                </td>
+            </tr>
         </table>
         <br>
 

--- a/resources/web/panel/js/gamesPanel.js
+++ b/resources/web/panel/js/gamesPanel.js
@@ -55,6 +55,9 @@
                     if (msgObject['results'][idx]['key'] == 'enterMessage') {
                         $('#adventure' + msgObject['results'][idx]['key']).html(toggleIcon[msgObject['results'][idx]['value']]);
                     }
+                    if (msgObject['results'][idx]['key'] == 'coolDownAnnounce') {
+                        $('#adventure' + msgObject['results'][idx]['key']).html(toggleIcon[msgObject['results'][idx]['value']]);
+                    }
                    $('#adventure' + msgObject['results'][idx]['key'] + 'Input').attr('placeholder', msgObject['results'][idx]['value']);
                 }
             }
@@ -339,6 +342,18 @@
         }
 
         if (setting == 'enterMessage') {
+            $("#adventure" + setting).html("<i style=\"color: var(--main-color)\" class=\"fa fa-spinner fa-spin\" />");
+            if (l == 'true') {
+                sendDBUpdate('games_adventure', 'adventureSettings', setting, 'true');
+            } else {
+                sendDBUpdate('games_adventure', 'adventureSettings', setting, 'false');
+            }
+            setTimeout(function() { doQuery(); }, TIMEOUT_WAIT_TIME);
+            setTimeout(function() { sendCommand('reloadadventure') }, TIMEOUT_WAIT_TIME);
+            return;
+        }
+        
+        if (setting == 'coolDownAnnounce') {
             $("#adventure" + setting).html("<i style=\"color: var(--main-color)\" class=\"fa fa-spinner fa-spin\" />");
             if (l == 'true') {
                 sendDBUpdate('games_adventure', 'adventureSettings', setting, 'true');


### PR DESCRIPTION
I have added a toggleable message for when the adventure is able to be ran again!

![toggle for the pannel](https://www.alixe.pro/share/img/firefox_035212359S230118.png)
![command thats ran to toggle the cooldown announcement](http://alixe.pro/share/img/firefox_0414042710230118.png)
![output after the cooldown has ended](https://www.alixe.pro/share/img/firefox_035300844d230118.png)


**You may delete this note from your Pull Request if you so desire. It is acceptable if you leave it in place.**