### PR TITLE
Handle an error at shutdown if there are bad loads of scripts.

### DIFF
--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -239,6 +239,9 @@ public class Script {
     }
 
     public void kill() {
+        if (context == null) {
+            return;
+        }
         ObservingDebugger od = new ObservingDebugger();
         context.setDebugger(od, 0);
         context.setGeneratingDebug(true);


### PR DESCRIPTION
**Script.java**
- If the context object is null, do not attempt to use it.
- This can happen if the object load has gone bad at any time or if a file is rejected.