### PR TITLE
StinkingBanana_KeywordCount_Fix

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -204,9 +204,9 @@
         }
 
         if (message.match(/\(keywordcount\s(.+)\)/g)) {
-            var input_keyword = message.match(/\(keywordcount\s(.+)\)/)[1],
+            var input_keyword = message.match(/.*\(keywordcount\s(.+)\).*/)[1],
                 keyword_info = JSON.parse($.inidb.get('keywords', input_keyword));
-        
+
             if ('count' in keyword_info) {
                 ++keyword_info["count"];
             } else {
@@ -214,7 +214,7 @@
             }
             $.inidb.set('keywords', input_keyword, JSON.stringify(keyword_info));
             
-            message = $.replace(message, message.match(/\(keywordcount\s(.+)\)/)[0], keyword_info["count"]);
+            message = $.replace(message, '(keywordcount ' + input_keyword + ')', keyword_info["count"]);
         }
 
         if (message.match(/\(random\)/g)) {

--- a/javascript-source/handlers/keywordHandler.js
+++ b/javascript-source/handlers/keywordHandler.js
@@ -56,6 +56,7 @@
                     }
                     // Keyword just has a normal response.
                     else {
+                        json.response = $.replace(json.response, '.*\(keywordcount\s(.*)\).*', '');
                         json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + json.keyword + ')');
                         $.say($.tags(event, json.response, false));
                     }
@@ -77,6 +78,7 @@
                         }
                         // Keyword just has a normal response.
                         else {
+                            json.response = $.replace(json.response, '.*\(keywordcount\s(.*)\).*', '');
                             json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + json.keyword + ')');
                             $.say($.tags(event, json.response, false));
                         }


### PR DESCRIPTION
## Summary
- Prevent user from calling (keywordcount another_keyword) to increase another keyword's count.
- Having multiple (keywordcount) in the response will work. It only increment once.

## Modification
**scripts\commands\customCommands.js**
- Modified function tags

**scripts\handlers\keywordHandler.js**
- Modified event ircChannelMessage

## Fixs
#### Prevent user from calling (keywordcount another_keyword) to increase another keyword's count.
**Keyword:** ```test1```
**Response:** ```test1 (keywordcount test4) (keywordcount test5)```
**Expected Behavior:** No keywordcounts were increased.
  
![test1](https://user-images.githubusercontent.com/842294/37501060-d57452a4-2889-11e8-92f8-5e8b5ca91e5b.gif)

**Keyword:** ```test4```
**Response:** ```test4 (keywordcount test5)```
**Keyword:** ```test5```
**Response:** ```test5 (keywordcount test4)```
**Expected Behavior:** No keywordcounts were increased.
  
![test4_5](https://user-images.githubusercontent.com/842294/37501113-0fe1fb76-288a-11e8-87a8-8cf0e078a7d2.gif)

#### Having multiple (keywordcount) in the response will work. It only increment once.
**Keyword:** ```test2```
**Response:** ```test2 (keywordcount) (keywordcount)```
**Expected Behavior:** Keywordcount only increased by one
  
![test2](https://user-images.githubusercontent.com/842294/37501678-a7822120-288c-11e8-97b3-410a19c1db1d.gif)

#### Normal Case
**Keyword:** ```test3```
**Response:** ```test3 (keywordcount)```
**Expected Behavior:** Keywordcount increased by one.
  
![test3](https://user-images.githubusercontent.com/842294/37501803-1e587cc2-288d-11e8-9f6f-98be736db3d8.gif)