### PR TITLE
Implemented Twitch UserID tracking and automatic name change handling

### DIFF
--- a/javascript-source/commands/nameConverter.js
+++ b/javascript-source/commands/nameConverter.js
@@ -1,4 +1,46 @@
 (function() {
+    
+    /*
+     * @function changeTwitchName
+     */
+    function changeTwitchName(oldName, newName) {
+        var tables = ['points', 'time', 'followed', 'subscribed', 'visited', 'group', 'panelchatuserstats', 'panelchatstats', 'gamewispsubs'],
+            changed = 0,
+            i;
+
+        $.inidb.setAutoCommit(false);
+
+        // Update the default tables with that users new name if it's currently in any tables.
+        for (i in tables) {
+            if ($.inidb.exists(tables[i], oldName.toLowerCase()) == true) {
+                $.inidb.set(tables[i], newName.toLowerCase(), $.inidb.get(tables[i], oldName.toLowerCase()));
+                $.inidb.del(tables[i], oldName.toLowerCase());
+                changed++;
+            }
+        }
+
+        // Update the username in the quotes table.
+        var keys = $.inidb.GetKeyList('quotes', ''),
+            jsonArr,
+            foundAQuote = false;
+
+        for (i in keys) {
+            if ($.inidb.get('quotes', keys[i]).toLowerCase().indexOf(oldName.toLowerCase()) > -1) {
+                jsonArr = JSON.parse($.inidb.get('quotes', keys[i]));
+                $.inidb.set('quotes', keys[i], JSON.stringify([String(newName), String(jsonArr[1]), String(jsonArr[2]), String(jsonArr[3])]));
+                foundAQuote = true;
+            }
+        }
+        
+        if (foundAQuote) {
+            changed++;
+        }
+        
+        $.inidb.setAutoCommit(true);
+        
+        return changed;
+    }
+    
     $.bind('command', function(event) {
         var sender = event.getSender(),
             command = event.getCommand(),
@@ -16,31 +58,9 @@
                 return;
             }
 
-            var tables = ['points', 'time', 'followed', 'subscribed', 'visited', 'group', 'panelchatuserstats', 'panelchatstats', 'gamewispsubs'],
-                changed = 0,
-                i;
-
             $.say($.whisperPrefix(sender) + $.lang.get('namechange.updating', action, subAction));
 
-            // Update the default tables with that users new name if it's currently in any tables.
-            for (i in tables) {
-                if ($.inidb.exists(tables[i], action.toLowerCase()) == true) {
-                    $.inidb.set(tables[i], subAction.toLowerCase(), $.inidb.get(tables[i], action.toLowerCase()));
-                    $.inidb.del(tables[i], action.toLowerCase());
-                    changed++;
-                }
-            }
-
-            // Update the username in the quotes table.
-            var keys = $.inidb.GetKeyList('quotes', ''),
-                jsonArr;
-
-            for (i in keys) {
-                if ($.inidb.get('quotes', keys[i]).toLowerCase().indexOf(action.toLowerCase()) > -1) {
-                    jsonArr = JSON.parse($.inidb.get('quotes', keys[i]));
-                    $.inidb.set('quotes', keys[i], JSON.stringify([String(subAction), String(jsonArr[1]), String(jsonArr[2]), String(jsonArr[3])]));
-                }
-            }
+            var changed = changeTwitchName(action, subAction);
 
             // Announce in chat once done.
             if (changed > 0) {
@@ -49,6 +69,10 @@
                 $.say($.whisperPrefix(sender) + $.lang.get('namechange.notfound', action));
             }
         }
+    });
+    
+    $.bind('twitchUserNameChanged', function(event) {
+       changeTwitchName(event.getOldName(), event.getNewName()); 
     });
 
     $.bind('initReady', function() {

--- a/javascript-source/commands/nameConverter.js
+++ b/javascript-source/commands/nameConverter.js
@@ -36,6 +36,13 @@
             changed++;
         }
         
+        var key = $.inidb.GetKeyByValue('userids', '', oldName);
+        
+        if (key != null) {
+            $.inidb.SetString('userids', '', key, newName);
+            changed++;
+        }
+        
         $.inidb.setAutoCommit(true);
         
         return changed;

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -637,6 +637,7 @@
                     }
                     $.checkGameWispSub(joins[i]);
                     $.users.push([joins[i], now]);
