### PR TITLE
- Fixed action mode breaking Twitch commands and raid handler features

### DIFF
--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -135,14 +135,21 @@
             return;
         }
 
-        if (respond && (!action || message.startsWith('/w'))) {
+        if (respond && !action) {
             $.session.say(message);
         } else {
             if (respond && action) {
-                $.session.say('/me ' + message);
+                // If the message is a Twitch command, remove the /me.
+                if (message.startsWith('.') || message.startsWith('/')) {
+                    $.session.say(message);
+                } else {
+                    $.session.say('/me ' + message);
+                }
             }
             if (!respond) {
                 $.consoleLn('[MUTED] ' + message);
+                $.log.file('chat', '[MUTED] ' + $.botName.toLowerCase() + ': ' + message);
+                return;
             }
         }
         $.log.file('chat', '' + $.botName.toLowerCase() + ': ' + message);
@@ -161,17 +168,7 @@
 
         timeout = systemTime();
 
-        if (respond && (!action || message.startsWith('/w'))) {
-            $.session.say(message);
-        } else {
-            if (respond && action) {
-                $.session.say('/me ' + message);
-            }
-            if (!respond) {
-                $.consoleLn('[MUTED] ' + message);
-            }
-        }
-        $.log.file('chat', '' + $.botName.toLowerCase() + ': ' + message);
+        say(message);
     }
 
     /**

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -794,6 +794,9 @@
 
         $.inidb.del('modules', './systems/raidSystem.js');
 
+        // Remove old raids for the new format.
+        $.inidb.RemoveFile('outgoing_raids');
+
         $.consoleLn('PhantomBot update 2.4.1 completed!');
         $.inidb.set('updates', 'installedv2.4.1', 'true');
     }

--- a/javascript-source/handlers/raidHandler.js
+++ b/javascript-source/handlers/raidHandler.js
@@ -30,7 +30,7 @@
         if (raidObj.hasOwnProperty('totalRaids')) {
             // Increase total raids.
             raidObj.totalRaids = parseInt(raidObj.totalRaids) + 1;
-            // Increase total viewers.
+            // Increase total viewers which the user has raided for in total (all time).
             raidObj.totalViewers = (parseInt(raidObj.totalViewers) + parseInt(viewers));
             // Update last raid time.
             raidObj.lastRaidTime = $.systemTime();
@@ -66,6 +66,36 @@
     }
 
     /*
+     * @function Saves the outgoing raid for the user or adds it to the list.
+     *
+     * @param {String} username
+     * @param {String} viewers
+     */
+    function saveOutRaidForUsername(username, viewers) {
+    	var raidObj = JSON.parse($.getIniDbString('outgoing_raids', username, '{}'));
+
+    	if (raidObj.hasOwnProperty('totalRaids')) {
+    		// Increase total raids.
+            raidObj.totalRaids = parseInt(raidObj.totalRaids) + 1;
+            // Increase total viewers which the channel has raided the other channel for (all time).
+            raidObj.totalViewers = (parseInt(raidObj.totalViewers) + parseInt(viewers));
+            // Update last raid time.
+            raidObj.lastRaidTime = $.systemTime();
+            // Last raid viewers.
+            raidObj.lastRaidViewers = viewers;
+        } else {
+        	// Increase total raids.
+            raidObj.totalRaids = '1';
+            // Increase total viewers.
+            raidObj.totalViewers = viewers;
+            // Update last raid time.
+            raidObj.lastRaidTime = $.systemTime();
+            // Last raid viewers.
+            raidObj.lastRaidViewers = viewers;
+        }
+    }
+
+    /*
      * @function Handles sending the messages in chat for outgoing raids.
      *
      * @param {String} username
@@ -90,7 +120,7 @@
         // Use the .raid command.
         $.say('.raid ' + username);
         // Increase out going raids.
-        $.inidb.incr('outgoing_raids', username, 1);
+        saveOutRaidForUsername(username + '', $.getViewers($.channelName) + '');
     }
 
     /*


### PR DESCRIPTION
**raidHandler.js:**
- Added a proper way to track outgoing raids for the new panel.

**misc.js:**
- Action (/me) mode will no longer break Twitch commands.

**updates.js:**
- Removed outgoing_raids table for the new method of saving raids.