### PR TITLE
Added a reply if permComMsgEnabled is enabled

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -100,7 +100,7 @@
             var user = message.match(/\(useronly=(.*?)\)/)[1];
             if (!event.getSender().equalsIgnoreCase(user)) {
                 if ($.getIniDbBoolean('settings', 'permComMsgEnabled', true)) {
-                    $.say($.whisperPrefix(sender) + $.lang.get('cmd.useronly', user));
+                    $.say($.whisperPrefix(event.getSender()) + $.lang.get('cmd.useronly', user));
                 }
                 return null;
             }

--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -99,6 +99,9 @@
         if (message.match(/\(useronly=.*\)/g)) {
             var user = message.match(/\(useronly=(.*?)\)/)[1];
             if (!event.getSender().equalsIgnoreCase(user)) {
+                if ($.getIniDbBoolean('settings', 'permComMsgEnabled', true)) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('cmd.useronly', user));
+                }
                 return null;
             }
             message = $.replace(message, message.match(/(\(useronly=.*?\))/)[1], '');

--- a/javascript-source/lang/english/main.js
+++ b/javascript-source/lang/english/main.js
@@ -243,6 +243,7 @@ $.lang.register('cmd.404', 'command !$1 does not exist or is not registered.');
 $.lang.register('cmd.adminonly', 'Only an Administrator has access to that command!');
 $.lang.register('cmd.casteronly', 'Only a Caster has access to that command!');
 $.lang.register('cmd.modonly', 'Only a Moderator has access to that command!');
+$.lang.register('cmd.useronly', 'Only $1 has access to that command!');
 $.lang.register('cmd.needpoints', 'That command costs $1, which you don\'t have.');
 $.lang.register('cmd.perm.404', 'you do not have access to that command. Only $1 or higher can access it.');
 $.lang.register('commandlist.commands', 'Commands (page $1 of $2): $3');


### PR DESCRIPTION
Added a reply if permComMsgEnabled is enabled for (useronly=)

**Example** 
```
[11-10-2018 @ 21:33:40.916 GMT] dakoda: !meonly
[11-10-2018 @ 21:33:40.924 GMT] [CHAT]  Yayyy Dakoda
[11-10-2018 @ 21:33:53.392 GMT] lawlypopzz: !meonly
[11-10-2018 @ 21:33:53.396 GMT] [CHAT] @lawlypopzz, Only dakoda has access to that command!
```

**PS** this was requested by a few people but i didn't see the point until i saw how easy it was to add it :)