### PR TITLE
Changed outgoing raid to use native Twitch raid

### DIFF
--- a/javascript-source/systems/raidSystem.js
+++ b/javascript-source/systems/raidSystem.js
@@ -26,7 +26,8 @@
             }
 
             $.inidb.incr('outgoingRaids', username, 1);
-            $.say($.lang.get('raidsystem.raid', $.username.resolve(username), $.getIniDbString('settings', 'raidMessage', '')));
+            $.say('/raid ' + $.user.sanitize(username + ''));
+            $.say($.getIniDbString('settings', 'raidMessage', ''));
         }
 
         /**


### PR DESCRIPTION
Twitch has had native raiding functionality for awhile and this leverages this instead of the faux system

**raidSystem.js**
- Uses twitch raid in place of linking
- Still supports raid message by placing it after the raid
