### PR TITLE
- Added support for Twitch's anonymous sub gifters & new IRC tag support.

### DIFF
--- a/source/tv/phantombot/event/twitch/subscriber/TwitchAnonymousSubscriptionGiftEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchAnonymousSubscriptionGiftEvent.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016-2018 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tv.phantombot.event.twitch.subscriber;
+
+import tv.phantombot.event.twitch.TwitchEvent;
+
+/**
+ *
+ * @author Branden
+ */
+public class TwitchAnonymousSubscriptionGiftEvent extends TwitchEvent {
+    private final String recipient;
+    private final String months;
+    private final String plan;
+    
+    /**
+     * The class constructor.
+     * 
+     * @param username
+     * @param recipient
+     * @param plan 
+     */
+    public TwitchAnonymousSubscriptionGiftEvent(String username, String recipient, String plan) {
+        this.recipient = recipient;
+        this.months = null;
+        this.plan = plan;
+    }
+    
+    /**
+     * The class constructor.
+     * @param username
+     * @param recipient
+     * @param months
+     * @param plan 
+     */
+    public TwitchAnonymousSubscriptionGiftEvent(String username, String recipient, String months, String plan) {
+        this.recipient = recipient;
+        this.months = months;
+        this.plan = plan;
+    }
+    
+    /*
+     * Method that returns the gifted the subscription.
+     *
+     * @return {String} username
+     */
+    public String getUsername() {
+        return "anonymous";
+    }
+
+    /*
+     * Method that returns the recipient.
+     *
+     * @return {String} recipient
+     */
+    public String getRecipient() {
+        return this.recipient;
+    }
+
+    /*
+     * Method that returns the months, can be 0.
+     *
+     * @return {String} months
+     */
+    public String getMonths() {
+        return (this.months == null) ? "1" : this.months;
+    }
+
+    /*
+     * Method that returns the subcription plan. (1000, 2000, 3000 and Prime)
+     *
+     * @return {String} plan
+     */
+    public String getPlan() {
+        return this.plan;
+    }
+}

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchMassAnonymousSubscriptionGiftedEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchMassAnonymousSubscriptionGiftedEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2018 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tv.phantombot.event.twitch.subscriber;
+
+import tv.phantombot.event.twitch.TwitchEvent;
+
+/**
+ *
+ * @author Branden
+ */
+public class TwitchMassAnonymousSubscriptionGiftedEvent extends TwitchEvent {
+    private final String amount;
+    private final String plan;
+    
+    /**
+     * Class constructor.
+     * 
+     * @param amount
+     * @param plan 
+     */
+    public TwitchMassAnonymousSubscriptionGiftedEvent(String amount, String plan) {
+        this.amount = amount;
+        this.plan = plan;
+    }
+    
+    /**
+     * Get the user, which is always anonymous.
+     * 
+     * @return 
+     */
+    public String getUsername() {
+        return "anonymous";
+    }
+    
+    /**
+     * Gets the amount of subs gifted.
+     * 
+     * @return 
+     */
+    public String getAmount() {
+        return amount;
+    }
+    
+    /**
+     * Gets the sub plan.
+     * 
+     * @return 
+     */
+    public String getPlan() {
+        return plan;
+    }
+}

--- a/source/tv/phantombot/twitch/irc/chat/utils/SubscriberBulkGifter.java
+++ b/source/tv/phantombot/twitch/irc/chat/utils/SubscriberBulkGifter.java
@@ -19,6 +19,7 @@ package tv.phantombot.twitch.irc.chat.utils;
 public class SubscriberBulkGifter {
     private final String username;
     private final int totalSubscriptionsGifted;
+    private final boolean isAnonymous;
     private int currentSubscriptionsGifted = 0;
     
     /**
@@ -27,9 +28,10 @@ public class SubscriberBulkGifter {
      * @param username
      * @param totalSubscriptionsGifted 
      */
-    public SubscriberBulkGifter(String username, int totalSubscriptionsGifted) {
+    public SubscriberBulkGifter(String username, int totalSubscriptionsGifted, boolean isAnonymous) {
         this.username = username;
         this.totalSubscriptionsGifted = totalSubscriptionsGifted;
+        this.isAnonymous = isAnonymous;
     }
     
     /**
@@ -61,5 +63,14 @@ public class SubscriberBulkGifter {
      */
     public void increaseCurrentSubscriptionGifted() {
         currentSubscriptionsGifted++;
+    }
+    
+    /**
+     * Method that returns if this was by anonymous.
+     * 
+     * @return 
+     */
+    public boolean isAnonymous() {
+        return isAnonymous;
     }
 }


### PR DESCRIPTION
- This adds two new events `twitchMassSubscriptionGifted` and
`twitchAnonymousSubscriptionGift` which allows us to have a custom
message for when someone gifts a sub anonymously.
- Twitch is also not using the events on their docs for this, so I added
support for the events on the docs, and the current active ones from
their forums, here's the link:
https://discuss.dev.twitch.tv/t/anonymous-sub-gifting-to-launch-11-15-launch-details/18683
- I also added the new code for when Twitch removes deprecated IRC tags