### PR TITLE
Added missing lang entries for discord customcommands

### DIFF
--- a/javascript-source/lang/english/discord/commands/commands-customCommand.js
+++ b/javascript-source/lang/english/discord/commands/commands-customCommand.js
@@ -29,3 +29,5 @@ $.lang.register('discord.customcommands.delalias.usage', 'Usage: !delalias [alia
 $.lang.register('discord.customcommands.delalias.success', 'Alias !$1 has been removed.');
 $.lang.register('discord.customcommands.404', 'That command does not exist.');
 $.lang.register('discord.customcommands.alias.404', 'That alias does not exist.');
+$.lang.register('discord.customcommands.customapi.404', 'The !$1 command requires parameters.');
+$.lang.register('discord.customcommands.customapijson.err', '!$1: An error occurred processing the API.');


### PR DESCRIPTION
I was unable to reproduce a customapi error (as it just returned null each time) so I cannot submit test cases.

This commit was based off the following bug report: https://community.phantombot.tv/t/missing-lines-in-commands-customcommand-js-for-discord/3308