### PR TITLE
Fix Multiple Cheers-Only (No Message) Discord Bits Handler

### DIFF
--- a/javascript-source/discord/handlers/bitsHandler.js
+++ b/javascript-source/discord/handlers/bitsHandler.js
@@ -92,11 +92,11 @@
             s = $.replace(s, '(amount)', bits);
         }
 
-        if ((ircMessage + '').length > 1) {
+        if ((ircMessage + '').length > 0) {
             if (emoteRegexStr.length() > 0) {
                 emoteRegex = new RegExp(emoteRegexStr, 'gi');
                 ircMessage = String(ircMessage).valueOf();
-                ircMessage = ircMessage.replace(emoteRegex, '');
+                ircMessage = ircMessage.replace(emoteRegex, '').trim();
             }
         }
 


### PR DESCRIPTION
**bitsHandler.js**
- One more patch to follow PR 1999.  Now trim the string (wipe out spaces) and then the check for an empty string is happy.