### PR TITLE
Add OS and Java Version to the Control Panel Information Screen

### DIFF
--- a/resources/web/panel/js/helpPanel.js
+++ b/resources/web/panel/js/helpPanel.js
@@ -41,15 +41,24 @@
         // Check for dbkeysresult queries
         if (msgObject['versionresult'] !== undefined) {
             var version = "",
+                java_version = "",
+                os_version = "",
                 panelVersion = "Control Panel Version " + PANEL_VERSION;
 
             if (panelMatch(msgObject['versionresult'], 'help_version')) {
                 version = msgObject['version'];
+                java_version = msgObject['java-version'];
+                os_version = msgObject['os-version'];
             } else {
                 version = "PhantomBot 2";
+                java_version = "Unknown";
+                os_version = "Unknown";
             }
-            $("#botVersion").html("<strong>" + version + "<br>" + panelVersion + "</strong><br><br>" +
-                                  "<small>" +
+
+            $("#botVersion").html("<strong>" + version + "<br>" + panelVersion + "<br>" +
+                                  "Java Version: " + java_version + "<br>" +
+                                  "OS Version: " + os_version + "<br></strong>" +
+                                  "<br><small>" +
                                   "    <strong>Control Panel Software</strong><br>" +
                                   "    jQuery " + $().jquery + "<br>" + 
                                   "    jQuery UI " + $.ui.version + "<br>" +

--- a/source/tv/phantombot/panel/NewPanelSocketServer.java
+++ b/source/tv/phantombot/panel/NewPanelSocketServer.java
@@ -487,7 +487,11 @@ public class NewPanelSocketServer {
             return;
         }
 
-        jsonObject.object().key("versionresult").value(id).key("version").value(version).endObject();
+        jsonObject.object().key("versionresult").value(id);
+        jsonObject.key("version").value(version);
+        jsonObject.key("java-version").value(System.getProperty("java.runtime.version"));
+        jsonObject.key("os-version").value(System.getProperty("os.name"));
+        jsonObject.endObject();
         webSocket.send(jsonObject.toString());
     }
 

--- a/source/tv/phantombot/panel/PanelSocketServer.java
+++ b/source/tv/phantombot/panel/PanelSocketServer.java
@@ -468,7 +468,11 @@ public class PanelSocketServer extends WebSocketServer {
             return;
         }
 
-        jsonObject.object().key("versionresult").value(id).key("version").value(version).endObject();
+        jsonObject.object().key("versionresult").value(id);
+	jsonObject.key("version").value(version);
+	jsonObject.key("java-version").value(System.getProperty("java.runtime.version"));
+	jsonObject.key("os-version").value(System.getProperty("os.name"));
+	jsonObject.endObject();
         webSocket.send(jsonObject.toString());
     }
 


### PR DESCRIPTION
**NewPanelSocketServer.java, PanelSocketServer.java**
- Provide OS and Java version in the JSON payload for version.

**helpPanel.js**
- Display the OS and Java version

<img width="478" alt="cap0000e" src="https://user-images.githubusercontent.com/12041043/35477172-181cf73e-037b-11e8-95ed-9a9e970f608e.png">
