### PR TITLE
Fixed errenous output on HTTP DB API getKey

### DIFF
--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -336,7 +336,7 @@ public class HTTPServerCommon {
                     jsonObject.object().key("table");
                     jsonObject.object();
                     jsonObject.key("table_name").value(dbTable);
-                    jsonObject.key("key").value(keyValue[0]);
+                    jsonObject.key("key").value(keyValue[1]);
                     jsonObject.key("value").value(dbString);
                     jsonObject.endObject();
                     jsonObject.endObject();


### PR DESCRIPTION
*** HTTPServerCommon ***
Fixed that the json property "key" was set to "getKey" instead of the actual key that was being queried.

***********************

Before
https://1drv.ms/i/s!AqJWOcIz2x-UgvNRQWsmu4Rh1IlS3Q

After
https://1drv.ms/i/s!AqJWOcIz2x-UgvkfkNrmzmgrM7JF4g