### PR TITLE
Support Creative Commons Only Mode in YTP and Provide Method to Clear YTP ID Cache

### DIFF
--- a/javascript-source/lang/english/systems/systems-youtubeplayer.js
+++ b/javascript-source/lang/english/systems/systems-youtubeplayer.js
@@ -11,8 +11,15 @@ $.lang.register('ytplayer.songrequests.disabled', '[\u266B] Song requests have b
 $.lang.register('ytplayer.command.volume.get', 'Current YouTube Player Volume: $1');
 $.lang.register('ytplayer.command.volume.set', 'Set YouTube Player Volume: $1');
 
+$.lang.register('ytplayer.command.ytp.resetdefaultlist.active', 'This must be ran when the YouTube Player is not connected.');
+$.lang.register('ytplayer.command.ytp.resetdefaultlist.success', 'The default playlist has been reset.');
+
+$.lang.register('ytplayer.command.ytp.togglecconly.enable', 'YouTube Player will only play Creative Commons licensed songs.');
+$.lang.register('ytplayer.command.ytp.togglecconly.disable', 'YouTube Player will play all licensed songs.');
+
 $.lang.register('ytplayer.command.ytp.togglestealrefund.enable', 'YouTube Player stolen songs will be refunded to users.');
 $.lang.register('ytplayer.command.ytp.togglestealrefund.disable', 'YouTube Player stolen songs will NOT be refunded to users.');
+
 $.lang.register('ytplayer.command.ytp.togglerandom.toggled', 'YouTube Player Playlist Randomization has been $1');
 $.lang.register('ytplayer.command.ytp.toggleannounce.toggled', 'YouTube Player Announcements have been $1');
 
@@ -63,7 +70,10 @@ $.lang.register('ytplayer.command.delrequest.success', 'Removed song with ID [$1
 $.lang.register('ytplayer.command.delrequest.404', 'Song requests do not have a song with an ID of [$1]');
 $.lang.register('ytplayer.command.delrequest.usage', 'Usage: !ytp delrequest [YouTube ID]');
 
-$.lang.register('ytplayer.command.ytp.usage', 'Usage: !ytp [togglesongrequest | toggleannounce | delrequest | pause | volume | togglerandom | setrequestmax | setmaxvidlength | votecount]');
+$.lang.register('ytplayer.command.ytp.clearcache.warning', 'This will remove all cached YouTube Player IDs. If you are sure, run !ytp clearcache now');
+$.lang.register('ytplayer.command.ytp.clearcache.success', 'YouTube Player ID cache has been cleared.');
+
+$.lang.register('ytplayer.command.ytp.usage', 'Usage: !ytp [togglecconly | togglesongrequest | toggleannounce | delrequest | pause | volume | togglerandom | setrequestmax | setmaxvidlength | votecount | resetdefaultlist | clearcache]');
 
 $.lang.register('ytplayer.command.wrongsong.success', 'Removed last requested song: [$1]');
 $.lang.register('ytplayer.command.wrongsong.404', 'No songs found');

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -15,6 +15,7 @@
         songRequestsMaxSecondsforVideo = $.getSetIniDbNumber('ytSettings', 'songRequestsMaxSecondsforVideo', (8 * 60)),
         stealRefund = $.getSetIniDbBoolean('ytSettings', 'stealRefund', false),
         voteCount = $.getSetIniDbNumber('ytSettings', 'voteCount', 0),
+        playCCOnly = $.getSetIniDbBoolean('ytSettings', 'playCCOnly', false),
         voteArray = [],
         skipCount,
         lastSkipTime = 0,
@@ -47,6 +48,7 @@
         announceInChat = $.getIniDbBoolean('ytSettings', 'announceInChat');
         stealRefund = $.getIniDbBoolean('ytSettings', 'stealRefund', false);
         voteCount = $.getIniDbNumber('ytSettings', 'voteCount', 0);
+        playCCOnly = $.getIniDbBoolean('ytSettings', 'playCCOnly', false);
     };
 
     /**
@@ -64,6 +66,17 @@
     }
 
     /**
+     * @function createDefaultPl
+     */
+    function createDefaultPl() {
+        $.inidb.set('ytPlaylist_default', '1', 'vY_kyk8yL9U');
+        $.inidb.set('ytPlaylist_default', '2', 'q_Wk_dn-jEg');
+        $.inidb.set('ytPlaylist_default', '3', '5WRZ-bC5XzE');
+        $.inidb.set('ytPlaylist_default', '4', '9Y5CCHacHfk');
+        $.inidb.set('ytPlaylist_default', 'lastkey', '4');
+    }
+
+    /**
      * @function loadDefaultPl
      */
     function loadDefaultPl() {
@@ -72,23 +85,30 @@
             currentPlaylist = new BotPlayList(activePlaylistname, true);
             /** if the current playlist is "default" and it's empty, add some default songs. */
             if (currentPlaylist.getPlaylistname().equals('default') && currentPlaylist.getplaylistLength() == 0) {
-                /** CyberPosix - Under The Influence (Outertone Free Release) */
+                /** whatfunk - Waves FREE CC0 No Copyright Royalty Free Music */
                 try {
-                    currentPlaylist.addToPlaylist(new YoutubeVideo('gotxnim9h8w', $.botName));
+                    currentPlaylist.addToPlaylist(new YoutubeVideo('vY_kyk8yL9U', $.botName));
                 } catch (ex) {
                     $.log.error("YoutubeVideo::exception: " + ex);
                 }
 
-                /** Different Heaven & Eh!de - My Heart (Outertone 001 - Zero Release) */
+                /** CYAN!DE - Scorpion FREE Electro House Music For Monetize */
                 try {
-                    currentPlaylist.addToPlaylist(new YoutubeVideo('WFqO9DoZZjA', $.botName));
+                    currentPlaylist.addToPlaylist(new YoutubeVideo('q_Wk_dn-jEg', $.botName));
                 } catch (ex) {
                     $.log.error("YoutubeVideo::exception: " + ex);
                 }
 
-                /** Tobu - Higher (Outertone Release) */
+                /** SmaXa - We're Coming In FREE Creative Commons Music */
                 try {
-                    currentPlaylist.addToPlaylist(new YoutubeVideo('l7C29RM1UmU', $.botName))
+                    currentPlaylist.addToPlaylist(new YoutubeVideo('5WRZ-bC5XzE', $.botName))
+                } catch (ex) {
+                    $.log.error("YoutubeVideo::exception: " + ex);
+                }
+
+                /** Static Love - Choices FREE Pop Music for Monetize */
+                try {
+                    currentPlaylist.addToPlaylist(new YoutubeVideo('9Y5CCHacHfk', $.botName))
                 } catch (ex) {
                     $.log.error("YoutubeVideo::exception: " + ex);
                 }
@@ -107,7 +127,9 @@
     function YoutubeVideo(searchQuery, owner) {
         var videoId = '',
             videoTitle = '',
-            videoLength = -1;
+            videoLength = -1,
+            license = 0,
+            embeddable = 0;
 
         this.found = false;
 
@@ -153,6 +175,16 @@
         };
 
         /**
+         * @function getVideoInfo
+         * Sets the member values for embeddable and license.
+         */
+        this.getVideoInfo = function() {
+            var videoInfo = $.youtube.GetVideoInfo(videoId);
+            license = videoInfo[0];
+            embeddable = videoInfo[1];
+        }
+
+        /**
          * @function getVideoLengthMMSS
          * @returns {String}
          */
@@ -191,6 +223,8 @@
         if (!searchQuery) {
             throw "No Search Query Given";
         }
+
+        searchQuery = searchQuery.trim();
 
         if (!owner.equals(playlistDJname)) {
             owner = owner.toLowerCase();
@@ -249,6 +283,14 @@
             jsonData["time"] = videoLength;
             var jsonString = JSON.stringify(jsonData);
             $.inidb.set('ytcache', videoId, jsonString);
+        }
+
+        this.getVideoInfo();
+        if (license == 0 && playCCOnly) {
+            throw 'Video is not licensed as Creative Commons (ID: ' + videoId + ')';
+        }
+        if (embeddable == 0) {
+            throw 'This video is not allowed to be embedded (ID: ' + videoId + ')';
         }
 
         /** END CONTRUCTOR YoutubeVideo() */
@@ -658,26 +700,31 @@
                 return null;
             }
 
-            previousVideo = currentVideo;
+            exception = true;
+            while (exception) {
+                previousVideo = currentVideo;
 
-            if (!requests.isEmpty()) {
-                currentVideo = requests.poll();
-            } else {
-                if (defaultPlaylist.length == 0) {
-                    if (this.loadPlaylistKeys() == 0) {
-                        return null;
+                if (!requests.isEmpty()) {
+                    currentVideo = requests.poll();
+                    exception = false;
+                } else {
+                    if (defaultPlaylist.length == 0) {
+                        if (this.loadPlaylistKeys() == 0) {
+                            return new YoutubeVideo('7lO1iBF0p_0', playlistDJname);
+                        }
+                        return new YoutubeVideo('7lO1iBF0p_0', playlistDJname);
                     }
-                    return null;
+    
+                    try {
+                        var playListIndex = defaultPlaylist.shift();
+                        currentVideo = new YoutubeVideo($.inidb.get(playListDbId, playListIndex), playlistDJname);
+                        exception = false
+                    } catch (ex) {
+                        $.log.error("YoutubeVideo::exception: " + ex);
+                        exception = true;
+                    }
+    
                 }
-
-                try {
-                    var playListIndex = defaultPlaylist.shift();
-                    currentVideo = new YoutubeVideo($.inidb.get(playListDbId, playListIndex), playlistDJname);
-                } catch (ex) {
-                    $.log.error("YoutubeVideo::exception: " + ex);
-                    this.nextVideo();
-                }
-
             }
 
             connectedPlayerClient.play(currentVideo);
@@ -1279,6 +1326,53 @@
 
             if (!action) {
                 $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.usage'));
+                return;
+            }
+
+            /**
+             * @commandpath ytp clearcache now - Clears the cache of YouTube IDs from the database.
+             */
+            if (action.equalsIgnoreCase('clearcache')) {
+                if (args.length < 2) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.clearcache.warning'));
+                } else {
+                    if (actionArgs[0].equalsIgnoreCase('now')) {
+                        $.inidb.RemoveFile('ytcache');
+                        $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.clearcache.success'));
+                    } else {
+                        $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.clearcache.warning'));
+                    }
+                }
+                return;
+            }
+            
+            /**
+             * @commandpath ytp resetdefaultlist - Resets the default playlist back to the default songs.
+             */
+            if (action.equalsIgnoreCase('resetdefaultlist')) {
+                if (connectedPlayerClient) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.resetdefaultlist.active'));
+                    return;
+                }
+                $.inidb.RemoveFile('ytPlaylist_default');
+                createDefaultPl();
+                $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.resetdefaultlist.success'));
+                return;
+            }
+
+            /**
+             * @commandpath ytp togglecconly - Toggle option to only use Creative Commons licensed songs.
+             */
+            if (action.equalsIgnoreCase('togglecconly')) {
+                if ($.getIniDbBoolean('ytSettings', 'playCCOnly')) {
+                    playCCOnly = false;
+                    $.setIniDbBoolean('ytSettings', 'playCCOnly', false);
+                    $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.togglecconly.disable'));
+                } else {
+                    playCCOnly = true;
+                    $.setIniDbBoolean('ytSettings', 'playCCOnly', true);
+                    $.say($.whisperPrefix(sender) + $.lang.get('ytplayer.command.ytp.togglecconly.enable'));
+                }
                 return;
             }
 

--- a/source/com/gmt2001/YouTubeAPIv3.java
+++ b/source/com/gmt2001/YouTubeAPIv3.java
@@ -451,6 +451,30 @@ public class YouTubeAPIv3 {
                };
     }
 
+    public int[] GetVideoInfo(String id) {
+        int licenseRetval = 0;
+        int embedRetval = 0;
+
+        JSONObject jsonObject = GetData(request_type.GET, "https://www.googleapis.com/youtube/v3/videos?id=" + id + "&key=" + apikey + "&part=status");
+
+        if (jsonObject.getBoolean("_success")) {
+            if (jsonObject.getInt("_http") == 200) {
+                JSONArray items = jsonObject.getJSONArray("items");
+                if (items.length() > 0) {
+                    JSONObject item = items.getJSONObject(0);
+                    JSONObject status = item.getJSONObject("status");
+
+                    String license = status.getString("license");
+                    boolean embeddable = status.getBoolean("embeddable");
+
+                    licenseRetval = license.equals("creativeCommon") ? 1 : 0;
+                    embedRetval = embeddable == true ? 1 : 0;
+                }
+            }
+        }
+        return new int[] { licenseRetval, embedRetval };
+    }
+
     public int max() {
         return Integer.parseInt(simpleScramble.simpleFixedUnscramble("FHgb"));
     }


### PR DESCRIPTION
**systems-youtubeplayer.js**
- Language updates for new commands.

**youtubePlayer.js**
- The embed and license flags are now checked.
- If Creative Common only mode is enabled then only videos licensed as Creative Commons will play.
- To toggle: !ytp togglecconly
- Provide new command to wipe YTP cache database: !ytp clearcache
- Provide command to reset the default playlist with Creative Commons music: !ytp resetdefaultlist
- The above should be done if switching to Creative Commons only mode.
- Potential bug fix around song requests, trim() the query string.  Was finding issues with some requests with this.

**YouTubeAPIv3.java**
- Perform new lookup to check the license and embed status of a video.