### PR TITLE
Cleanup YouTube API and Add Quota Points Tracking

### DIFF
--- a/source/tv/phantombot/console/ConsoleEventHandler.java
+++ b/source/tv/phantombot/console/ConsoleEventHandler.java
@@ -114,6 +114,21 @@ public class ConsoleEventHandler implements Listener {
         }
 
         /**
+         * @consolecommand checkytquota - This command checks the quota points used by YouTube.
+         */
+        if (message.equalsIgnoreCase("checkytquota")) {
+            String ytQuotaDate = dataStore.GetString("youtubePlayer", "", "quotaDate");
+            String ytQuotaPoints = dataStore.GetString("youtubePlayer", "", "quotaPoints");
+
+            if (ytQuotaDate == null || ytQuotaPoints == null) {
+                com.gmt2001.Console.out.println("No YouTube Quota Data Found.");
+            } else {
+                com.gmt2001.Console.out.println("YouTube Quota Date (US/Pacific): " + ytQuotaDate + " Points Used: " + ytQuotaPoints);
+            }
+            return;
+        }
+            
+        /**
          * @consolecommand exportpoints - This command exports points and time to a CSV file.
          */
         if (message.equalsIgnoreCase("exportpoints")) {


### PR DESCRIPTION
**YouTubeAPIv3.java**
- Cleaned up the REST handling
- Use a simplified and more modular way to query YouTube
- Cleaned up debug logging
- Added in quota point tracking.  Note that this only tracks the points used in the YouTube API in Phantombot.  YouTube does not return the points used.  If the API key is used elsewhere, such as in an external process to create playlist import files, those points are not counted.
- Will reset the quota points when a new date is detected, based on the US/Pacific (US/Los_Angeles) time zone.

**ConsoleEventHandler.java**
- New command: checkytquota
- Checks the quota points used during a 24-hour period.
