### PR TITLE
Inserted missing D in "customcommands.add.disable(d)" on line 12

### DIFF
--- a/javascript-source/lang/english/commands/commands-customCommands.js
+++ b/javascript-source/lang/english/commands/commands-customCommands.js
@@ -9,7 +9,7 @@ $.lang.register('customcommands.alias.delete.usage', 'Usage: !delalias (alias na
 $.lang.register('customcommands.alias.error', 'An alias already exists for !$1. Delete it first.');
 $.lang.register('customcommands.alias.error.target404', 'The target command does not exist!');
 $.lang.register('customcommands.alias.error.exists', 'The command you want to alias to already exists.');
-$.lang.register('customcommands.add.disable', 'That command is currently disabled. Re-enable the command or delete it to add a new command with that name.');
+$.lang.register('customcommands.add.disabled', 'That command is currently disabled. Re-enable the command or delete it to add a new command with that name.');
 $.lang.register('customcommands.alias.success', 'The command !$1 was successfully aliased to !$2');
 $.lang.register('customcommands.alias.usage', 'Usage: !aliascom (alias name) (existing command) [optional parameters]');
 $.lang.register('customcommands.delete.success', 'Command !$1 has been removed!');


### PR DESCRIPTION
**Please read, especially if your first time contributing to PhantomBot:**

Thank you for contributing to PhantomBot! Hopefully you followed the code style guide:
https://github.com/PhantomBot/PhantomBot/blob/master/CODESTYLE.md

If you added in code from a third party, it must have a license that is compatible with PhantomBot.  If it is not, we will reject the merge request.  The development team takes this very seriously.  If you add in access to an API and PhantomBot would use that API improperly, we will reject the merge request.  Again, the development team takes this very seriously.

You must provide test results for your change.  If test results are not provided we will do one of two things. We will ask you for test results or we will just reject the change.  Test results convince us that you performed a unit test and verified your change.

We reserve the right to reject a change for any reason at all.  Typically, we will provide a reason but if we do not, that is at our discretion.  There are some reasons for which we will reject changes, other than the ones given above (but they will be repeated):

- Code style does not match.
- Incompatible license/improper use of license of third party software/API.
- No test results.
- Potential performance issues.
- Design changes that go against the core design philosophy.
- Items with potential to spam or consume the outgoing message queue.
- Poorly architected items.
- Item is supported in chat but no update for the Control Panel.
- Any command that would violate the Twitch Terms of Service or the Terms of Service of any provider.

You are not to harass the development team if a pull request is rejected.  You may discuss and argue why you disagree with a rejection.  We do ask that you stay professional and amicable in your argument and discussion.

All pull requests will be reviewed by at least two PhantomBot developers. Please be patient while two developers take the time to do so.  We understand that this adds time to an approval, but it is to ensure that the development team is not missing anything.

**You may delete this entire text from your Pull Request if you so desire. It is acceptable if you leave it in place as well.**
