### PR TITLE
added some bots

### DIFF
--- a/resources/addons/ignorebots.txt
+++ b/resources/addons/ignorebots.txt
@@ -12,3 +12,6 @@ curseappbot
 revlobot
 muxybot
 faegwent
+electricalskateboard
+electricallongboard
+streamelements


### PR DESCRIPTION
Electricalskateboard and electricallongboard are host raffle bots and streamelements is the bot of the donation service with the same name.

