### PR TITLE
Promote System for Twitch Channels in Discord

### DIFF
--- a/javascript-source/discord/systems/promoteSystem.js
+++ b/javascript-source/discord/systems/promoteSystem.js
@@ -1,0 +1,459 @@
+/**
+ * promoteSystem.js
+ *
+ * TODO:
+ * - Add controls to the Beta Panel once that is the formal release.
+ * 
+ */
+(function() {
+    var showStats = $.getSetIniDbBoolean('promotesettings', 'showstats', true);
+    var showBanner = $.getSetIniDbBoolean('promotesettings', 'showbanner', true);
+    var promoteChannel = $.getSetIniDbString('promotesettings', 'channel', '');
+    var streamChannel = $.getSetIniDbString('promotesettings', 'streamchannel', '');
+    var allowSelfManage = $.getSetIniDbBoolean('promotesettings', 'allowselfmanage', true);
+    var lastIdx = $.getSetIniDbNumber('promotesettings', 'lastidx', 0);
+    var promoteInterval = $.getSetIniDbNumber('promotesettings', 'promoteinterval', 120);
+    var promoteIntervalID = -1;
+
+    /**
+     * @event discordChannelCommand
+     */
+    $.bind('discordChannelCommand', function(event) {
+        var channel = event.getDiscordChannel(),
+            command = event.getCommand(),
+            sender = event.getSender(),
+            mention = event.getMention(),
+            args = event.getArgs(),
+            action = args[0];
+
+        /*
+         * @discordcommandpath promoteadm channel discord_channel - Channel to send promotion messages to.
+         * @discordcommandpath promoteadm streamchannel discord_channel - Channel to send go-live messages to.
+         * @discordcommandpath promoteadm toggleselfmanage - If you do not want people to add themselves.
+         * @discordcommandpath promoteadm setinterval - Change the interval for promotion messages from 120 minutes to something else.
+         * @discordcommandpath promoteadm togglestats - Show follow and view stats or not.
+         * @discordcommandpath promoteadm togglebanner - Display the channel banner or not.
+         * @discordcommandpath promoteadm so - Shout out a user.
+         * @discordcommandpath promoteadm add - Add a user based on their Twitch channel.
+         * @discordcommandpath promoteadm delete - Delete a user based on their Twitch channel.
+         * @discordcommandpath promoteadm revoke - Revoke the privilege of a user to be able to promote themselves.
+         * @discordcommandpath promoteadm allow - Allow a user to be able to promote themselves.
+         * @discordcommandpath promoteadm list - List the users currently configured.
+         * @discordcommandpath promote add - Add yourself if permitted to do so.
+         * @discordcommandpath promote delete - Delete yourself if permitted to do so.
+         */
+ 
+        if (command.equalsIgnoreCase('promote')) {
+            if (action === undefined) {
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.usage'));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('add') || action.equalsIgnoreCase('delete')) {
+                if (!allowSelfManage) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.noselfmanage'));
+                    return;
+                }
+                if (promoteChannel.length === 0 && streamChannel.length === 0) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.nochannels'));
+                    return;
+                }
+                var twitchName = $.discord.resolveTwitchName(event.getSenderId());
+                if (twitchName === null || twitchName === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.accountlink.usage.nolink'));
+                    return;
+                }
+                var twitchID = $.username.getID(twitchName);
+                if ($.inidb.exists('promoterevoke', twitchID)) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.revoked'));
+                    return;
+                }
+            }
+          
+            if (action.equalsIgnoreCase('add')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.add.nobio'));
+                    return;
+                }
+                var biography = args.splice(1).join(' ');
+                if (biography.equalsIgnoreCase('none')) {
+                    biography = '';
+                }
+                $.inidb.set('promotebio', twitchID, biography);
+                $.inidb.set('promoteids', twitchID, twitchName.toLowerCase());
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.add.success', twitchName.toLowerCase()));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('delete')) {
+                $.inidb.del('promotebio', twitchID);
+                $.inidb.del('promoteids', twitchID);
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promote.del.success', twitchName.toLowerCase()));
+                return;
+            }
+        }
+
+        if (command.equalsIgnoreCase('promoteadm')) {
+            if (action === undefined) {
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.usage'));
+                return;
+            }
+
+            if ((action.equalsIgnoreCase('add') || action.equalsIgnoreCase('delete')) && (promoteChannel.length === 0 && streamChannel.length === 0))  {
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.nochannels'));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('add')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.add.nouser'));
+                    return;
+                }
+                
+                var twitchID = $.username.getID(args[1]);
+                if (twitchID.equals('0')) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.noacct', args[1]));
+                    return;
+                }
+                if (args[2] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.add.nobio'));
+                    return;
+                }
+                var biography = args.splice(2).join(' ');
+                if (biography.equalsIgnoreCase('none')) {
+                    biography = '';
+                }
+                $.inidb.set('promotebio', twitchID, biography);
+                $.inidb.set('promoteids', twitchID, args[1].toLowerCase());
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.add.success', args[1].toLowerCase()));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('delete')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.del.nouser'));
+                    return;
+                }
+                
+                var twitchID = $.username.getID(args[1]);
+                if (twitchID.equals('0')) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.noacct'));
+                    return;
+                }
+
+                $.inidb.del('promotebio', twitchID);
+                $.inidb.del('promoteids', twitchID);
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.del.success', args[1].toLowerCase()));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('channel')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.channel.nochannel'));
+                    return;
+                }
+            
+                promoteChannel = args[1].replace('#', '').toLowerCase();
+                if (promoteChannel.equals('clear')) {
+                    $.inidb.set('promotesettings', 'channel', '');
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.channel.cleared'));
+                } else {
+                    $.inidb.set('promotesettings', 'channel', promoteChannel);
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.channel.success', promoteChannel));
+                }
+                return;
+            }
+
+            if (action.equalsIgnoreCase('streamchannel')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.streamchannel.nochannel'));
+                    return;
+                }
+            
+                streamChannel = args[1].replace('#', '').toLowerCase();
+                if (streamChannel.equals('clear')) {
+                    streamChannel = '';
+                    $.inidb.set('promotesettings', 'streamchannel', '');
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.streamchannel.cleared'));
+                } else {
+                    $.inidb.set('promotesettings', 'streamchannel', streamChannel);
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.streamchannel.success', streamChannel));
+                }
+                return;
+            }
+
+            if (action.equalsIgnoreCase('revoke')) {
+                if (args[1] == undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.revoke.nouser'));
+                    return;
+                }
+
+                var twitchID = $.username.getID(args[1]);
+                if (twitchID.equals('0')) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.noacct', args[1]));
+                    return;
+                }
+
+                $.inidb.del('promotebio', twitchID);
+                $.inidb.del('promoteids', twitchID);
+                $.inidb.set('promoterevoke', twitchID);
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.revoke.success', args[1].toLowerCase()));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('allow')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.allow.nouser'));
+                    return;
+                }
+
+                var twitchID = $.username.getID(args[1]);
+                if (twitchID.equals('0')) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.noacct', args[1]));
+                    return;
+                }
+
+                $.inidb.del('promoterevoke', twitchID);
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.allow.success', args[1].toLowerCase()));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('toggleselfmanage')) {
+                if (allowSelfManage) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.toggleselfmanage.off'));
+                } else {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.toggleselfmanage.off'));
+                }
+                allowSelfManage = !allowSelfManage;
+                $.setIniDbBoolean('promotesettings', 'allowselfmanage', allowSelfManage);
+                return;
+            }
+
+            if (action.equalsIgnoreCase('togglestats')) {
+                if (showStats) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.togglestats.off'));
+                } else {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.togglestats.on'));
+                }
+                showStats = !showStats;
+                $.setIniDbBoolean('promotesettings', 'showstats', showStats);
+                return;
+            }
+
+            if (action.equalsIgnoreCase('togglebanner')) {
+                if (showBanner) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.togglebanner.off'));
+                } else {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.togglebanner.on'));
+                }
+                showBanner = !showBanner;
+                $.setIniDbBoolean('promotesettings', 'showbanner', showBanner);
+                return;
+            }
+
+
+            if (action.equalsIgnoreCase('list')) {
+                var twitchIDs = $.inidb.GetKeyList('promoteids', '');
+                if (twitchIDs.length === 0) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.list.empty'));
+                    return;
+                }
+
+                var twitchNames = [];
+                for (var i = 0; i < twitchIDs.length; i++) {
+                    twitchNames.push($.inidb.get('promoteids', twitchIDs[i]));   
+                }
+                
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.list.success', twitchNames.join(', ')));
+                return;
+            }
+
+            if (action.equalsIgnoreCase('setinterval')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.setinterval.nominutes'));
+                    return;
+                }
+                if (isNaN(args[1])) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.setinterval.nominutes'));
+                    return;
+                }
+                var newPromoteInterval = parseInt(args[1]);
+                if (newPromoteInterval < 15) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.setinterval.toolow'));
+                    return;
+                }
+                $.setIniDbNumber('promotesettings', 'promoteinterval', newPromoteInterval);
+                promoteInterval = newPromoteInterval;
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.promoteadm.setinterval.success', promoteInterval));
+                startPromote();
+                return;
+            }
+
+            if (action.equalsIgnoreCase('so')) {
+                if (args[1] === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.so.nouser'));
+                    return;
+                }
+                var twitchID = $.inidb.GetKeyByValue('promoteids', '', args[1].toLowerCase());
+                if (twitchID === null || twitchID === undefined) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.promotesystem.cmd.so.noexist'));
+                    return;
+                }
+
+                var twitchName = $.inidb.get('promoteids', twitchID);
+                var biography = $.inidb.get('promotebio', twitchID);
+                if (biography.equals('')) {
+                    biography = 'No biography provided.';
+                }
+                $.discordAPI.sendMessageEmbed($.inidb.get('promotesettings', 'channel'), new Packages.sx.blah.discord.util.EmbedBuilder()
+                                              .withThumbnail('http://iotv.me/i/followontwitch.jpg')
+                                              .withTitle('https://twitch.tv/' + twitchName)
+                                              .withDesc($.lang.get('discord.promotesystem.promotemsg.description', $.username.resolve(twitchName)))
+                                              .withColor(31, 158, 242)
+                                              .appendField($.lang.get('discord.promotesystem.promotemsg.biography'), biography, true)
+                                              .withUrl('https://twitch.tv/' + twitchName).build());
+            }
+        }
+    });
+
+    /**
+     * Check for online status of channels every minute.
+     */
+    setInterval(function() {
+        if ($.inidb.get('promotesettings', 'streamchannel').equals('')) {
+            return;
+        }
+
+        var twitchIDs = $.inidb.GetKeyList('promoteids', '');
+        if (twitchIDs.length === 0) {
+            return;
+        }
+        var start = 0;
+        var end = 100;
+        var total = twitchIDs.length;
+
+        do {
+            var queryString = twitchIDs.slice(start, end).join(',') + '&stream_type=live';
+            var jsonObject = $.twitch.GetStreams(queryString);
+
+            start += 100;
+            end += 100;
+
+            if (!jsonObject.has('_total') || !jsonObject.has('streams')) {
+                return;
+            }
+    
+            if (jsonObject.getInt('_total') === 0) {
+                return;
+            }
+    
+            var liveStreamers = [];
+            var jsonStreams = jsonObject.getJSONArray('streams');
+            for (var i = 0; i < jsonStreams.length(); i++) {
+                var twitchID = jsonStreams.getJSONObject(i).getJSONObject('channel').getInt('_id').toString();
+                var logoUrl = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('logo');
+                var url = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('url');
+                var game = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('game');
+                var title = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('status');
+                var twitchName = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('display_name');
+                var followers = jsonStreams.getJSONObject(i).getJSONObject('channel').getInt('followers');
+                var views = jsonStreams.getJSONObject(i).getJSONObject('channel').getInt('views');
+                var banner = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('profile_banner');
+                liveStreamers.push(twitchID);
+    
+                if (!$.inidb.exists('promoteonline', twitchID)) {
+                    if ($.systemTime() - $.getIniDbNumber('promoteonlinetime', twitchID, 0) >= (6e4 * 5)) {
+                        $.inidb.set('promoteonlinetime', twitchID, $.systemTime());
+                        var embedBuilder = new Packages.sx.blah.discord.util.EmbedBuilder();
+                        embedBuilder.withThumbnail(logoUrl)
+                                    .withTitle($.lang.get('discord.promotesystem.livemsg.title', $.username.resolve(twitchName), twitchName))
+                                    .withColor(100, 65, 164)
+                                    .withTimestamp(Date.now())
+                                    .appendField($.lang.get('discord.promotesystem.livemsg.nowplaying'), game, true)
+                                    .appendField($.lang.get('discord.promotesystem.livemsg.streamtitle'), title, true);
+    
+                        if (showStats) {
+                            embedBuilder.appendField($.lang.get('discord.promotesystem.livemsg.followers'), followers, true)
+                                        .appendField($.lang.get('discord.promotesystem.livemsg.views'), views, true);
+                        }
+                        if (banner != null && showBanner) {
+                            embedBuilder.withImage(banner)
+                        }
+     
+                        embedBuilder.withFooterText($.inidb.get('promotebio', twitchID))
+                                    .withUrl('https://twitch.tv/' + twitchName);
+                        $.discordAPI.sendMessageEmbed($.inidb.get('promotesettings', 'streamchannel'), embedBuilder.build());
+                    }
+                }
+            }
+    
+            $.inidb.RemoveFile('promoteonline');
+            for (var i = 0; i < liveStreamers.length; i++) {
+                $.inidb.set('promoteonline', liveStreamers[i], $.inidb.get('promoteids', liveStreamers[i]));
+            }
+        } while (start < total);
+    }, 6e4, 'scripts::promote.js::checkstreams');
+
+    /**
+     * Send out biography information every so often.
+     */
+    function startPromote() {
+        if (promoteIntervalID != -1) {
+           $.consoleLn('Restarting the Promotion Interval Handler');
+           clearInterval(promoteIntervalID);
+        }
+
+        promoteIntervalID = setInterval(function() {
+            if ($.inidb.get('promotesettings', 'channel').equals('')) {
+                return;
+            }
+    
+            var twitchIDs = $.inidb.GetKeyList('promoteids', '');
+            if (twitchIDs.length === 0) {
+                return;
+            }
+    
+            if (++lastIdx >= twitchIDs.length) {
+                lastIdx = 0;
+            }
+            $.setIniDbNumber('promotesettings', 'lastidx', lastIdx);
+    
+            var twitchName = $.inidb.get('promoteids', twitchIDs[lastIdx]);
+            var biography = $.inidb.get('promotebio', twitchIDs[lastIdx]);
+            if (biography.equals('')) {
+                biography = 'No biography provided.';
+            }
+            $.discordAPI.sendMessageEmbed($.inidb.get('promotesettings', 'channel'), new Packages.sx.blah.discord.util.EmbedBuilder()
+                                          .withThumbnail('http://iotv.me/i/followontwitch.jpg')
+                                          .withTitle('https://twitch.tv/' + twitchName)
+                                          .withDesc($.lang.get('discord.promotesystem.promotemsg.description', $.username.resolve(twitchName)))
+                                          .withColor(31, 158, 242)
+                                          .appendField($.lang.get('discord.promotesystem.promotemsg.biography'), biography, true)
+                                          .withUrl('https://twitch.tv/' + twitchName).build());
+        }, promoteInterval * 6e4, 'scripts::promote.js::biography'); 
+    }
+    
+    /**
+     * @event initReady
+     */
+    $.bind('initReady', function() {
+        $.discord.registerCommand('./discord/systems/promoteSystem.js', 'promote', 0);
+        $.discord.registerCommand('./discord/systems/promoteSystem.js', 'promoteadm', 1);
+        $.discord.registerSubCommand('promote', 'add', 0);
+        $.discord.registerSubCommand('promote', 'delete', 0);
+        $.discord.registerSubCommand('promoteadm', 'add', 1);
+        $.discord.registerSubCommand('promoteadm', 'delete', 1);
+        $.discord.registerSubCommand('promoteadm', 'channel', 1);
+        $.discord.registerSubCommand('promoteadm', 'streamchannel', 1);
+        $.discord.registerSubCommand('promoteadm', 'revoke', 1);
+        $.discord.registerSubCommand('promoteadm', 'allow', 1);
+        $.discord.registerSubCommand('promoteadm', 'toggleselfmanage', 1);
+        $.discord.registerSubCommand('promoteadm', 'list', 1);
+        $.discord.registerSubCommand('promoteadm', 'setinterval', 1);
+        $.discord.registerSubCommand('promoteadm', 'togglestats', 1);
+        $.discord.registerSubCommand('promoteadm', 'togglebanner', 1);
+        $.discord.registerSubCommand('promoteadm', 'so', 1);
+
+        startPromote();
+    });
+})();

