### PR TITLE
Ignore Bots Completely

### DIFF
--- a/javascript-source/commands/topCommand.js
+++ b/javascript-source/commands/topCommand.js
@@ -21,8 +21,7 @@
  * Build and announce lists of top viewers (Highest points, highest time spent in the channel)
  */
 (function() {
-    var bots = $.readFile('./addons/ignorebots.txt'),
-        amountPoints = $.getSetIniDbNumber('settings', 'topListAmountPoints', 5),
+    var amountPoints = $.getSetIniDbNumber('settings', 'topListAmountPoints', 5),
         amountTime = $.getSetIniDbNumber('settings', 'topListAmountTime', 5);
 
     /*
@@ -34,32 +33,22 @@
     }
 
     /*
-     * @function isTwitchBot
-     * @param {string} username
-     * @returns {Boolean}
-     */
-    function isTwitchBot(username) {
-        for (var i in bots) {
-            if (bots[i].equalsIgnoreCase(username)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /*
      * @function getTop5
      *
      * @param {string} iniName
      * @returns {Array}
      */
     function getTop5(iniName) {
-        var keys = $.inidb.GetKeysByNumberOrderValue(iniName, '', 'DESC', (iniName.equals('points') ? amountPoints + bots.length + 1 : amountTime + bots.length + 1), 0),
+        var keys = $.inidb.GetKeysByNumberOrderValue(iniName, '', 'DESC', (iniName.equals('points') ? amountPoints + 2: amountTime + 2), 0),
             list = [],
-            i;
+            i,
+            ctr = 0;
 
         for (i in keys) {
-            if (!$.isBot(keys[i]) && !$.isOwner(keys[i]) && !isTwitchBot(keys[i])) {
+            if (!$.isBot(keys[i]) && !$.isOwner(keys[i])) {
+                if (ctr++ == (iniName.equals('points') ? amountPoints : amountTime)) {
+                    break;
+                }
                 list.push({
                     username: keys[i],
                     value: $.inidb.get(iniName, keys[i])
@@ -158,10 +147,9 @@
         }
 
         /*
-         * @commandpath reloadtopbots - Reload the list of bots and users to ignore
+         * @commandpath reloadtopbots - DEPRECATED. Use !reloadbots
          */
         if (command.equalsIgnoreCase('reloadtopbots')) {
-            bots = $.readFile('./addons/ignorebots.txt');
             $.say($.whisperPrefix(sender) + $.lang.get('top5.reloadtopbots'));
         }
 

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -32,7 +32,32 @@
         users = [],
         moderatorsCache = [],
         lastJoinPart = $.systemTime(),
-        isUpdatingUsers = false;
+        isUpdatingUsers = false,
+        twitchBots = $.readFile('./addons/ignorebots.txt');
+
+    /**
+     * @function cleanTwitchBots
+     */
+    function cleanTwitchBots() {
+        for (var i in twitchBots) {
+            $.inidb.del('points', twitchBots[i].toLowerCase());
+            $.inidb.del('time', twitchBots[i].toLowerCase());
+        }
+    }
+
+    /**
+     * @function isTwitchBot
+     * @param {string} username
+     * @returns {Boolean}
+     */
+    function isTwitchBot(username) {
+        for (var i in twitchBots) {
+            if (twitchBots[i].equalsIgnoreCase(username)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * @function updateUsersObject
@@ -647,6 +672,10 @@
                 // Cast the user as a string, because Rhino.
                 joins[i] = (joins[i] + '');
 
+                if (isTwitchBot(joins[i])) {
+                    continue;
+                }
+
                 if (!userExists(joins[i])) {
                     if (!$.user.isKnown(joins[i])) {
                         $.setIniDbBoolean('visited', joins[i], true);
@@ -668,6 +697,10 @@
     $.bind('ircChannelJoin', function(event) {
         var username = event.getUser().toLowerCase();
 
+        if (isTwitchBot(username)) {
+            return;
+        }
+
         if (!isUpdatingUsers && !userExists(username)) {
             if (!$.user.isKnown(username)) {
                 $.setIniDbBoolean('visited', username, true);
@@ -685,6 +718,10 @@
      */
     $.bind('ircChannelMessage', function(event) {
         var username = event.getSender().toLowerCase();
+
+        if (isTwitchBot(username)) {
+            return;
+        }
 
         if (!isUpdatingUsers && !userExists(username)) {
             if (!$.user.isKnown(username)) {
@@ -822,6 +859,15 @@
         var sender = event.getSender().toLowerCase(),
             command = event.getCommand(),
             args = event.getArgs();
+
+        /*
+         * @commandpath reloadbots - Reload the list of bots and users to ignore. They will not gain points or time.
+         */
+        if (command.equalsIgnoreCase('reloadbots')) {
+            twitchBots = $.readFile('./addons/ignorebots.txt');
+            cleanTwitchBots();
+            $.say($.whisperPrefix(sender) + $.lang.get('permissions.reloadbots'));
+        }
 
         /**
          * @commandpath users - List users currently in the channel
@@ -980,6 +1026,8 @@
         $.registerChatCommand('./core/permissions.js', 'permissionpoints', 1);
         $.registerChatCommand('./core/permissions.js', 'users', 2);
         $.registerChatCommand('./core/permissions.js', 'mods', 2);
+        $.registerChatCommand('./core/permissions.js', 'reloadbots', 1);
+
 
         /** Load groups and generate default groups if they don't exist */
         reloadGroups();
@@ -988,6 +1036,9 @@
 
         // Load the moderators cache. This needs to load after the privmsg check.
         setTimeout(loadModeratorsCache, 7e3);
+
+        // Clean up data for Twitch bots. 
+        cleanTwitchBots();
     });
 
     /** Export functions to API */

--- a/javascript-source/lang/english/commands/commands-top10Command.js
+++ b/javascript-source/lang/english/commands/commands-top10Command.js
@@ -22,4 +22,4 @@ $.lang.register('top5.amount.max', 'The max amount of users is 15.');
 $.lang.register('top5.amount.points.set', '$1 users will now show in the !top command.');
 $.lang.register('top5.amount.time.usage', 'Usage: !toptimeamount (amount) - Set how many viewers will appear in the !toptime list.');
 $.lang.register('top5.amount.time.set', '$1 viwers will now show in the !toptime command.');
-$.lang.register('top5.reloadtopbots', 'Reloaded list of bots/users to ignore in top commands.');
+$.lang.register('top5.reloadtopbots', 'Deprecated. Please run !reloadbots');

--- a/javascript-source/lang/english/main.js
+++ b/javascript-source/lang/english/main.js
@@ -339,6 +339,7 @@ $.lang.register('logging.usage', 'Usage: !log [files / errors / events]');
 $.lang.register('logging.rotatedays.usage', 'usage: !log rotatedays [days]. 0 to keep all logs. Currently: $1');
 $.lang.register('logging.rotatedays.success', 'Logs will rotate every $1 days.');
 $.lang.register('logging.rotatedays.success.off', 'Logs will not be rotated');
+$.lang.register('permissions.reloadbots', 'Reloaded list of bots and users to not accumulate time or points.');
 $.lang.register('permissions.current.listtoolong', 'There are over $1 to list, I suggest checking the viewerslist in the Twitch chat.');
 $.lang.register('permissions.current.mods', 'Mods in channel: $1');
 $.lang.register('permissions.current.users', 'Users in channel: $1');

--- a/source/tv/phantombot/console/ConsoleEventHandler.java
+++ b/source/tv/phantombot/console/ConsoleEventHandler.java
@@ -255,13 +255,17 @@ public class ConsoleEventHandler implements Listener {
         }
 
         /**
-         * @consolecommand jointest - Sends 30 fake join events.
+         * @consolecommand jointest - Sends 30 fake join events or one specific user for testing.
          */
         if (message.equalsIgnoreCase("jointest")) {
             com.gmt2001.Console.out.println("[CONSOLE] Executing jointest");
 
-            for (int i = 0 ; i < 30; i++) {
-                EventBus.instance().postAsync(new IrcChannelJoinEvent(PhantomBot.instance().getSession(), PhantomBot.generateRandomString(8)));
+            if (argument != null) {
+                EventBus.instance().postAsync(new IrcChannelJoinEvent(PhantomBot.instance().getSession(), argument[0]));
+            } else {
+                for (int i = 0 ; i < 30; i++) {
+                    EventBus.instance().postAsync(new IrcChannelJoinEvent(PhantomBot.instance().getSession(), PhantomBot.generateRandomString(8)));
+                }
             }
         }
 


### PR DESCRIPTION
**topCommand.js**
- Moved out the logic to load/reload the ignorebots.txt file
- Added fix to return proper number of users when a bot or owner is on the top list

**permissions.js**
- Added the handling of ignorebots.txt
- Added !reloadbots
- Do not add an entry to the users list if they are in ignorebots.txt
- Delete data for list of users in ignorebots.txt from the points and time tables on boot and !reloadbots

**lang**
- Update for !reloadbots and !reloadtopbots

**ConsoleEventHandler.java**
- Modified jointest to allow for single user for verifying this change