### PR TITLE
Add count to commands + fixed (runcode)

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -4,7 +4,7 @@
         reCustomAPIJson = new RegExp(/\(customapijson ([\w\.:\/\$=\?\&\-]+)\s([\w\W]+)\)/), // URL[1], JSONmatch[2..n]
         reCustomAPITextTag = new RegExp(/{([\w\W]+)}/),
         reCommandTag = new RegExp(/\(command\s([\w]+)\)/),
-        tagCheck = new RegExp(/\(subscribers\)|\(age\)|\(sender\)|\(@sender\)|\(baresender\)|\(random\)|\(1\)|\(2\)|\(3\)|\(count\)|\(pointname\)|\(currenttime|\(price\)|\(#|\(uptime\)|\(follows\)|\(game\)|\(status\)|\(touser\)|\(echo\)|\(alert [,.\w]+\)|\(readfile|\(1=|\(countdown=|\(downtime\)|\(paycom\)|\(onlineonly\)|\(offlineonly\)|\(code=|\(followage\)|\(gameinfo\)|\(titleinfo\)|\(gameonly=|\(playtime\)|\(gamesplayed\)|\(pointtouser\)|\(lasttip\)|\(writefile .+\)|\(readfilerand|\(commandcostlist\)|\(playsound |\(customapi |\(customapijson /),
+        tagCheck = new RegExp(/\(subscribers\)|\(age\)|\(sender\)|\(@sender\)|\(baresender\)|\(random\)|\(1\)|\(2\)|\(3\)|\(count\)|\(pointname\)|\(currenttime|\(price\)|\(#|\(uptime\)|\(follows\)|\(game\)|\(status\)|\(touser\)|\(echo\)|\(alert [,.\w]+\)|\(readfile|\(1=|\(countdown=|\(downtime\)|\(paycom\)|\(onlineonly\)|\(offlineonly\)|\(code=|\(followage\)|\(gameinfo\)|\(titleinfo\)|\(gameonly=|\(playtime\)|\(gamesplayed\)|\(pointtouser\)|\(lasttip\)|\(writefile .+\)|\(runcode .+\)|\(readfilerand|\(commandcostlist\)|\(playsound |\(customapi |\(customapijson /),
         customCommands = [],
         ScriptEventManager = Packages.tv.phantombot.script.ScriptEventManager,
         CommandEvent = Packages.tv.phantombot.event.command.CommandEvent;

--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -4,7 +4,7 @@
         reCustomAPIJson = new RegExp(/\(customapijson ([\w\.:\/\$=\?\&\-]+)\s([\w\W]+)\)/), // URL[1], JSONmatch[2..n]
         reCustomAPITextTag = new RegExp(/{([\w\W]+)}/),
         reCommandTag = new RegExp(/\(command\s([\w]+)\)/),
-        tagCheck = new RegExp(/\(subscribers\)|\(age\)|\(sender\)|\(@sender\)|\(baresender\)|\(random\)|\(1\)|\(2\)|\(3\)|\(count\)|\(pointname\)|\(currenttime|\(price\)|\(#|\(uptime\)|\(follows\)|\(game\)|\(status\)|\(touser\)|\(echo\)|\(alert [,.\w]+\)|\(readfile|\(1=|\(countdown=|\(downtime\)|\(paycom\)|\(onlineonly\)|\(offlineonly\)|\(code=|\(followage\)|\(gameinfo\)|\(titleinfo\)|\(gameonly=|\(playtime\)|\(gamesplayed\)|\(pointtouser\)|\(lasttip\)|\(writefile .+\)|\(runcode .+\)|\(readfilerand|\(commandcostlist\)|\(playsound |\(customapi |\(customapijson /),
+        tagCheck = new RegExp(/\(subscribers\)|\(age\)|\(sender\)|\(@sender\)|\(baresender\)|\(random\)|\(1\)|\(2\)|\(3\)|\(count\)|\(pointname\)|\(points\)|\(currenttime|\(price\)|\(#|\(uptime\)|\(follows\)|\(game\)|\(status\)|\(touser\)|\(echo\)|\(alert [,.\w]+\)|\(readfile|\(1=|\(countdown=|\(downtime\)|\(paycom\)|\(onlineonly\)|\(offlineonly\)|\(code=|\(followage\)|\(gameinfo\)|\(titleinfo\)|\(gameonly=|\(useronly=|\(playtime\)|\(gamesplayed\)|\(pointtouser\)|\(lasttip\)|\(writefile .+\)|\(runcode .+\)|\(readfilerand|\(commandcostlist\)|\(playsound |\(customapi |\(customapijson /),
         customCommands = [],
         ScriptEventManager = Packages.tv.phantombot.script.ScriptEventManager,
         CommandEvent = Packages.tv.phantombot.event.command.CommandEvent;

--- a/resources/web/panel/commands.html
+++ b/resources/web/panel/commands.html
@@ -14,7 +14,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+ 
  @author IllusionaryOne
 -->
 
@@ -25,14 +25,6 @@
     <h3>Commands</h3>
     <div>
         <div id="_editCustomCommandsPanelDisabled" />
-    <div id="_editCustomCommandsPanel">
-
-        <div>
-            <button type="button" class="btn btn-primary btn-xs inline pull-right" onclick="window.open('https://community.phantombot.tv/t/command-variables')"><small>Command variables</small></button>
-            <br><br>
-        </div>
-    </div>
-
         <form role="form">
             <div class="form-group" onkeypress="return event.keyCode != 13">
                 <label for="runCustomCommand">Run a command</label>
@@ -88,6 +80,17 @@
 
         <strong>Current Command Prices</strong><br><br>
         <div id="priceCommandsList" style="height: 200px; overflow: auto;" />
+    </div>
+    </div>
+
+    <h3>Count</h3>
+    <div>
+    <div id="_commandCountersPanelDisabled" />
+    <div id="_commandCountersPanel">
+        <strong>Current Command Count</strong>
+        <br>
+        <br>
+        <div id="countCommandsList" style="height: 200px; overflow: auto;" />
     </div>
     </div>
 
@@ -170,7 +173,7 @@
                 <button type="button" class="btn btn-primary inline pull-right" onclick="$.addCooldown()">Submit</button>
                 <input type="text" class="form-control" id="cooldownCmdInputCommand" placeholder="Command name" />
                 <input type="number" min="0" class="form-control" id="cooldownCmdInput" placeholder="Seconds" />
-
+            
             <div class="checkbox pull-right">
                 <label>
                     <input type="checkbox" id="globalCooldownCheck" value="global" checked data-toggle="tooltip" title="When this is checked the cooldown will be applied to everyone

--- a/resources/web/panel/commands.html
+++ b/resources/web/panel/commands.html
@@ -25,6 +25,13 @@
     <h3>Commands</h3>
     <div>
         <div id="_editCustomCommandsPanelDisabled" />
+    <div id="_editCustomCommandsPanel">
+
+        <div>
+            <button type="button" class="btn btn-primary btn-xs inline pull-right" onclick="window.open('https://community.phantombot.tv/t/command-variables')"><small>Command variables</small></button>
+            <br><br>
+        </div>
+    </div>
         <form role="form">
             <div class="form-group" onkeypress="return event.keyCode != 13">
                 <label for="runCustomCommand">Run a command</label>

--- a/resources/web/panel/js/commandsPanel.js
+++ b/resources/web/panel/js/commandsPanel.js
@@ -217,6 +217,33 @@
                 handleInputFocus();
             }
 
+            if (panelCheckQuery(msgObject, 'commands_count')) {
+                if (msgObject['results'].length === 0) {
+                    $('#countCommandsList').html('<i>There are no commands with counters defined.</i>');
+                    return;
+                }
+                msgObject['results'].sort(sortCommandTable);
+                for (idx in msgObject['results']) {
+                    commandName = msgObject['results'][idx]['key'];
+                    commandValue = msgObject['results'][idx]['value'];
+                    html += '<tr style="textList">' +
+                        '    <td style="width: 10%">!' + commandName + '</td>' +
+                        '    <td style="vertical-align: middle">' +
+                        '        <form onkeypress="return event.keyCode != 13">' +
+                        '            <input style="width: 60%" type="text" class="input-control" id="resetCommandCount_' + commandName.replace(/[^a-zA-Z0-9_]/g, '_SP_') + '"' +
+                        '                   value="' + commandValue + '" readonly/>' +
+                        '              <button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" title="Reset Count to 0." onclick="$.resetCommandCount(\'' + commandName + '\')"><i class="fa fa-undo" /> </button> ' +
+                        '              <button type="button" class="btn btn-default btn-xs" id="deleteCommandCount_' + commandName.replace(/[^a-zA-Z0-9_]/g, '_SP_') + '" data-toggle="tooltip" title="Removes Current Counter." onclick="$.deleteCommandCount(\'' + commandName + '\')"><i class="fa fa-trash" /> </button>' +
+                        '             </form>' +
+                        '        </form>' +
+                        '    </td>' +
+                        '</tr>';
+                }
+                html += "</table>";
+                $("#countCommandsList").html(html);
+                handleInputFocus();
+            }
+
             if (panelCheckQuery(msgObject, 'commands_payment')) {
                 if (msgObject['results'].length === 0) {
                     $('#payCommandsList').html('<i>There are no commands with payments defined.</i>');
@@ -320,6 +347,7 @@
         sendDBKeys("commands_commands", "command");
         sendDBKeys("commands_aliases", "aliases");
         sendDBKeys("commands_pricecom", "pricecom");
+        sendDBKeys("commands_count", "commandCount");
         sendDBKeys("commands_payment", "paycom");
         sendDBKeys("commands_cooldown", "cooldown");
         sendDBKeys("commands_cooldownsettings", "cooldownSettings");
@@ -365,6 +393,28 @@
         setTimeout(function() { doQuery(); }, TIMEOUT_WAIT_TIME);
         setTimeout(function() { sendCommand("reloadcommand") }, TIMEOUT_WAIT_TIME);
     };
+
+    /**
+     * @function deleteCommandCount
+     * @param {String} command
+     */
+    function deleteCommandCount(command) {
+        $("#deleteCommandCount_" + command.replace(/[^a-zA-Z0-9_]/g, '_SP_')).html("<i style=\"color: var(--main-color)\" class=\"fa fa-spinner fa-spin\" />");
+        sendDBDelete("commands_delcomcount_" + command, "commandCount", command);
+        setTimeout(function () { doQuery(); }, TIMEOUT_WAIT_TIME);
+        setTimeout(function () { sendCommand("reloadcommand") }, TIMEOUT_WAIT_TIME);
+    };
+
+    /**
+    * @function resetCommandCount
+    * @param {String} command
+    */
+    function resetCommandCount(command) {
+        $('#resetCommandCount_' + command.replace(/[^a-zA-Z0-9_]/g, '_SP_')).html("<i style=\"color: var(--main-color)\" class=\"fa fa-spinner fa-spin\" />");
+        sendDBUpdate('commands_editcount_' + command, 'commandCount', command.toLowerCase(), '0');
+        setTimeout(function () { doQuery(); }, TIMEOUT_WAIT_TIME);
+        setTimeout(function () { sendCommand("reloadcommand") }, TIMEOUT_WAIT_TIME);
+    }
 
     /**
      * @function deleteCommandPay
@@ -716,6 +766,8 @@
     $.setCommandPrice = setCommandPrice;
     $.setCommandPay = setCommandPay;
     $.updateCommandPrice = updateCommandPrice;
+    $.deleteCommandCount = deleteCommandCount;
+    $.resetCommandCount = resetCommandCount;
     $.updateCommandPay = updateCommandPay;
     $.addCooldown = addCooldown;
     $.deleteCooldown = deleteCooldown;


### PR DESCRIPTION
**Changes**
* fixed (runcode ) from being ran if command has a target.
* added a list of counters to the commands panel page.


**Runecode Fix**
*before*
[03-16-2018 @ 01:52:02.244 GMT] dakoda: !test target
[03-16-2018 @ 01:52:02.246 GMT] [CHAT] target -> (runcode $.say(hi hi hi);)

*after*
[03-16-2018 @ 01:52:05.133 GMT] dakoda: !test target
[03-16-2018 @ 01:52:05.135 GMT] [CHAT] hi hi hi


**Count panel**
without any counters
![with none set](http://alixe.pro/share/img/chrome_0351374656160318.png)

list the counters
![with some set](http://alixe.pro/share/img/chrome_0350147897160318.png)

**You may delete this entire text from your Pull Request if you so desire. It is acceptable if you leave it in place as well.**
