### PR TITLE
Missing letter fix

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -1436,7 +1436,7 @@
 
                 if (subAction.equalsIgnoreCase('links')) {
                     if (!args[2]) {
-                        $.say($.whisperPrefix(sender) + $.lang.get('chatmoderator.silenttimeout.toggle.link', getModerationFilterStatus(silentTimeout.Links, true)));
+                        $.say($.whisperPrefix(sender) + $.lang.get('chatmoderator.silenttimeout.toggle.links', getModerationFilterStatus(silentTimeout.Links, true)));
                         return;
                     }
 


### PR DESCRIPTION
This can be checked against line 113 in scripts/lang/english/main.js.
The same $.lang.get is not found anywhere else in PB.