### PR TITLE
Fix Keyword panel not reflect modified cooldown.

### DIFF
--- a/resources/web/panel/js/keywordsPanel.js
+++ b/resources/web/panel/js/keywordsPanel.js
@@ -80,8 +80,8 @@
             }
 
             if (panelCheckQuery(msgObject, 'keywords_cooldown')) {
-                for (idx in msgObject['results']) {
-                    cooldowns[msgObject['results'][idx]['key']] = msgObject['results'][idx]['value'];
+                for (idx in msgObject['results'].sort(sortKeywordsTable)) {
+                    cooldowns[idx] = msgObject['results'][idx]['value'];
                 }
                 sendDBKeys('keywords_keywords', 'keywords');
             }


### PR DESCRIPTION
# Summary
Fix Keyword panel not reflect modified cooldown

# To Reproduce
- Add a new keyword
- Edit keyword cooldown
- Check the keyword cooldown

# Explanation
Back in Ver 2.4.0.2, it was using cooldowns[keywords] to access the cooldown for each keyword.
In Ver 2.4.0.3, ```function editKeywordnew(keyword, response)``` has been changed to ```function editKeywordnew(idx)```. 
keywords, responses, isRegexs array are all using index to locate the records. cooldowns array is the only one left still using keyword to locate the records.

This fix will solve this issue.

# Result

## Before
![keyword_cooldown_1](https://user-images.githubusercontent.com/842294/38203096-e1646d16-3652-11e8-986a-3a3b76834824.gif)

## After
![keyword_cooldown_2](https://user-images.githubusercontent.com/842294/38203102-e73a4cba-3652-11e8-91b7-0a5a64eec1ec.gif)
