### PR TITLE
Feature/discord emotes

### DIFF
--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -418,7 +418,11 @@ public final class PhantomBot implements Listener {
 
         /* Set the Discord variables */
         this.discordToken = this.pbProperties.getProperty("discord_token", "");
-        this.discordServerId = Long.parseLong(this.pbProperties.getProperty("discord_server"));
+        try {
+            this.discordServerId = Long.parseLong(this.pbProperties.getProperty("discord_server"));
+        } catch(NumberFormatException nfe) {
+            this.discordServerId = null;
+        }
 
         /* Set the GameWisp variables */
         this.gameWispOAuth = this.pbProperties.getProperty("gamewispauth", "");

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -187,6 +187,7 @@ public final class PhantomBot implements Listener {
 
     /* Discord Configuration */
     private String discordToken = "";
+    private Long discordServerId;
 
     /* PhantomBot Commands API Configuration */
     private String dataRenderServiceAPIToken = "";
@@ -417,6 +418,7 @@ public final class PhantomBot implements Listener {
 
         /* Set the Discord variables */
         this.discordToken = this.pbProperties.getProperty("discord_token", "");
+        this.discordServerId = Long.parseLong(this.pbProperties.getProperty("discord_server"));
 
         /* Set the GameWisp variables */
         this.gameWispOAuth = this.pbProperties.getProperty("gamewispauth", "");
@@ -881,7 +883,7 @@ public final class PhantomBot implements Listener {
 
         /* Connect to Discord if the data is present. */
         if (!discordToken.isEmpty()) {
-            DiscordAPI.instance().connect(discordToken);
+            DiscordAPI.instance().connect(discordToken, discordServerId);
         }
 
         /* Set Streamlabs currency code, if possible */

--- a/source/tv/phantombot/discord/DiscordAPI.java
+++ b/source/tv/phantombot/discord/DiscordAPI.java
@@ -171,7 +171,7 @@ public class DiscordAPI extends DiscordUtil {
      * Method to set the guild and shard objects.
      */
     private void setGuildAndShard() {
-        if (DiscordAPI.getClient().getGuilds().size() > 1 && DiscordAPI.serverId != null) {
+        if (DiscordAPI.getClient().getGuilds().size() > 1 && DiscordAPI.serverId == null) {
             // PhantomBot only works in one server, so throw an error if there's multiple.
             com.gmt2001.Console.err.println("Discord bot works only with one server. Please define 'discord_server' parameter if you want to unleash custom emotes. Now disconnecting from Discord...");
             DiscordAPI.client.logout();
@@ -188,6 +188,11 @@ public class DiscordAPI extends DiscordUtil {
         }
     }
 
+    /**
+     * Method that will return a comma separated list of guild names
+     *
+     * @return {String} guilds
+     */
     private String getGuildNamesFormatted()
     {
         ArrayList<String> guilds = new ArrayList<>();


### PR DESCRIPTION
This change allows a bot to be connected to multiple servers while working only with a defined one as usual. Twitch sub emotes are unavailable to bots (with no ETA on implementing the support), so bot owners can bypass this limitation by mirroring their emotes on personal servers. Discord bots have Nitro benefits, so they can use custom emotes from any connected server.

**PhantomBot.java**
- Added `discord_server` config property.

**discord/DiscordAPI.java**
- Added support for connecting to multiple guilds.