### PR TITLE
Add Custom text functionality to gif alerts

### DIFF
--- a/resources/web/alerts/index.html
+++ b/resources/web/alerts/index.html
@@ -36,6 +36,12 @@
                 align-items: center;
                 justify-content: center;
             }
+
+            .main-text-alert {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
         </style>
 
         <!-- Load our favicon -->
@@ -47,6 +53,10 @@
         <div class="main-alert">
             <!-- Where the gif gets played. -->
             <div id="alert"></div>
+        </div>
+        <div class="main-text-alert">
+            <!-- Where the custom gif text is displayed. -->
+            <div id="alert-text"></div>
         </div>
 
         <!-- jQuery -->

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -229,6 +229,7 @@ $(function() {
                 gifVolume = getOptionSetting('gif-default-volume', '0.8'),
                 gifFile = '',
                 gifCss = '',
+                gifText = '',
                 htmlObj,
                 audio;
 
@@ -251,6 +252,9 @@ $(function() {
                         case 3:
                             gifCss = value;
                             break;
+                        case 4:
+                            gifText = value;
+                            break;
                     }
                 });
             } else {
@@ -272,6 +276,20 @@ $(function() {
                     'style': gifCss
                 });
             }
+
+            // p obeject to hold custom gif alert text and style
+            textObj = $('<p/>', {
+                'style': gifCss
+            }).text(gifText);
+
+            // Append the custom text object to the page
+            $('#alert-text').append(textObj).fadeIn(1e2).delay(gifDuration)
+              .fadeOut(1e2, function() { //Remove the text with a fade out.
+                let t = $(this);
+
+                // Remove the p tag
+                t.find('p').remove();
+              });
 
             // Append a new the image.
             $('#alert').append(htmlObj).fadeIn(1e2, function() {


### PR DESCRIPTION
* Adds an optional extra parameter for the (alert) function for gif alerts to add custom text to the screen

Sample command using new functionality:
```
(alert banana.gif,5,0.5,color:red; font-size:30px;,CUSTOM TEXT PLEASE IGNORE)
```
|Parameter|Value|
|---|---|
| file | banana.gif |
|duration|5 seconds|
|volume|50%|
|custom CSS|color:red; font-size:30px|
|custom Text|CUSTOM TEXT PLEASE IGNORE|

Adds feature requested in [thread a](https://community.phantombot.tv/t/gif-alert-with-custom-text-and-command-user-name/1969) and [thread b](https://community.phantombot.tv/t/gif-alert-with-custom-text-in-screen-not-in-chat/399)