### PR TITLE
Updated ignorebots.txt with aditional bots

### DIFF
--- a/resources/addons/ignorebots.txt
+++ b/resources/addons/ignorebots.txt
@@ -12,3 +12,8 @@ curseappbot
 revlobot
 muxybot
 faegwent
+electricalskateboard
+electricallongboard
+streamelements
+stay_hydrated_bot
+fatmanleg


### PR DESCRIPTION
**Addet the Following Bots. this time with a description what they do**
i don't know what tests you want so if you need anything just message me!

_The other pull-requests can be closed, that one here is up-to-date_

- **electricalskateboard**

> A Twitch bot that does Host Raffles. is in many channels and actually writes nothing, only monitors if stream is live

- **fatmanleg**

> A Twitch bot that does Host Raffles. is in many channels and actually writes nothing, only monitors if stream is live

- **electricallongboard**

> A Twitch bot that does Host Raffles. is in many channels and actually writes nothing, only monitors if stream is live

- **Streamelements**

> the official bot of the Donation & Alert service with the same name. 

- **Stay_Hydrated_Bot**

> A little friendly bot that reminds you to Drink enough