--- a/javascript-source/lang/english/discord/systems/systems-promoteSystem.js
+++ b/javascript-source/lang/english/discord/systems/systems-promoteSystem.js
@@ -1,0 +1,60 @@
+$.lang.register('discord.promotesystem.cmd.promote.usage', '!promote add [short bio] | delete - Add or delete yourself from being promoted.');
+$.lang.register('discord.promotesystem.cmd.promote.noselfmanage', 'No one is allowed to manage themselves, please speak to a moderator to be added or deleted.');
+$.lang.register('discord.promotesystem.cmd.promote.nochannels', 'Ask an admin to set a promote channel with !promote channel and/or !promote streamchannel');
+$.lang.register('discord.promotesystem.cmd.promote.revoked', 'You are no longer allowed to add yourself.');
+
+$.lang.register('discord.promotesystem.cmd.promote.add.nobio', 'You need to provide a short biography or use the keyword \'none\' (!promote add none).');
+$.lang.register('discord.promotesystem.cmd.promote.add.success', 'You ($1) will now be promoted');
+$.lang.register('discord.promotesystem.cmd.promote.del.success', 'You ($1) will no longer be promoted');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.usage', '!promoteadm add | delete | so | channel | streamchannel | revoke | allow | toggleselfmanage | togglestats | togglebanner | list | setinterval');
+$.lang.register('discord.promotesystem.cmd.promoteadm.nochannels', 'Set channels with !promoteadm channel and/or !promoteadm streamchannel');
+$.lang.register('discord.promotesystem.cmd.promoteadm.noacct', 'That account does not appear to exist in Twitch: $1');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.add.nouser', 'Who do you wish to promote?');
+$.lang.register('discord.promotesystem.cmd.promoteadm.add.nobio', 'You need to provide a short biography or use the keyword \'none\' (!promoteadm add user none).');
+$.lang.register('discord.promotesystem.cmd.promoteadm.add.success', '$1 will now be promoted');
+$.lang.register('discord.promotesystem.cmd.promoteadm.del.nouser', 'Who you wish to remove from being promoted?');
+$.lang.register('discord.promotesystem.cmd.promoteadm.del.success', '$1 will no longer be promoted');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.channel.nochannel', 'Use which channel for promotions? To remove current channel use !promoteadm channel clear');
+$.lang.register('discord.promotesystem.cmd.promoteadm.channel.cleared', 'Promote channel has been cleared.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.channel.success', 'Promote channel has been set to: #$1'); 
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.streamchannel.nochannel', 'Use which channel for stream announcements? To remove current channel use !promoteadm streamchannel clear');
+$.lang.register('discord.promotesystem.cmd.promoteadm.streamchannel.cleared', 'Stream announcement channel has been cleared.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.streamchannel.success', 'Stream announcement channel has been set to: #$1');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.revoke.nouser', 'Revoke the privilege of which user to be able to add themselves?');
+$.lang.register('discord.promotesystem.cmd.promoteadm.revoke.success', '$1 will no longer be promoted and will no longer be able to manage themselves.');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.allow.nouser',  'Allow which user to be able to add themselves again?');
+$.lang.register('discord.promotesystem.cmd.promoteadm.allow.success', '$1  will be allowed to add themselves again.');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.toggleselfmanage.off', 'Users will no longer be able to manage themselves via !promote add and delete.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.toggleselfmanage.on', 'Users will now be able to manage themselves via !promote add and delete.');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.togglestats.off', 'Stats will no longer show when a stream is announced.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.togglestats.on', 'Stats will now show when a stream is announced.');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.togglebanner.off', 'Banners will no longer show when a stream is announced.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.togglebanner.on', 'Banners will now show when a stream is announced.');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.list.empty', 'No users are presently being promoted.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.list.success', 'Users being promoted: $1');
+
+$.lang.register('discord.promotesystem.cmd.promoteadm.setinterval.nominutes', 'Provide an interval in minutes.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.setinterval.toolow', 'The interval should be 15 minutes or more as to not spam the channel.');
+$.lang.register('discord.promotesystem.cmd.promoteadm.setinterval.success', 'The interval for promoting streamers has been set to $1 minutes.');
+
+$.lang.register('discord.promotesystem.cmd.so.nouser', 'You must provide a user to lookup and shoutout.');
+$.lang.register('discord.promotesystem.cmd.so.noexist', 'That user is not currently being promoted. Check !promoteadm list');
+
+$.lang.register('discord.promotesystem.livemsg.title', '$1 is LIVE @ https://twitch.tv/$2');
+$.lang.register('discord.promotesystem.livemsg.nowplaying', 'Now Playing');
+$.lang.register('discord.promotesystem.livemsg.streamtitle', 'Stream Title');
+$.lang.register('discord.promotesystem.livemsg.followers', 'Followers');
+$.lang.register('discord.promotesystem.livemsg.views', 'Views');
+
+$.lang.register('discord.promotesystem.promotemsg.description', 'Be sure to follow and checkout $1');
+$.lang.register('discord.promotesystem.promotemsg.biography', 'Bio');


### PR DESCRIPTION
**promoteSystem.js**
- Allows for the management of Twitch stream promotions.
 promoteadm channel discord_channel - Channel to send promotion messages to.  Use clear to clear value.
 promoteadm streamchannel discord_channel - Channel to send go-live messages to.  Use clear to clear value.
 promoteadm toggleselfmanage - If you do not want people to add themselves.
 promoteadm setinterval - Change the interval for promotion messages from 120 minutes to something else.
 promoteadm togglestats - Show follow and view stats or not.
 promoteadm togglebanner - Display the channel banner or not.
 promoteadm so - Shout out a user.
 promoteadm add - Add a user based on their Twitch channel.
 promoteadm delete - Delete a user based on their Twitch channel.
 promoteadm revoke - Revoke the privilege of a user to be able to promote themselves.
 promoteadm allow - Allow a user to be able to promote themselves.
 promoteadm list - List the users currently configured.
 promote add - Add yourself if permitted to do so.
 promote delete - Delete yourself if permitted to do so.

**systems-promoteSystem.js**
- Related language file.

Special thanks to DarkInsanities for performing testing and providing a lot of great feedback.