### PR TITLE
Remove Internal YouTube API Key, Require User to Obtain

### DIFF
--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -373,9 +373,6 @@
                             $.log.error("importPlaylistFile::skipped [" + importedList[i] + "]: " + ex);
                             failCount++;
                         }
-                        if (importCount == $.youtube.max() && !$.youtube.checkapi()) {
-                            break;
-                        }
                     }
                     $.inidb.set(playlistDbPrefix + listName, 'lastkey', importCount);
 

--- a/resources/web/ytplayer/js/index.js
+++ b/resources/web/ytplayer/js/index.js
@@ -33,7 +33,7 @@ $(function() {
     /*
      * @function Loads the player page.
      *
-     * @param {boolean} hasPlaylistData - If a playlis is loaded.
+     * @param {boolean} hasPlaylistData - If a playlist is loaded.
      */
     const openPlayer = hasPlaylistData => {
         $('.loader').fadeOut(6e2, () => {
@@ -42,7 +42,7 @@ $(function() {
         // Show the page.
         $('#main').fadeIn(5e2);
 
-        if (!hasPlaylistData) {
+        if (!hasPlaylistData && player.hasAPIKey()) {
             toastr.error('Failed to load a playlist with songs.');
 
             // Create a fake progress slider.

--- a/source/com/gmt2001/YouTubeAPIv3.java
+++ b/source/com/gmt2001/YouTubeAPIv3.java
@@ -44,9 +44,7 @@ import com.illusionaryone.SimpleScramble;
 public class YouTubeAPIv3 {
 
     private static final YouTubeAPIv3 instance = new YouTubeAPIv3();
-    private final SimpleScramble simpleScramble = new SimpleScramble();
-    private String scramblekey = "ZARRKwMxPSgWRQ5rKQdHQVhAFUAXH14BQCdAa2UYfB9IIA8OKgET";
-    private String apikey = simpleScramble.simpleFixedUnscramble(scramblekey);
+    private String apikey = "";
 
     private enum request_type {
 
@@ -127,21 +125,6 @@ public class YouTubeAPIv3 {
                 i = new BufferedInputStream(c.getErrorStream());
             }
 
-            /*
-             * if (i != null) { available = i.available();
-             *
-             * while (available == 0 && (new Date().getTime() -
-             * postconnect.getTime()) < 450) { Thread.sleep(500); available =
-             * i.available(); }
-             *
-             * if (available == 0) { i = new
-             * BufferedInputStream(c.getErrorStream());
-             *
-             * if (i != null) { available = i.available(); } } }
-             *
-             * if (available == 0) { content = "{}"; } else { content =
-             * IOUtils.toString(i, c.getContentEncoding()); }
-             */
             content = IOUtils.toString(i, c.getContentEncoding());
             rawcontent = content;
             prejson = new Date();
@@ -409,7 +392,6 @@ public class YouTubeAPIv3 {
                                };
                     }
 
-                    //String d = cd.getString("duration").substring(2);
                     int h, m, s;
 
                     String hours = d.toStandardHours().toString().substring(2);
@@ -421,19 +403,6 @@ public class YouTubeAPIv3 {
                     String seconds = d.toStandardSeconds().toString().substring(2);
                     s = Integer.parseInt(seconds.substring(0, seconds.indexOf("S")));
 
-                    /*
-                     * if (d.contains("H")) { h =
-                     * Integer.parseInt(d.substring(0, d.indexOf("H")));
-                     *
-                     * d = d.substring(0, d.indexOf("H")); }
-                     *
-                     * if (d.contains("M")) { m =
-                     * Integer.parseInt(d.substring(0, d.indexOf("M")));
-                     *
-                     * d = d.substring(0, d.indexOf("M")); }
-                     *
-                     * s = Integer.parseInt(d.substring(0, d.indexOf("S")));
-                     */
                     com.gmt2001.Console.debug.println("YouTubeAPIv3.GetVideoLength Success");
 
                     return new int[] {
@@ -483,13 +452,5 @@ public class YouTubeAPIv3 {
             }
         }
         return new int[] { licenseRetval, embedRetval };
-    }
-
-    public int max() {
-        return Integer.parseInt(simpleScramble.simpleFixedUnscramble("FHgb"));
-    }
-
-    public boolean checkapi() {
-        return !apikey.equals(simpleScramble.simpleFixedUnscramble(scramblekey));
     }
 }

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -356,6 +356,12 @@ public final class PhantomBot implements Listener {
         }
     }
 
+    /* Check to see if YouTube Key is configured.
+     */
+    public boolean isYouTubeKeyEmpty() {
+        return youtubeKey.isEmpty();
+    }
+
     /*
      * Constructor for PhantomBot object.
      *

--- a/source/tv/phantombot/ytplayer/YTWebSocketServer.java
+++ b/source/tv/phantombot/ytplayer/YTWebSocketServer.java
@@ -187,7 +187,9 @@ public class YTWebSocketServer extends WebSocketServer {
             sessionData.setPlayer(true);
             authResult(authenticated, webSocket);
             if (authenticated) {
-                EventBus.instance().postAsync(new YTPlayerConnectEvent());
+                if (!checkYouTubeKey(webSocket)) {
+                    EventBus.instance().postAsync(new YTPlayerConnectEvent());
+                }
             }
             return;
         }
@@ -431,6 +433,17 @@ public class YTWebSocketServer extends WebSocketServer {
 
     public void setClientConnected(boolean clientConnected) {
         this.clientConnected = clientConnected;
+    }
+
+    private boolean checkYouTubeKey(WebSocket webSocket) {
+        JSONStringer jsonObject = new JSONStringer();
+        webSocket.send(jsonObject.object().key("ytkeycheck").value(!PhantomBot.instance().isYouTubeKeyEmpty()).endObject().toString());
+
+        if (PhantomBot.instance().isYouTubeKeyEmpty()) {
+            com.gmt2001.Console.err.println("A YouTube API key has not been configured. Please review the instructions on the " +
+                                            "PhantomBot Community Forum at: https://community.phantombot.tv/t/acquire-youtube-api-key/222");
+        }
+        return PhantomBot.instance().isYouTubeKeyEmpty();
     }
 
     // Class for storing Session data.


### PR DESCRIPTION
**youtubePlayer.js**
- Remove limits for playlists as individuals will have their own keys.

**ytplayer/index.js**
- Updated to not load a playlist if there is not an API key.
- Prevents a useless (and annoying) error from popping up.
- Fixed typo.  There was "Playist Error" on the modal error for playlists.

**ytplayer/socket.js**
- Added from the Core to see if an API key is present
- If not, throws an error with instructions.

**YouTubeAPIv3.java**
- Removed methods no longer needed.
- Cleaned up comments.

**PhantomBot.java**
- New method to determine if the YouTube API key is empty.

**YTWebSocketServer.java**
- New method to determine if the YouTube API key is empty, sends event to the YouTube Player.
- Do not send an event to youtubePlayer.js to indicate that the GUI is up if there is not an API key.