### PR TITLE
Updated Botlist (again)

### DIFF
--- a/resources/addons/ignorebots.txt
+++ b/resources/addons/ignorebots.txt
@@ -12,3 +12,6 @@ curseappbot
 revlobot
 muxybot
 faegwent
+electricalskateboard
+electricallongboard
+streamelements

--- a/resources/addons/ignorebots.txt
+++ b/resources/addons/ignorebots.txt
@@ -15,3 +15,4 @@ faegwent
 electricalskateboard
 electricallongboard
 streamelements
+stay_hydrated_bot


### PR DESCRIPTION
**Addet the Following Bots. this time with a description what they do**

- **electricalskateboard**

> A Twitch bot that does Host Raffles. is in many channels and actually writes nothing, only monitors if stream is live

- **electricallongboard**

> A Twitch bot that does Host Raffles. is in many channels and actually writes nothing, only monitors if stream is live

- **Streamelements**

> the official bot of the Donation & Alert service with the same name. 

- **Stay_Hydrated_Bot**

> A little friendly bot that reminds you to Drink enough