### PR TITLE
Fix Issue in Notices when Removing Several Messages

### DIFF
--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -41,6 +41,9 @@
             }
 
             numberOfNotices = $.inidb.GetKeyList('notices', '').length;
+            if (RandomNotice >= numberOfNotices) {
+                RandomNotice = 0;
+            }
             isReloading = false;
         }
     };


### PR DESCRIPTION
**noticeSystem.js**
- Reset RandomNotice to 0 in reloadNotices() when it is above the new largest value.