### PR TITLE
Fix the creation of mods.txt

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -817,7 +817,7 @@
     $.bind('ircPrivateMessage', function(event) {
         var sender = event.getSender().toLowerCase(),
             message = event.getMessage().toLowerCase().trim(),
-            modMessageStart = 'the moderators of this room are: ',
+            modMessageStart = 'the moderators of this channel are: ',
             vipMessageStart = 'VIPs for this channel are: ',
             keys = $.inidb.GetKeyList('group', ''),
             subsTxtList = [],


### PR DESCRIPTION
**permissions.js**
- Twitch changed the text from .mods command from:
	The moderators of this room are:
  to
	The moderators of this channel are:
- Updated script to support