### PR TITLE
Filters regex update

### DIFF
--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -29,8 +29,8 @@
         nonAlphaSeq: /([^a-z0-9 ])(\1+)/ig,
         nonAlphaCount: /([^a-z0-9 ])/ig,
         capsCount: /([A-Z])/g,
-        meCheck: /^\/me/,
-        fakePurge: new RegExp(/^<message \w+>|^<\w+ deleted>/i)
+        meCheck: /(^\/me)/i,
+        fakePurge: new RegExp(/(^<message\s+deleted\.?>$)/i)
     };
 
     /**


### PR DESCRIPTION
### **/me FILTER**

At the moment, the color message filter can be bypassed using /ME in the uppercase. So I suggest to replace `/^\/me/` with `/(^\/me)/i`.

**Testing**
```
userName: /me Test message #1
[CHAT] .timeout userName 5 Using colored text. (Automated by botName)
[CHAT] @userName, you were timed out for using colored text. (warning)
userName: /ME Test message #2
[CHAT] .timeout userName 600 Using colored text. (Automated by botName)
```

- - - - - - - - -

### **FAKE PURGE FILTER**

Twitch added a different purge message for its mobile applications, and it looks like `<Message deleted.>`.

At the moment regex catches only messages starting with `<message` and/or containing `deleted>`. Examples: `<message deleted>` as it is, `<mEsSaGe annihilated>` and `<My message was unfairly deleted> WTF?`. The last two are definitely not a fake purge, but a joke (attempt to make a joke) or anything.

My suggestion is to replace `/^<message \w+>|^<\w+ deleted>/i` with `/(^<message\s+deleted\.?>$)/i`.

Transcription:
- `^<`… – `<`… must be at the beginning of a message;
- `\s+` – one or more spaces between `message` and `deleted`;
- `\.?` – null or one dot `.` (for `<message deleted>` in a browser and `<Message deleted.>` in the mobile app);
- …`>$` – …`>` must be at the end of a message.

After such improvement the script catches official Twitch messages `<message deleted>` and `<Message deleted.>` in any case (upper or lower), but does not catches messages like before (examples: `<message unreasonably deleted>` or `<message deleted> why???` or even `<sh*t deleted> FFS!!! Kappa`) that actually are not fake purges but jokes or insults (which are not a duty of fake purge filter but a duty of a moderators).

**Testing**
```
userName: <message deleted>
[CHAT] .timeout userName 5 Fake purge. (Automated by botName)
[CHAT] @userName, you were timed out for a fake purge. (timeout)
userName: <Message deleted.>
[CHAT] .timeout userName 600 Fake purge. (Automated by botName)
```