### PR TITLE
Fixed log misprint & quote marks

### DIFF
--- a/javascript-source/handlers/wordCounter.js
+++ b/javascript-source/handlers/wordCounter.js
@@ -66,7 +66,7 @@
                 subAction = subAction.replace(action, '').toLowerCase();
                 $.inidb.del('wordCounter', subAction);
                 $.say(subAction + $.lang.get('wordcounter.removed'));
-                $.log.event(sender + ' removed "' + subAction + '" to the word counter list');
+                $.log.event(sender + ' removed "' + subAction + '" from the word counter list');
             }
         }
 

--- a/javascript-source/lang/english/commands/commands-deathctrCommand.js
+++ b/javascript-source/lang/english/commands/commands-deathctrCommand.js
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$.lang.register("deathcounter.set-error", "Provide a new valid death counter value.");
-$.lang.register("deathcounter.set-success", "Death counter for $1 set to $2.");
-$.lang.register("deathcounter.add-success", "$1 has died again in $2, bringing the total to $3.");
-$.lang.register("deathcounter.sub-success", "Calling back a death, the total is now $2 in $1.");
-$.lang.register("deathcounter.sub-zero", "The death counter for $1 is already zero, can't go any lower!");
-$.lang.register("deathcounter.counter", "$1 has died $3 times in $2.");
-$.lang.register("deathcounter.none", "$1 has not died in $2....yet.");
-$.lang.register("deathcounter.reset", "Reset the death counter back to 0 from $2 for $1.");
-$.lang.register("deathcounter.reset-nil", "The death counter for $1 is already 0.");
+$.lang.register('deathcounter.set-error', 'Provide a new valid death counter value.');
+$.lang.register('deathcounter.set-success', 'Death counter for $1 set to $2.');
+$.lang.register('deathcounter.add-success', '$1 has died again in $2, bringing the total to $3.');
+$.lang.register('deathcounter.sub-success', 'Calling back a death, the total is now $2 in $1.');
+$.lang.register('deathcounter.sub-zero', 'The death counter for $1 is already zero, can\'t go any lower!');
+$.lang.register('deathcounter.counter', '$1 has died $3 times in $2.');
+$.lang.register('deathcounter.none', '$1 has not died in $2....yet.');
+$.lang.register('deathcounter.reset', 'Reset the death counter back to 0 from $2 for $1.');
+$.lang.register('deathcounter.reset-nil', 'The death counter for $1 is already 0.');


### PR DESCRIPTION
Minor improvements:
- fixed misprint for logs;
- replaced double quote marks `"` with single quote marks `'` according to PB code style;
- replaced `can't` with `can\'t`.