### PR TITLE
Skip Loading ._ Files at Startup

### DIFF
--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -141,6 +141,11 @@ public class Script {
             return;
         }
 
+        /* macOS user reported errors loading ._ files. Could be from text editor. */
+        if (file.getName().startsWith("._")) {
+            return;
+        }
+
         /* Enable Error() in JS to provide an object with fileName and lineNumber. */
         final ContextFactory ctxFactory = new ContextFactory() {
             @Override


### PR DESCRIPTION
**Script.java**
- Appears that a macOS editor leaves behind ._ temporary files.
- Unable to reproduce on my Mac, but I use VIM.
- Skip files that start with ._