### PR TITLE
Improved regex for fake purges and CAPS

### DIFF
--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -26,11 +26,11 @@
         link: new RegExp('((?:(http|https|rtsp):\\/\\/(?:(?:[a-z0-9\\$\\-\\_\\.\\+\\!\\*\\\'\\(\\)' + '\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,64}(?:\\:(?:[a-z0-9\\$\\-\\_' + '\\.\\+\\!\\*\\\'\\(\\)\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,25})?\\@)?)?' + '((?:(?:[a-z0-9][a-z0-9\\-]{0,64}\\.)+' + '(?:' + '(?:aero|a[cdefgilmnoqrstuwxz])' + '|(?:biz|b[abdefghijmnorstvwyz])' + '|(?:com|c[acdfghiklmnoruvxyz])' + '|d[ejkmoz]' + '|(?:edu|e[cegrstu])' + '|(?:fyi|f[ijkmor])' + '|(?:gov|g[abdefghilmnpqrstuwy])' + '|(?:how|h[kmnrtu])' + '|(?:info|i[delmnoqrst])' + '|(?:jobs|j[emop])' + '|k[eghimnrwyz]' + '|l[abcikrstuvy]' + '|(?:mil|mobi|moe|m[acdeghklmnopqrstuvwxyz])' + '|(?:name|net|n[acefgilopruz])' + '|(?:org|om)' + '|(?:pro|p[aefghklmnrstwy])' + '|qa' + '|(?:r[eouw])' + '|(?:s[abcdeghijklmnortuvyz])' + '|(?:t[cdfghjklmnoprtvwz])' + '|u[agkmsyz]' + '|(?:vote|v[ceginu])' + '|(?:xxx)' + '|(?:watch|w[fs])' + '|y[etu]' + '|z[amw]))' + '|(?:(?:25[0-5]|2[0-4]' + '[0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9])\\.(?:25[0-5]|2[0-4][0-9]' + '|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1]' + '[0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}' + '|[1-9][0-9]|[0-9])))' + '(?:\\:\\d{1,5})?)' + '(\\/(?:(?:[a-z0-9\\;\\/\\?\\:\\@\\&\\=\\#\\~' + '\\-\\.\\+\\!\\*\\\'\\(\\)\\,\\_])|(?:\\%[a-fA-F0-9]{2}))*)?' + '(?:\\b|$)' + '|(\\.[a-z]+\\/|magnet:\/\/|mailto:\/\/|ed2k:\/\/|irc:\/\/|ircs:\/\/|skype:\/\/|ymsgr:\/\/|xfire:\/\/|steam:\/\/|aim:\/\/|spotify:\/\/)', 'i'),
         emotes: new RegExp('([0-9][0-9]-[0-9][0-9])|([0-9]-[0-9])', 'g'),
         repeatedSeq: /(.)(\1+)/ig,
-        nonAlphaSeq: /([^a-z0-9 ])(\1+)/ig,
-        nonAlphaCount: /([^a-z0-9 ])/ig,
-        capsCount: /([A-Z])/g,
+        nonAlphaSeq: /([^a-z0-9а-яёα-ϖ ])(\1+)/ig,
+        nonAlphaCount: /([^a-z0-9а-яёα-ϖ ])/ig,
+        capsCount: /([A-ZА-ЯЁΑ-Ω])/g,
         meCheck: /^\/me/,
