### PR TITLE
Out of Bounds Error Occured with No Badges

### DIFF
--- a/source/tv/phantombot/twitch/irc/TwitchWSIRCParser.java
+++ b/source/tv/phantombot/twitch/irc/TwitchWSIRCParser.java
@@ -226,7 +226,7 @@ public class TwitchWSIRCParser implements Runnable {
             // The first tag should be badges.
             // So we should parse them into tags, since Twitch doesn't provide us this anymore.
             String[] keyValues = tagParts[0].split("=");
-            if (keyValues.length > 0 && keyValues[0].equals("badges")) {
+            if (keyValues.length > 1 && keyValues[0].equals("badges")) {
                 tags.putAll(parseBadges(keyValues[1]));
             }
             


### PR DESCRIPTION
**TwitchWSIRCParser.java**
- When no badges were presented, an array out of bounds error was tossed
- Changed code to ensure that there are enough array elements before trying to grab badges.