### PR TITLE
Enhance callHook Error Log

### DIFF
--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -314,7 +314,8 @@
             try {
                 hook.handlers[i].handler(event);
             } catch (ex) {
-                $.log.error('(hook.call, ' + hookName + ', ' + hook.handlers[i].scriptName + ') ' + ex);
+                $.log.error('(hook.call, ' + hookName + ', ' + hook.handlers[i].scriptName + ') Stack: ' + ex.stack.split('\n').join(' > ').replace(/anonymous\(\)@|callHook\(\)@/g, '') + ' Exception: ' + ex);
+
             }
         } else {
             for (i in hook.handlers) {
@@ -322,7 +323,8 @@
                     try {
                         hook.handlers[i].handler(event);
                     } catch (ex) {
-                        $.log.error('(hook.call, ' + hookName + ', ' + hook.handlers[i].scriptName + ') ' + ex);
+                        $.log.error('(hook.call, ' + hookName + ', ' + hook.handlers[i].scriptName + ') Stack: ' + ex.stack.split('\n').join(' > ').replace(/anonymous\(\)@|callHook\(\)@/g, '') + ' Exception: ' + ex);
+
                     }
                 }
             }


### PR DESCRIPTION
**init.js**
- Show the stack trace to indicate where the exception was thrown from.
	- Example: [12-31-2018 @ 14:19:34.141 MST] [ERROR] [init.js:317] (hook.call, command, ./systems/quoteSystem.js) Stack: quoteSystem.js:292 > init.js:315 > init.js:512 >  Exception: ReferenceError: "blah" is not defined.
	- The offending code is in quoteSystem.js on line 292.