### PR TITLE
New Quote System Feature: Alias Names

### DIFF
--- a/javascript-source/lang/english/systems/systems-quoteSystem.js
+++ b/javascript-source/lang/english/systems/systems-quoteSystem.js
@@ -34,3 +34,9 @@ $.lang.register('quotesystem.quotemessage.success', 'Changed the message used fo
 $.lang.register('quotesystem.searchquote.usage', 'Usage: !searchquote [text] (Must provide at least 5 characters)');
 $.lang.register('quotesystem.searchquote.404', 'No matching quotes found.');
 $.lang.register('quotesystem.searchquote.found', 'Quote IDs with matches: $1');
+$.lang.register('quotesystem.aliases.add.usage', 'Usage: !quoteaddalias [quoteId] [alias]');
+$.lang.register('quotesystem.aliases.add.duplicate', 'Alias "$1" already exists.');
+$.lang.register('quotesystem.aliases.add.success', 'Added alias "$1" for quote ID $2.');
+$.lang.register('quotesystem.aliases.del.usage', 'Usage: !quotedelalias [alias]');
+$.lang.register('quotesystem.aliases.del.404', 'Could not find alias "$1".');
+$.lang.register('quotesystem.aliases.del.success', 'Deleted alias "$1".');

--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -78,13 +78,13 @@
             $.inidb.del('quotes', quoteId);
             quoteKeys = $.inidb.GetKeyList('quotes', '');
             aliases = $.inidb.GetKeyList('quotealiases', '');
-            
+
             $.inidb.setAutoCommit(false);
             for (i in quoteKeys) {
                 quotes.push($.inidb.get('quotes', quoteKeys[i]));
                 $.inidb.del('quotes', quoteKeys[i]);
             }
-            
+
             for (i in quotes) {
                 $.inidb.set('quotes', i, quotes[i]);
             }
@@ -94,7 +94,7 @@
                 if (aliasTarget == quoteId) $.inidb.del('quotealiases', aliases[i]);
                 if (aliasTarget > quoteId) $.inidb.set('quotealiases', aliases[i], aliasTarget-1);
             }
-            
+
             $.inidb.setAutoCommit(true);
             isDeleting = false;
             return (quotes.length ? quotes.length : 0);
@@ -110,18 +110,18 @@
      */
     function getQuote(quoteId) {
         var quote;
-        
+
         if (!quoteId) {
             quoteId = $.rand($.inidb.GetKeyList('quotes', '').length);
         } 
-        
+
         if (isNaN(quoteId)) {
             $.consoleLn("[DEBUG] Looking for quoteId that is NaN: "+quoteId);
             quoteId = $.getIniDbNumber('quotealiases', quoteId, false);
             $.consoleLn("[DEBUG] Looked up quoteId: "+quoteId);
             if (quoteId === false) return [];
         }
-        
+
         if ($.inidb.exists('quotes', quoteId)) {
             quote = JSON.parse($.inidb.get('quotes', quoteId));
             quote.push(quoteId);
@@ -324,7 +324,7 @@
 
             $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.searchquote.found', matchingKeys.join(', ')));
         }
-        
+
         /**
          * @commandpath quoteaddalias [quoteId] [alias] - Adds an alias for a quote
          */
@@ -333,16 +333,16 @@
                 $.say($.whisperPrefix(sender) + 'Usage: !quoteaddalias [quoteId] [alias]');
                 return;
             }
-            
+
             if ($.getIniDbString('quotealiases',args[1])) {
                 $.say($.whisperPrefix(sender) + 'Alias "'+args[1]+'" already exists.');
                 return;
             }
-            
+
             $.setIniDbNumber('quotealiases',args[1],args[0]);
             $.say($.whisperPrefix(sender) + 'Added alias "'+args[1]+'" for quote ID '+args[0]);
         }
-        
+
         /**
          * @commandpath quotedelalias [alias] - Removes an alias
          */
@@ -351,12 +351,12 @@
                 $.say($.whisperPrefix(sender) + 'Usage: !quotedelalias [alias]');
                 return;
             }
-            
+
             if (!$.inidb.exists('quotealiases',args[0])) {
                 $.say($.whisperPrefix(sender) + 'Could not find alias "'+args[0]+'"');
                 return;
             }
