### PR TITLE
Regex Code Matters

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -400,7 +400,7 @@
             if (!$.getGame($.channelName).equalsIgnoreCase(game)) {
                 return null;
             }
-            message = $.replace(message, game, '');
+            message = $.replace(message, message.match(/(\(gameonly=.*\))/)[1], '');
         }
         
         if (message.match(/\(useronly=.*\)/g)) {
@@ -409,7 +409,7 @@
             if (!event.getSender().equalsIgnoreCase(user)) {
                 return null;
             }
-            message = $.replace(message, user, '');
+            message = $.replace(message, message.match(/(\(useronly=.*\))/)[1], '');
         }
 
         if (message.match(reCustomAPIJson) || message.match(reCustomAPI) || message.match(reCommandTag)) {


### PR DESCRIPTION
Fixed the (gameonly=) and (useronly=)

**Before**
```
[04-01-2018 @ 04:56:59.518 BST] dakoda: !test
[04-01-2018 @ 04:56:59.525 BST] [CHAT] (useronly=) this is simple
[04-01-2018 @ 04:58:17.154 BST] dakoda: !test
[04-01-2018 @ 04:58:17.156 BST] [CHAT] (gameonly=) this is simple
```

**After**
```
[04-01-2018 @ 05:02:24.954 BST] dakoda: !test
[04-01-2018 @ 05:02:24.983 BST] [CHAT]  this is simple
```

**You may delete this entire text from your Pull Request if you so desire. It is acceptable if you leave it in place as well.**
