### PR TITLE
Make DataStore clsoe connections on shutdown, to commit/flush all pending operations

### DIFF
--- a/source/com/gmt2001/datastore/DataStore.java
+++ b/source/com/gmt2001/datastore/DataStore.java
@@ -354,6 +354,9 @@ public class DataStore {
     public Connection CreateConnection(String db, String user, String pass) {
         return null;
     }
+    
+    public void CloseConnection() {
+    }
 
     public void setAutoCommit(boolean mode) {
     }

--- a/source/com/gmt2001/datastore/H2Store.java
+++ b/source/com/gmt2001/datastore/H2Store.java
@@ -106,6 +106,18 @@ public class H2Store extends DataStore {
     }
 
     @Override
+    public void CloseConnection() {
+        try {
+            if (connection != null) {
+                connection.close();
+                connection = null;
+            }
+        } catch (SQLException ex) {
+            com.gmt2001.Console.err.printStackTrace(ex);
+        }
+    }
+
+    @Override
     protected void finalize() throws Throwable {
         super.finalize();
 

--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -103,6 +103,18 @@ public class MySQLStore extends DataStore {
     }
 
     @Override
+    public void CloseConnection() {
+        try {
+            if (connection != null) {
+                connection.close();
+                connection = null;
+            }
+        } catch (SQLException ex) {
+            com.gmt2001.Console.err.printStackTrace(ex);
+        }
+    }
+
+    @Override
     protected void finalize() throws Throwable {
         super.finalize();
 

--- a/source/com/gmt2001/datastore/SqliteStore.java
+++ b/source/com/gmt2001/datastore/SqliteStore.java
@@ -175,6 +175,7 @@ public class SqliteStore extends DataStore {
         return connection;
     }
 
+    @Override
     public void CloseConnection() {
         try {
             if (connection != null) {

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1180,6 +1180,9 @@ public final class PhantomBot implements Listener {
             com.gmt2001.Console.out.print("\r\n");
             com.gmt2001.Console.err.printStackTrace(ex);
         }
+        
+        print("Closing the database...");
+        dataStore.CloseConnection();
 
         com.gmt2001.Console.out.print("\r\n");
         print(this.botName + " is exiting.");

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1181,10 +1181,11 @@ public final class PhantomBot implements Listener {
             com.gmt2001.Console.err.printStackTrace(ex);
         }
         
-        print("Closing the database...");
-        dataStore.CloseConnection();
 
         com.gmt2001.Console.out.print("\r\n");
+        print("Closing the database...");
+        dataStore.CloseConnection();
+        
         print(this.botName + " is exiting.");
     }
 


### PR DESCRIPTION
*** DataStore ***
Added new method CloseConnection, no-op by default

*** MySQLStore, H2Store ***
Add @Override CloseConnection to close the connection to the database

*** SQLiteStore ***
Add @override annotation to CloseConnection

*** PhantomBot ***
Add call to DataStore.CloseConnection just before exiting

*********************

This change will allow the database driver to commit/flush all pending
operations before the bot exits. For example: SQLite is supposed
to commit all changes in the WAL to the db when the last open connection
is properly closed, and then delete the WAL/SHM files (as they are then empty).

*********************

Screenshots before change
https://1drv.ms/i/s!AqJWOcIz2x-UgudbYE_ginXvJ9OKCw
https://1drv.ms/i/s!AqJWOcIz2x-UgudcFhMAbsxNMOrxhg

Screenshots after change
https://1drv.ms/i/s!AqJWOcIz2x-Ugu0Mlm7rEREkaT4GJA
https://1drv.ms/i/s!AqJWOcIz2x-Ugu0DITllDVfZl7RLEQ

Screenshot of the bot launched again and working after the previous screenshot
https://1drv.ms/i/s!AqJWOcIz2x-Ugu0P3Cp-pE8XqaYh0w

*********************

The only thing not pictured in the screenshots is the second commit in this PR which just shuffles around the CRLF at the end of the onExit method to fix the "Closing database" message being on the same line as "Waiting for stuff to finish". I did test the bot again after doing that.