-        fakePurge: new RegExp(/^<message \w+>|^<\w+ deleted>/i)
+        fakePurge: new RegExp(/(^<[mмμ][eеε]ss[aаα]g[eеε]\s+d[eеε][liι][eеε][tтτ][eе]d\.?>$)/i)
     };
 
     /**

--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -30,7 +30,7 @@
         nonAlphaCount: /([^a-z0-9а-яёα-ϖ ])/ig,
         capsCount: /([A-ZА-ЯЁΑ-Ω])/g,
         meCheck: /^\/me/,
-        fakePurge: new RegExp(/(^<[mмμ][eеε]ss[aаα]g[eеε]\s+d[eеε][liι][eеε][tтτ][eе]d\.?>$)/i)
+        fakePurge: new RegExp(/(^<[mмμ][eеε]ss[aаα]g[eеε]\s+d[eеε][liι][eеε][tтτ][eеε]d\.?>$)/i)
     };
 
     /**


### PR DESCRIPTION
### **FAKE PURGES**

At the moment regex `/^<message \w+>|^<\w+ deleted>/i` catches only messages starting with `<message` and/or containing `deleted>`. Examples: `<message deleted>` as it is, `<mEsSaGe annihilated>` and `<My message was unfairly deleted> WTF?`. The last two are definitely not fake purge, but a joke (or attempts to make a joke) or wonder.

Also Twitch added a different purge message for its mobile applications, and it looks like this: `<Message deleted.>`.

My suggestion is not just to add the possible dot before the `>`, but to improve regex this way:
`/(^<[mмμ][eеε]ss[aаα]g[eеε]\s+d[eеε][liι][eеε][tтτ][eеε]d\.?>$)/i`.

Transcription:

- `^<`… – `<`… must be at the beginning of a message;
- `[mмμ]` – any of this letters: Greek uppercase `Μ` (lowercase `μ`) and Cyrillic uppercase `М` (lowercase `м`) looks absolutely similar to Latin `M` (`m`);
- `[eеε]` – any of this letters: Greek uppercase `Ε` (lowercase `ε`) and Cyrillic uppercase `Е` (lowercase `е`) looks absolutely similar to Latin `E` (`e`);
- `ss` – just letters;
- `[aаα]` – any of this letters: Greek uppercase `Α` (lowercase `α`) and Cyrillic uppercase `А` (lowercase `а`) looks absolutely similar to Latin `A` (`a`);
- `g` – just letter;
- `[eеε]` – see above;
- `\s+` – one or more spaces between the first and the last (second) words;
- `d` – just letter;
- `[eеε]` – see above;
- `[liι]` – any of this letters: Greek uppercase `Ι` (lowercase `ι`) and Latin uppercase `I` (lowercase `i`) looks similar to Latin lowercase `l` (uppercase `L`) in many fonts;
- `[eеε]` – see above;
- `[tтτ]` – any of this letters: Greek uppercase `Τ` (lowercase `τ`) and Cyrillic uppercase `Т` (lowercase `т`) looks absolutely similar to Latin `T` (`t`);
- `[eеε]` – see above;
- `d` – just letter;
- `\.?` – null or one dot `.` (for `<message deleted>` in a browser and `<Message deleted.>` in the mobile app);
- …`>$` – …`>` must be at the end of a message.

You may not have seen the substitution of letters from non-Latin alphabets, but it is quite a well-known phenomenon on European channels (Greece, ex-USSR, ex-Yugoslavia, Bulgaria, and even Germany and Israel with huge Russian and Ukrainian communities). Why only Greek and Cyrillic writing systems? Because other [world popular writing systems](https://en.wikipedia.org/wiki/List_of_writing_systems) have only slightly similar, but not absolutely similar letters.
After such improvement the script catches official Twitch messages `<message deleted>` and `<Message deleted.>` in any language combinations of letters and in any case (upper or lower), but does not catches messages like before (examples: "`<message unreasonably deleted>`" or `<message deleted> why???` or even "`<sh*t deleted> FFS!!! Kappa`") that actually are not fake purges but jokes or insults (which are not a duty of fake purge filter but a duty of a moderators).

-------------------------------

### **GREEK AND CYRILLIC CAPS SUPPORT**

`[A-ZА-ЯЁΑ-Ω]` instead of `[A-Z]`

Transcription:

- `Α-Ω` – Greek letters;
- `А-ЯЁ` – Cyrillic letters and Russian letter `Ё` which is not a part of the range `А-Я`.

Why only Greek and Cyrillic again? Other world most popular writing systems doesn't see the difference between uppercase and lowercase.

Thus, `[^a-z0-9 ]` for `nonAlphaCount` and `nonAlphaSeq` should be similarly replaced with `[^a-z0-9а-яёα-ϖ ]` containing lowercase Greek and Cyrillic letters.

-------------------------------

### **TESTING**

I've been testing all this for three weeks: CAPS and fake purge filters work successfully for both monolingual and multilingual messages.
Sorry for my imperfect English.