### PR TITLE
- Fixed DB backup delete days not working

### DIFF
--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -2652,7 +2652,7 @@ public final class PhantomBot implements Listener {
                 Iterator dirIterator = FileUtils.iterateFiles(new File("./dbbackup"), new WildcardFileFilter("phantombot.auto.*"), null);
                 while (dirIterator.hasNext()) {
                     File backupFile = (File) dirIterator.next();
-                    if (FileUtils.isFileOlder(backupFile, (System.currentTimeMillis() / 1000) - (86400 * backupSQLiteKeepDays))) {
+                    if (FileUtils.isFileOlder(backupFile, (System.currentTimeMillis() - (long) (backupSQLiteKeepDays * 864e5)))) {
                         FileUtils.deleteQuietly(backupFile);
                     }
                 }


### PR DESCRIPTION
**PhantomBot.java:**
- Acording to FileUtils you need to specify the time in milliseconds for
the `isFileOlder` method, if you use seconds it will not work.