### PR TITLE
Ensure that Gift Subscription Months returns non-null value

### DIFF
--- a/source/tv/phantombot/event/twitch/subscriber/TwitchSubscriptionGiftEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchSubscriptionGiftEvent.java
@@ -77,7 +77,7 @@ public class TwitchSubscriptionGiftEvent extends TwitchEvent {
      * @return {String} months
      */
     public String getMonths() {
-        return this.months;
+        return (this.months == null) ? "1" : this.months;
     }
 
     /*


### PR DESCRIPTION
**TwitchSubscriptionGiftEvent.java**
- Twitch indicates that a gift subscription does not return a months value, even though an example shows that it does:
	> msg-param-months:	(Sent only on sub or resub) The number of consecutive months the user has subscribed for, in a resub notice.
- Someone reported an 'empty string' on JSON message during a Gift Subscription, assuming this is the culprit.  Fairly confident that Twitch returned a sender and a recipient.
- If months is null from the tag, just return '1'