+                    $.username.addUser(joins[i]);
                 }
             }
             // Enable auto commit again and force save.
@@ -661,6 +662,7 @@
 
             users.push([username, $.systemTime()]);
             $.checkGameWispSub(username);
+            $.username.addUser(username);
         }
     });
 
@@ -677,6 +679,7 @@
 
             users.push([username, $.systemTime()]);
             $.checkGameWispSub(username);
+            $.username.addUser(username, event.getTags());
         }
     });
 

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -976,6 +976,14 @@
         $api.on($script, 'PubSubModerationUnBan', function(event) {
             callHook('PubSubModerationUnBan', event, false);
         });
+
+        /*
+         * @event twitchUserNameChanged
+         */
+        $api.on($script, 'twitchUserNameChanged', function(event) {
+            callHook('twitchUserNameChanged', event, true);
+        }
+        
     }
 
     // Export functions to API

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -982,7 +982,7 @@
          */
         $api.on($script, 'twitchUserNameChanged', function(event) {
             callHook('twitchUserNameChanged', event, true);
-        }
+        });
         
     }
 

--- a/source/tv/phantombot/cache/UsernameCache.java
+++ b/source/tv/phantombot/cache/UsernameCache.java
@@ -17,13 +17,22 @@
 package tv.phantombot.cache;
 
 import com.gmt2001.TwitchAPIv5;
-import com.google.common.collect.Maps;
+import com.gmt2001.datastore.DataStore;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import tv.phantombot.PhantomBot;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.json.JSONException;
 import org.json.JSONObject;