-            
+
             $.inidb.del('quotealiases',args[0]);
             $.say($.whisperPrefix(sender) + 'Deleted alias "'+args[0]+'"');
         }

--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -328,17 +328,17 @@
          */
         if (command.equalsIgnoreCase('quoteaddalias')) {
             if (args.length<2||(isNaN(args[0])||String(args[1]).match(/^[0-9]+$/)!= null)) {
-                $.say($.whisperPrefix(sender) + 'Usage: !quoteaddalias [quoteId] [alias]');
+                $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.aliases.add.usage'));
                 return;
             }
 
             if ($.getIniDbString('quotealiases',args[1])) {
-                $.say($.whisperPrefix(sender) + 'Alias "'+args[1]+'" already exists.');
+                $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.aliases.add.duplicate', args[1]));
                 return;
             }
 
             $.setIniDbNumber('quotealiases',args[1],args[0]);
-            $.say($.whisperPrefix(sender) + 'Added alias "'+args[1]+'" for quote ID '+args[0]);
+            $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.aliases.add.success', args[1], args[0]));
         }
 
         /**
@@ -346,17 +346,17 @@
          */
         if (command.equalsIgnoreCase('quotedelalias')) {
             if (!args[0]) {
-                $.say($.whisperPrefix(sender) + 'Usage: !quotedelalias [alias]');
+                $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.aliases.del.usage'));
                 return;
             }
 
             if (!$.inidb.exists('quotealiases',args[0])) {
-                $.say($.whisperPrefix(sender) + 'Could not find alias "'+args[0]+'"');
+                $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.aliases.del.404', args[0]));
                 return;
             }
 
             $.inidb.del('quotealiases',args[0]);
-            $.say($.whisperPrefix(sender) + 'Deleted alias "'+args[0]+'"');
+            $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.aliases.del.success', args[0]));
         }
     });
 

--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -116,9 +116,7 @@
         } 
 
         if (isNaN(quoteId)) {
-            $.consoleLn("[DEBUG] Looking for quoteId that is NaN: "+quoteId);
             quoteId = $.getIniDbNumber('quotealiases', quoteId, false);
-            $.consoleLn("[DEBUG] Looked up quoteId: "+quoteId);
             if (quoteId === false) return [];
         }
 


### PR DESCRIPTION
EDIT: **Do not merge yet**. I'm going to integrate this into the panel and update this PR.

Added support for alias names for quotes from quoteSystem.js

**quoteSystem.js**
- updated function `getQuote()` to attempt to fetch the ID of the quote based on the argument, should it not be a number. Should the alias not exist it will return an empty array, same as if the argument was an invalid ID
- updated function `deleteQuote()` to remove aliases for the quote that is getting deleted and shift down values past the ID of the deleted quote to match the new IDs
- added command `!quoteaddalias [quoteId] [alias]` to add new aliases via chat
- added command `!quotedelalias [alias]` to remove an alias via chat

**Database**
- added file `quotealiases` to store quote aliases. The alias name is used as key, while the ID of the quote it belongs to is stored as the value. This allows for multiple aliases per quote and prevents overlapping names.

**EDIT:** ~~I'll be moving the strings in the added commands to a lang file. Can't test that currently as twitch chat is too slow to work right now.~~ Changes are commited and tested now.

Test results:

![quoteaddalias_1](https://user-images.githubusercontent.com/19474909/51126401-50cc5080-1823-11e9-89f5-3b24c1e78758.PNG)  
`!quote` now supports aliases. Adding aliases works and an exception is given should an alias of that name already exist.

![quotedelalias_1](https://user-images.githubusercontent.com/19474909/51126490-912bce80-1823-11e9-9c87-0858ad390ca5.PNG)  
`!quotedelalias` works and gives an exception should an alias of that name not exist.

![quotedel_1](https://user-images.githubusercontent.com/19474909/51126528-b3255100-1823-11e9-9515-8634cbd4ea09.PNG)  
The updated `!delquote` correctly shifts down IDs in the database file for quotes with IDs bigger than the deleted quote. The same result has also been replicated for deleting the command via the beta-panel!

![quotealiaserrors_1](https://user-images.githubusercontent.com/19474909/51126648-eff14800-1823-11e9-966d-893d92db8e5e.PNG)  
Further exceptions for incorrect or missing arguments for `!quoteaddalias` and `!quotedelalias`
