### PR TITLE
- Fixed type error with the Irc leave event in permissions.js

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -685,7 +685,7 @@
 
         if (!isUpdatingUsers) {
             for (i in users) {
-                if (users[i][0].equals(username.toLowerCase())) {
+                if (users[i] !== undefined && users[i][0].equals(username.toLowerCase())) {
                     users.splice(i, 1);
                     restoreSubscriberStatus(username.toLowerCase());
 
@@ -1007,7 +1007,7 @@
         // Load the moderators cache. This needs to load after the privmsg check.
         setTimeout(loadModeratorsCache, 7e3);
 
-        // Clean up data for Twitch bots. 
+        // Clean up data for Twitch bots.
         cleanTwitchBots();
     });
 


### PR DESCRIPTION
- Since we do not use concurrent objects, sometimes array indexes can be
undefined if another thread is updating it, this will be resolved in the
permission system move to the core with a Java ConcurrentHashMap