### PR TITLE
Rollback Trim in onMessage()

### DIFF
--- a/source/tv/phantombot/twitch/irc/TwitchWSIRC.java
+++ b/source/tv/phantombot/twitch/irc/TwitchWSIRC.java
@@ -178,22 +178,20 @@ public class TwitchWSIRC extends WebSocketClient {
      */
     @Override
     public void onMessage(String message) {
-        String messageTrim = message.trim();
-        
-        if (messageTrim.startsWith("PONG")) {
+        if (message.startsWith("PONG")) {
             lastPong = System.currentTimeMillis();
-        } else if (messageTrim.startsWith("PING")) {
+        } else if (message.startsWith("PING")) {
             send("PONG");
         } else {
             try {
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
-                        twitchWSIRCParser.parseData(messageTrim);
+                        twitchWSIRCParser.parseData(message);
                     }
                 }).start();
             } catch (Exception ex) {
-                twitchWSIRCParser.parseData(messageTrim);
+                twitchWSIRCParser.parseData(message);
             }
         }
     }


### PR DESCRIPTION
**TwitchWSIRC.java**
- Rolled back the trim() on the message in onMessage()
- Later in the WSIRCParser there is a cleanup operation that was removing a good character.
- Removing that cleanup broke multi-line messages.
- Need to revisit this to see if this can be done in a different way to achieve the desired (possible) performance improvement.