### PR TITLE
Log the YouTubeAPIv3 Error from YouTube

### DIFF
--- a/source/com/gmt2001/YouTubeAPIv3.java
+++ b/source/com/gmt2001/YouTubeAPIv3.java
@@ -156,6 +156,16 @@ public class YouTubeAPIv3 {
             j.put("_exceptionMessage", "");
             j.put("_content", content);
             postjson = new Date();
+
+            /* If the JSON was properly parsed then we may have received back a proper error JSON payload from YouTube. */
+            if (j.has("error")) {
+                if (j.getJSONObject("error").has("errors")) {
+                    JSONArray jaerror = j.getJSONObject("error").getJSONArray("errors");
+                    if (jaerror.getJSONObject(0).has("reason") && jaerror.getJSONObject(0).has("domain")) {
+                        com.gmt2001.Console.err.println("YouTubeAPIv3 Error: [Domain] " + jaerror.getJSONObject(0).getString("domain") + " [Reason] " + jaerror.getJSONObject(0).getString("reason"));
+                    }
+                }
+            }
         } catch (JSONException ex) {
             if (ex.getMessage().contains("A JSONObject text must begin with")) {
                 j = new JSONObject("{}");


### PR DESCRIPTION
**YouTubeAPIv3.java**
- If we receive a proper JSON payload back from YouTube, provide the domain and reason portions of the error message.
- Example:
    [12-14-2018 @ 10:18:40.683 MST] [ERROR] [GetData()@YouTubeAPIv3.java:180] YouTubeAPIv3 Error: [Domain] usageLimits [Reason] keyInvalid