### PR TITLE
Fix Discord Cheer Message

### DIFF
--- a/javascript-source/discord/handlers/bitsHandler.js
+++ b/javascript-source/discord/handlers/bitsHandler.js
@@ -98,7 +98,9 @@
                 ircMessage = String(ircMessage).valueOf();
                 ircMessage = ircMessage.replace(emoteRegex, '');
             }
+        }
 
+        if (ircMessage.length > 0) { 
         	$.discordAPI.sendMessageEmbed(channelName, new Packages.sx.blah.discord.util.EmbedBuilder()
                     .withColor(getBitsColor(bits))
                     .withThumbnail('https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/' + getCheerAmount(bits) + '/1.gif')

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1569,7 +1569,7 @@ public final class PhantomBot implements Listener {
 
         /* test the bits event */
         if (message.equalsIgnoreCase("bitstest")) {
-            String sendMessage = "This is a message from Twitch.";
+            String sendMessage = "";
             if (argument != null) {
                 sendMessage = String.join(" ", argument);
             }


### PR DESCRIPTION
**bitsHandler.js**
- Check the length of the modified IRC Message to not send an empty string to the Discord embed.

**PhantomBot.java**
- Changed bitstest command