### PR TITLE
Strip Cheer Emotes from Messages

### DIFF
--- a/javascript-source/discord/handlers/bitsHandler.js
+++ b/javascript-source/discord/handlers/bitsHandler.js
@@ -77,6 +77,7 @@
         var username = event.getUsername(),
             bits = event.getBits(),
             ircMessage = event.getMessage(),
+            emoteRegexStr = $.twitch.GetCheerEmotesRegex(),
             s = message;
 
         if (announce === false || toggle === false || channelName == '') {
@@ -92,6 +93,12 @@
         }
         
         if ((ircMessage + '').length > 0) {
+            if (emoteRegexStr.length() > 0) {
+                emoteRegex = new RegExp(emoteRegexStr, 'gi');
+                ircMessage = String(ircMessage).valueOf();
+                ircMessage = ircMessage.replace(emoteRegex, '');
+            }
+
         	$.discordAPI.sendMessageEmbed(channelName, new Packages.sx.blah.discord.util.EmbedBuilder()
                     .withColor(getBitsColor(bits))
                     .withThumbnail('https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/' + getCheerAmount(bits) + '/1.gif')

--- a/javascript-source/handlers/bitsHandler.js
+++ b/javascript-source/handlers/bitsHandler.js
@@ -24,6 +24,7 @@
         var username = event.getUsername(),
             bits = event.getBits(),
             ircMessage = event.getMessage(),
+            emoteRegexStr = $.twitch.GetCheerEmotesRegex(),
             s = message;
 
         if (announceBits === false || toggle === false) {
@@ -40,11 +41,17 @@
  
         if (s.match(/\(message\)/g)) {
             s = $.replace(s, '(message)', ircMessage);
+            if (emoteRegexStr.length() > 0) {
+                emoteRegex = new RegExp(emoteRegexStr, 'gi');
+                s = String(s).valueOf();
+                s = s.replace(emoteRegex, '');
+            }
         }
 
         if (bits >= minimum) {
             $.say(s);
         }
+
         $.writeToFile(username + ' ', './addons/bitsHandler/latestCheer.txt', false);
         $.writeToFile(username + ': ' + bits + ' ', './addons/bitsHandler/latestCheer&Bits.txt', false);
     });

--- a/source/com/gmt2001/TwitchAPIv5.java
+++ b/source/com/gmt2001/TwitchAPIv5.java
@@ -49,6 +49,7 @@ public class TwitchAPIv5 {
     private static final int timeout = 2 * 1000;
     private String clientid = "";
     private String oauth = "";
+    private String cheerEmotes = "";
 
     private enum request_type {
 
@@ -512,6 +513,39 @@ public class TwitchAPIv5 {
      */
     public JSONObject GetEmotes() {
         return GetData(request_type.GET, base_url + "/chat/emoticons", false);
+    }
+
+    /**
+     * Gets the list of cheer emotes from Twitch
+     *
+     * @return
+     */
+    public JSONObject GetCheerEmotes() {
+        return GetData(request_type.GET, base_url + "/bits/actions", false);
+    }
+
+    /**
+     * Builds a RegExp String to match cheer emotes from Twitch
+     *
+     * @return
+     */
+    public String GetCheerEmotesRegex() {
+        String[] emoteList;
+        JSONObject jsonInput;
+        JSONArray jsonArray;
+
+        if (cheerEmotes == "") {
+            jsonInput = GetCheerEmotes();
+            if (jsonInput.has("actions")) {
+                jsonArray = jsonInput.getJSONArray("actions");
+                emoteList = new String[jsonArray.length()];
+                for (int idx = 0; idx < jsonArray.length(); idx++) {
+                    emoteList[idx] = "\\b" + jsonArray.getJSONObject(idx).getString("prefix") + "\\d+\\b";
+                }
+                cheerEmotes = String.join("|", emoteList);
+            }
+        }
+        return cheerEmotes;
     }
 
     /**


### PR DESCRIPTION
**bitsHandler.js**
- Use the strip regexp to remove any cheer emotes from (message)

**discord/bitsHandler.js**
- Use the strip regexp to remove any cheer emotes from embed

**TwitchAPIv5.java**
- Provide a method for getting the cheer emote from Twitch
- Creates a regexp String
- Will only run ONCE during bot runtime, MUST reboot if need to cover new emotes