### PR TITLE
Add a Discord audit log for custom commands.

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -1197,9 +1197,9 @@
             if (args.length === 1) {
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.reset.success', action));
                 $.logCustomCommand({
-                  'reset.command': '!' + action,
-                  'reset.count': 0,
-                  'sender': sender,
+                    'reset.command': '!' + action,
+                    'reset.count': 0,
+                    'sender': sender,
                 });
                 $.inidb.del('commandCount', action);
             } else {

--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -23,7 +23,6 @@
         reCommandTag = new RegExp(/\(command\s([\w]+)\)/),
         tagCheck = new RegExp(/\(views\)|\(subscribers\)|\(age\)|\(sender\)|\(@sender\)|\(baresender\)|\(random\)|\(1\)|\(2\)|\(3\)|\(count\)|\(pointname\)|\(points\)|\(currenttime|\(price\)|\(#|\(uptime\)|\(follows\)|\(game\)|\(status\)|\(touser\)|\(echo\)|\(alert [,.\w]+\)|\(readfile|\(1=|\(countdown=|\(countup=|\(downtime\)|\(paycom\)|\(onlineonly\)|\(offlineonly\)|\(code=|\(followage\)|\(gameinfo\)|\(titleinfo\)|\(gameonly=|\(useronly=|\(playtime\)|\(gamesplayed\)|\(pointtouser\)|\(lasttip\)|\(writefile .+\)|\(runcode .+\)|\(readfilerand|\(commandcostlist\)|\(playsound |\(customapi |\(customapijson /),
         customCommands = [],
-        customCommandLogs = $.getSetIniDbBoolean('discordSettings', 'customCommandLogs', false),
         ScriptEventManager = Packages.tv.phantombot.script.ScriptEventManager,
         CommandEvent = Packages.tv.phantombot.event.command.CommandEvent;
 
@@ -701,21 +700,6 @@
     }
 
     /*
-     * @function logIfEnabled
-     *
-     * @param {object} info
-     */
-    function logIfEnabled(info) {
-        if (!$.getIniDbBoolean('discordSettings', 'customCommandLogs', false)) return;
-        var channel = $.getIniDbString('discordSettings', 'modLogChannel');
-        if (!channel) return;
-        var message = Object.keys(info)
-            .map(function(key) { return '**' + key + '**: ' + info[key]; })
-            .join('\r\n\r\n');
-        $.discordAPI.sendMessageEmbed(channel, 'blue', message);
-    }
-
-    /*
      * @event command
      */
     $.bind('command', function(event) {
@@ -768,10 +752,10 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.add.success', action));
-            logIfEnabled({
-                'Custom command created': '!' + action,
-                'Response': argsString,
-                'By': sender,
+            $.logCustomCommand({
+                'add.command': '!' + action,
+                'add.response': argsString,
+                'sender': sender,
             });
             $.registerChatCommand('./commands/customCommands.js', action);
             $.inidb.set('command', action, argsString);
@@ -805,10 +789,10 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.edit.success', action));
-            logIfEnabled({
-                'Custom command edited': '!' + action,
-                'New response': argsString,
-                'By': sender,
+            $.logCustomCommand({
+                'edit.command': '!' + action,
+                'edit.response': argsString,
+                'sender': sender,
             });
             $.registerChatCommand('./commands/customCommands.js', action, 7);
             $.inidb.set('command', action, argsString);
@@ -833,9 +817,9 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.delete.success', action));
-            logIfEnabled({
-                'Custom command deleted': '!' + action,
-                'By': sender,
+            $.logCustomCommand({
+                'delete.command': '!' + action,
+                'sender': sender,
             });
             $.inidb.del('command', action);
             $.inidb.del('permcom', action);
@@ -870,10 +854,10 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.alias.success', subAction, action));
-            logIfEnabled({
-                'Custom alias created': '!' + action,
-                'To': '!' + subAction,
-                'By': sender,
+            $.logCustomCommand({
+                'alias.command': '!' + action,
+                'alias.target': '!' + subAction,
+                'sender': sender,
             });
             $.registerChatCommand('./commands/customCommands.js', action);
             $.inidb.set('aliases', action, subAction);
@@ -898,9 +882,9 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.alias.delete.success', action));
-            logIfEnabled({
-                'Custom alias deleted': '!' + action,
-                'By': sender,
+            $.logCustomCommand({
+                'alias.delete.command': '!' + action,
+                'sender': sender,
             });
             $.unregisterChatCommand(action);
             $.inidb.del('aliases', action);
@@ -930,10 +914,10 @@
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.set.perm.success', action, $.getGroupNameById(group)));
-                logIfEnabled({
-                    'Command permissions updated': '!' + action,
-                    'To': $.getGroupNameById(group),
-                    'By': sender,
+                $.logCustomCommand({
+                    'set.perm.command': '!' + action,
+                    'set.perm.group': $.getGroupNameById(group),
+                    'sender': sender,
                 });
 
                 var list = $.inidb.GetKeyList('aliases', ''),
@@ -959,10 +943,10 @@
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.set.perm.success', action + ' ' + subAction, $.getGroupNameById(group)));
-                logIfEnabled({
-                    'Command permissions updated': '!' + action + ' ' + subAction,
-                    'To': $.getGroupNameById(group),
-                    'By': sender,
+                $.logCustomCommand({
+                    'set.perm.command': '!' + action + ' ' + subAction,
+                    'set.perm.group': $.getGroupNameById(group),
+                    'sender': sender,
                 });
                 $.inidb.set('permcom', action + ' ' + subAction, group);
                 $.updateSubcommandGroup(action, subAction, group);
@@ -993,10 +977,10 @@
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.set.price.success', action, subAction, $.pointNameMultiple));
-                logIfEnabled({
-                    'Command price updated': '!' + action,
-                    'New price': subAction,
-                    'By': sender,
+                $.logCustomCommand({
+                    'set.price.command': '!' + action,
+                    'set.price.amount': subAction,
+                    'sender': sender,
                 });
                 $.inidb.set('pricecom', action, subAction);
 
@@ -1018,10 +1002,10 @@
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.set.price.success', action + ' ' + subAction, args[2], $.pointNameMultiple));
-                logIfEnabled({
-                    'Command price updated': '!' + action + ' ' + subAction,
-                    'New price': args[2],
-                    'By': sender,
+                $.logCustomCommand({
+                    'set.price.command': '!' + action + ' ' + subAction,
+                    'set.price.amount': args[2],
+                    'sender': sender,
                 });
                 $.inidb.set('pricecom', action + ' ' + subAction, args[2]);
             } else {
@@ -1032,10 +1016,10 @@
                     }
 
                     $.say($.whisperPrefix(sender) + $.lang.get('customcommands.set.price.success', action + ' ' + subAction + ' ' + args[2], args[3], $.pointNameMultiple));
-                    logIfEnabled({
-                        'Command price updated': '!' + action + ' ' + subAction + ' ' + args[2],
-                        'New price': args[3],
-                        'By': sender,
+                    $.logCustomCommand({
+                        'set.price.command': '!' + action + ' ' + subAction + ' ' + args[2],
+                        'set.price.amount': args[3],
+                        'sender': sender,
                     });
                     $.inidb.set('pricecom', action + ' ' + subAction + ' ' + args[2], args[3]);
                 }
@@ -1063,10 +1047,10 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.set.pay.success', action, subAction, $.pointNameMultiple));
-            logIfEnabled({
-                'Command reward updated': '!' + action,
-                'New reward': subAction,
-                'By': sender,
+            $.logCustomCommand({
+                'set.pay.command': '!' + action,
+                'set.pay.amount': subAction,
+                'sender': sender,
             });
             $.inidb.set('paycom', action, subAction);
 
@@ -1164,9 +1148,9 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.disable.success', action));
-            logIfEnabled({
-                'Command disabled': '!' + action,
-                'By': sender,
+            $.logCustomCommand({
+                'disable.command': '!' + action,
+                'sender': sender,
             });
             $.inidb.set('disabledCommands', action, true);
             $.tempUnRegisterChatCommand(action);
@@ -1190,9 +1174,9 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('customcommands.enable.success', action));
-            logIfEnabled({
-                'Command enabled': '!' + action,
-                'By': sender,
+            $.logCustomCommand({
+                'enable.command': '!' + action,
+                'sender': sender,
             });
             $.inidb.del('disabledCommands', action);
             $.registerChatCommand(($.inidb.exists('tempDisabledCommandScript', action) ? $.inidb.get('tempDisabledCommandScript', action) : './commands/customCommands.js'), action);
@@ -1212,10 +1196,10 @@
 
             if (args.length === 1) {
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.reset.success', action));
-                logIfEnabled({
-                  'Command counter reset': '!' + action,
-                  'New value': 0,
-                  'By': sender,
+                $.logCustomCommand({
+                  'reset.command': '!' + action,
+                  'reset.count': 0,
+                  'sender': sender,
                 });
                 $.inidb.del('commandCount', action);
             } else {
@@ -1224,10 +1208,10 @@
                 } else {
                     $.inidb.set('commandCount', action, subAction);
                     $.say($.whisperPrefix(sender) + $.lang.get('customcommands.reset.change.success', action, subAction));
-                    logIfEnabled({
-                        'Command counter reset': '!' + action,
-                        'New value': subAction,
-                        'By': sender,
+                    $.logCustomCommand({
+                        'reset.command': '!' + action,
+                        'reset.count': subAction,
+                        'sender': sender,
                     });
                 }
             }

--- a/javascript-source/discord/systems/customCommandLogs.js
+++ b/javascript-source/discord/systems/customCommandLogs.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2018 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(function() {
+    var enabled = $.getSetIniDbBoolean('discordSettings', 'customCommandLogs', false),
+        channel = $.getSetIniDbString('discordSettings', 'modLogChannel', '');
+
+    /*
+     * @event webPanelSocketUpdate
+     */
+    $.bind('webPanelSocketUpdate', function(event) {
+        if (event.getScript().equalsIgnoreCase('./discord/systems/customCommandLogs.js')) {
+            enabled = $.getSetIniDbBoolean('discordSettings', 'customCommandLogs', false);
+            channel = $.getSetIniDbString('discordSettings', 'modLogChannel', '');
+        }
+    });
+
+
+    /*
+     * @function logCustomCommand
+     *
+     * @param {object} info
+     */
+    function logCustomCommand(info) {
+        var lines = Object.keys(info).map(function(key) {
+            return '**' + $.lang.get('discord.customcommandlogs.' + key) + '**: ' + info[key];
+        });
+        $.log.file('customCommands', lines.join('\r\n'));
+        if (enabled && channel) {
+            $.discordAPI.sendMessageEmbed(channel, 'blue', lines.join('\r\n\r\n'));
+        }
+    }
+
+    /*
+     * Export function to API
+     */
+    $.logCustomCommand = logCustomCommand;
+})();

--- a/javascript-source/lang/english/discord/systems/systems-customCommandLogs.js
+++ b/javascript-source/lang/english/discord/systems/systems-customCommandLogs.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2018 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$.lang.register('discord.customcommandlogs.sender', 'By');
+$.lang.register('discord.customcommandlogs.add.command', 'Custom command created');
+$.lang.register('discord.customcommandlogs.add.response', 'Response');
+$.lang.register('discord.customcommandlogs.edit.command', 'Custom command edited');
+$.lang.register('discord.customcommandlogs.edit.response', 'New response');
+$.lang.register('discord.customcommandlogs.delete.command', 'Custom command deleted');
+$.lang.register('discord.customcommandlogs.alias.command', 'Custom alias created');
+$.lang.register('discord.customcommandlogs.alias.target', 'To');
+$.lang.register('discord.customcommandlogs.alias.delete.command', 'Custom alias deleted');
+$.lang.register('discord.customcommandlogs.set.perm.command', 'Command permissions updated');
+$.lang.register('discord.customcommandlogs.set.perm.group', 'New group');
+$.lang.register('discord.customcommandlogs.set.price.command', 'Command price updated');
+$.lang.register('discord.customcommandlogs.set.price.amount', 'New price');
+$.lang.register('discord.customcommandlogs.set.pay.command', 'Command reward updated');
+$.lang.register('discord.customcommandlogs.set.pay.amount', 'New reward');
+$.lang.register('discord.customcommandlogs.disable.command', 'Command disabled');
+$.lang.register('discord.customcommandlogs.enable.command', 'Command enabled');
+$.lang.register('discord.customcommandlogs.reset.command', 'Command counter reset');
+$.lang.register('discord.customcommandlogs.reset.count', 'New value');

--- a/resources/web/panel/discord.html
+++ b/resources/web/panel/discord.html
@@ -319,11 +319,11 @@
                 <td>Toggle Custom Command Change Logs</td>
                 <td style="width: 25px"><div id="customCommandLogsInput" /></td>
                 <td style="width: 25px">
-                    <div data-toggle="tooltip" title="Enable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', 'commands/customCommands.js', 'discordSettings', 'customCommandLogs', 'true')">
+                    <div data-toggle="tooltip" title="Enable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', '', 'discordSettings', 'customCommandLogs', 'true')">
                         <i class="fa fa-circle" /></div>
                 </td>
                 <td style="width: 25px">
-                    <div data-toggle="tooltip" title="Disable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', 'commands/CustomCommands.js', 'discordSettings', 'customCommandLogs', 'false')">
+                    <div data-toggle="tooltip" title="Disable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', '', 'discordSettings', 'customCommandLogs', 'false')">
                         <i class="fa fa-circle-o" /></div>
                 </td>
             </tr>

--- a/resources/web/panel/discord.html
+++ b/resources/web/panel/discord.html
@@ -314,6 +314,19 @@
                         <i class="fa fa-circle-o" /></div>
                 </td>
             </tr>
+
+            <tr class="textList">
+                <td>Toggle Custom Command Change Logs</td>
+                <td style="width: 25px"><div id="customCommandLogsInput" /></td>
+                <td style="width: 25px">
+                    <div data-toggle="tooltip" title="Enable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', 'commands/customCommands.js', 'discordSettings', 'customCommandLogs', 'true')">
+                        <i class="fa fa-circle" /></div>
+                </td>
+                <td style="width: 25px">
+                    <div data-toggle="tooltip" title="Disable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', 'commands/CustomCommands.js', 'discordSettings', 'customCommandLogs', 'false')">
+                        <i class="fa fa-circle-o" /></div>
+                </td>
+            </tr>
         </table>
         <br>
 

--- a/resources/web/panel/discord.html
+++ b/resources/web/panel/discord.html
@@ -319,11 +319,11 @@
                 <td>Toggle Custom Command Change Logs</td>
                 <td style="width: 25px"><div id="customCommandLogsInput" /></td>
                 <td style="width: 25px">
-                    <div data-toggle="tooltip" title="Enable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', '', 'discordSettings', 'customCommandLogs', 'true')">
+                    <div data-toggle="tooltip" title="Enable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', 'systems/customCommandLogs.js', 'discordSettings', 'customCommandLogs', 'true')">
                         <i class="fa fa-circle" /></div>
                 </td>
                 <td style="width: 25px">
-                    <div data-toggle="tooltip" title="Disable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', '', 'discordSettings', 'customCommandLogs', 'false')">
+                    <div data-toggle="tooltip" title="Disable" class="button" onclick="$.updateDiscordTable('customCommandLogsInput', 'systems/customCommandLogs.js', 'discordSettings', 'customCommandLogs', 'false')">
                         <i class="fa fa-circle-o" /></div>
                 </td>
             </tr>


### PR DESCRIPTION
We currently use the moderation log setting to create an audit log in Discord for Twitch bans and timeouts, but we'd also like to have a record of who creates, edits, and deletes custom Twitch chat commands, along with when. This PR adds a toggle to include those events in the mod log channel (default off).

Tested manually, with the setting both on and off.

**customCommands.js**
- Initialize the `customCommandLogs` setting to `false` if unset
- Add an unexported function `logIfEnabled()` which formats and sends a Discord embed if the setting is turned on
- Call it from each command handler that alters a custom command

**discord.html**
- Add a corresponding toggle to the control panel