+import tv.phantombot.PhantomBot;
+import tv.phantombot.event.EventBus;
+import tv.phantombot.event.twitch.user.TwitchUserNameChangedEvent;
 
 public class UsernameCache {
 
@@ -33,13 +42,24 @@ public class UsernameCache {
         return instance;
     }
 
-    private final Map<String, UserData> cache = Maps.newHashMap();
+    private static final int intervalLookupMS = 1000;
+    private final ConcurrentMap<String, UserData> cache = new ConcurrentHashMap<>();
+    private final ScheduledThreadPoolExecutor tpExec = new ScheduledThreadPoolExecutor(1);
+    private Queue<String> lookupQueue = new ConcurrentLinkedQueue<>();
     private Date timeoutExpire = new Date();
     private Date lastFail = new Date();
     private int numfail = 0;
 
     private UsernameCache() {
         Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
+        
+        tpExec.scheduleAtFixedRate(() -> {
+            String next = lookupQueue.poll();
+            
+            if (next != null) {
+                lookupUserData(next);
+            }
+        }, intervalLookupMS, intervalLookupMS, TimeUnit.MILLISECONDS);
     }
 
     private void lookupUserData(String username) {
@@ -51,7 +71,7 @@ public class UsernameCache {
                     if (user.getJSONArray("users").length() > 0) {
                         String displayName = user.getJSONArray("users").getJSONObject(0).getString("display_name").replaceAll("\\\\s", " ");
                         String userID = user.getJSONArray("users").getJSONObject(0).getString("_id");
-                        cache.put(username, new UserData(displayName, userID));
+                        addUser(username, displayName, userID);
                     }
                 } else {
                     com.gmt2001.Console.debug.println("UsernameCache.updateCache: Failed to get username [" + username + "] http error [" + user.getInt("_http") + "]");
@@ -75,13 +95,28 @@ public class UsernameCache {
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (JSONException e) {
             com.gmt2001.Console.err.printStackTrace(e);
+        }
+    }
+    
+    private void checkUserNameChanged(String userName, String userID) {
+        DataStore ds = PhantomBot.instance().getDataStore();
+        String existingName = ds.GetString("userids", "", userID);
+        
+        if (existingName != null) {
+            if (!existingName.equalsIgnoreCase(userName)) {
+                EventBus.instance().post(new TwitchUserNameChangedEvent(userID, existingName, userName));
+                
+                ds.SetString("userids", "", userID, userName);
+            }
+        } else {
+            ds.SetString("userids", "", userID, userName);
         }
     }
 
     public String resolve(String username) {
-        return resolve(username, new HashMap<String, String>());
+        return resolve(username, new HashMap<>());
     }
 
     public String resolve(String username, Map<String, String> tags) {
@@ -95,7 +130,7 @@ public class UsernameCache {
             }
 
             if (tags.containsKey("display-name") && tags.get("display-name").equalsIgnoreCase(lusername) && tags.containsKey("user-id")) {
-                cache.put(lusername, new UserData(tags.get("display-name"), tags.get("user-id")));
+                addUser(lusername, tags.get("display-name"), tags.get("user-id"));
                 return tags.get("display-name");
             }
 
@@ -117,15 +152,30 @@ public class UsernameCache {
         }
     }
 
-    public void addUser(String userName, String displayName, int userID) {
-        if (!hasUser(userName) && displayName.length() > 0) {
-            cache.put(userName, new UserData(displayName.replaceAll("\\\\s", " "), userID));
+    public void addUser(String userName) {
+        addUser(userName, "", "");
+    }
+
+    public void addUser(String userName, Map<String, String> tags) {
+        if (tags.containsKey("display-name") && tags.get("display-name").equalsIgnoreCase(userName) && tags.containsKey("user-id")) {
+            addUser(userName, tags.get("display-name"), tags.get("user-id"));
+        } else {
+            addUser(userName);
         }
     }
 
+    public void addUser(String userName, String displayName, int userID) {
+        addUser(userName, displayName, "" + userID);
+    }
+
     public void addUser(String userName, String displayName, String userID) {
-        if (!hasUser(userName) && displayName.length() > 0 && userID.length() > 0) {
-            cache.put(userName, new UserData(displayName.replaceAll("\\\\s", " "), userID));
+        if (!hasUser(userName)) {
+            if (displayName.length() > 0 && userID.length() > 0 && !userID.equals("0")) {
+                cache.put(userName, new UserData(displayName.replaceAll("\\\\s", " "), userID));
+                checkUserNameChanged(userName, userID);
+            } else {
+                lookupQueue.add(userName);
+            }
         }
     }
 
@@ -142,13 +192,7 @@ public class UsernameCache {
         if (hasUser(lusername)) {
             return cache.get(lusername).getUserID();
         } else {
-            if (new Date().before(timeoutExpire)) {
-                return "0";
-            }
-            lookupUserData(lusername);
-            if (hasUser(lusername)) {
-                return cache.get(lusername).getUserID();
-            }
+            addUser(userName);
         }
         return "0";
     }

--- a/source/tv/phantombot/event/twitch/user/TwitchUserNameChangedEvent.java
+++ b/source/tv/phantombot/event/twitch/user/TwitchUserNameChangedEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016-2018 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package tv.phantombot.event.twitch.user;
+
+import tv.phantombot.event.twitch.TwitchEvent;
+
+/**
+ *
+ * @author gmt2001
+ */
+public class TwitchUserNameChangedEvent extends TwitchEvent {
+    private final String userID;
+    private final String oldName;
+    private final String newName;
+    
+    public TwitchUserNameChangedEvent(String userID, String oldName, String newName) {
+        this.userID = userID;
+        this.oldName = oldName;
+        this.newName = newName;
+    }
+    
+    public String getUserID() {
+        return this.userID;
+    }
+    
+    public String getOldName() {
+        return this.oldName;
+    }
+    
+    public String getNewName() {
+        return this.newName;
+    }
+}


### PR DESCRIPTION
Completes trello card https://trello.com/c/hl95xq7s

*** tv.phantombot.event.twitch ***
Added package tv.phantombot.event.twitch.user
Added class tv.phantombot.event.twitch.user.TwitchUserNameChanged with properties userID, oldName, and newName

*** UsernameCache ***
Added fields int intervalLookupMS, ScheduledThreadPoolExecutor tpExec, and Queue lookupQueue
Changed type of field cache to ConcurrentMap
Replaced deprecated call to Maps.newHashMap with diamond inference
Added overloads to method addUser
Replaced all calls to cache.put and lookupUserData with addUser
Added private method checkUserNameChanged
Changed addUser to add to the cache if all data is available
Changed addUser to enqueue usernames in lookupQueue if all data is not available

*** init.js ***
Added bind for twitchUserNameChanged

*** nameConverter.js ***
Moved name change execution logic to seperate function
Changed name change execution logic to use a transaction
Counted updating one or more quotes as +1 to number of changed tables
Updated !namechange to call the function
Added bind for twitchUserNameChanged

*** permissions.js ***
Added call to $.username.addUser to binds for ircChannelMessage, ircChannelJoin, and ircChannelUsersUpdate

*******************************

This update implements tracking of Twitch UserIDs. When a user enters the channel or gets resolved,
their information is added to the UsernameCache using IRCv3 tags, as before, if available.

If it is not available, the user is now queued to have their information looked up. This is
implemented as being done at a rate of 1 API call per second (if something is queued), to
prepare for helix rate limits. Each API call will attempt to retrieve up to 100 users.
The downside of this change is that if a user is resolved before they have been looked up, their
username will be returned instead of doing an instant lookup.

When addUser successfully detects valid data and adds the user to the cache, it calls a method
that looks up the UserID in the new userids table. If the UserID (table key) is found, it checks
the stored username (table value) against the username being cached. If they do not match, the
TwitchUserNameChangedEvent is posted to the EventBus. The stored username is inserted if it doesn't
exist or updated if it has changed.

init.js handles the event as a forced hook call, so that disabled scripts handling their own
name changes can update their tables in case they later get re-enabled.

The new overloads for addUser allow data to be inserted from existing data, or IRCv3 tags. addUser
now considers userID invalid, and therefore enqueues a user for lookup, if the userID is 0.

The changing of cache to a ConcurrentMap type is required for thread safety.

The use of a ScheduledThreadPoolExecutor is preferable to an infinite loop with Thread.sleep or a Timer.

*******************************

Here are my test screenshots showing the points table and the new userids table in the database, initialized to a before name change state.
https://1drv.ms/i/s!AqJWOcIz2x-Ugt1CW9iVoX-cqsRvDg
https://1drv.ms/i/s!AqJWOcIz2x-Ugt1DfgkFN16kcXi11A

These screenshots show the database state after starting the bot, joining chat, and saying hi (to fast-trigger the resolve).
https://1drv.ms/i/s!AqJWOcIz2x-Ugt1I6zxG3CqeZxFFAg
https://1drv.ms/i/s!AqJWOcIz2x-Ugt1JIAV9qUJvK-4zeA

And here is the database after running `!namechange gmt2001 gmt2001testing` to make sure the command still works. I left the command in for edge cases or for doing conversions while the user isn't there.
https://1drv.ms/i/s!AqJWOcIz2x-Ugt1NT5EOjCZdkhs0xw
https://1drv.ms/i/s!AqJWOcIz2x-UguJDBjNhBtg3v5YZ3A

Finally, here is a screenshot of the console, showing the bot isn't broken.
https://1drv.ms/i/s!AqJWOcIz2x-UguJRTwUN7Pi0rX7xWg

*******************************

This setup should be able to handle Helix when you later implement it. I chose my rate limit as half the authorized Helix rate limit. My proposed solution to Helix's two rate limits is to use the chat_login token if no apiOAuth token is provided to get the increased rate limit, but still disable the services that require an apiOAuth if it is not provided.