### PR TITLE
- Fixed being able to replace global Rhino vars without $

### DIFF
--- a/javascript-source/handlers/twitterHandler.js
+++ b/javascript-source/handlers/twitterHandler.js
@@ -4,7 +4,7 @@
  * Interfaces with Twitter.  Provides the connection to the Core to be provided
  * with Tweets and configuration of the module.  As the Core directly reads the
  * DB for configuration, there is not a need for local variables in this module.
- * 
+ *
  */
 
 
@@ -72,6 +72,7 @@
             twitterUserName,
             rewardNameArray = [],
             lastRetweet,
+            userName,
             reward = $.getIniDbNumber('twitter', 'reward_points'),
             cooldown = $.getIniDbFloat('twitter', 'reward_cooldown') * 3.6e6,
             now = $.systemTime();
@@ -492,7 +493,7 @@
             }
 
             /**
-             * @commandpath twitter unregister - Unregister your Twitter username 
+             * @commandpath twitter unregister - Unregister your Twitter username
              */
             if (commandArg.equalsIgnoreCase('unregister')) {
                 $.inidb.del('twitter_mapping', sender);
@@ -509,7 +510,7 @@
     function checkAutoUpdate() {
         var message = $.getIniDbString('twitter', 'message_update');
 
-        /* 
+        /*
          * If not online, nothing to do. The last_autoupdate is reset to ensure that
          * the moment a stream comes online an additional Tweet is not sent out.
          */

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -32,7 +32,7 @@ public class Script {
     public static final NativeObject global = new NativeObject();
     @SuppressWarnings("rawtypes")
     private final List<ScriptDestroyable> destroyables = Lists.newArrayList();
-    private final NativeObject vars = new NativeObject();
+    private static final NativeObject vars = new NativeObject();
     private final File file;
     private long lastModified;
     private Context context;
@@ -169,11 +169,10 @@ public class Script {
             context.setOptimizationLevel(9);
         }
 
-        scope = context.initStandardObjects(global, false);
-        scope.defineProperty("$", global, 0);
+        scope = context.initStandardObjects(vars, false);//Normal scripting object.
+        scope.defineProperty("$", global, 0);// Global functions that can only be accessed and replaced with $.
         scope.defineProperty("$api", ScriptApi.instance(), 0);
         scope.defineProperty("$script", this, 0);
-        scope.defineProperty("$var", vars, 0);
 
         /* Configure debugger. */
         if (PhantomBot.enableRhinoDebugger) {


### PR DESCRIPTION
**Script.java:**
- Global object isn't the same as the normal scripting one.

**twitterHandler.js:**
- Fixed not declaring `userName` as a var. (Thanks gmt2001)