### PR TITLE
Block Access to commands for ignored bots

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -902,7 +902,7 @@
         }
 
         /**
-         * @commandpath ignoreremove - List the bots from the ignorebots.txt
+         * @commandpath ignorelist - List the bots from the ignorebots.txt
          */
         if (command.equalsIgnoreCase('ignorelist')) {
             var tmp = Object.keys(botList);
@@ -914,14 +914,14 @@
         }
 
         /**
-         * @commandpath ignoreadd - Add a bot to the ignorebots.txt
+         * @commandpath ignoreadd [username] - Add a bot to the ignorebots.txt
          */
         if (command.equalsIgnoreCase('ignoreadd')) {
             if (!actionValue) {
                 $.say($.whisperPrefix(sender) + $.lang.get('ignoreadd.usage'));
             } else {
                 actionValue = actionValue.toLowerCase();
-                actionValue = actionValue.trim();
+                actionValue = $.user.sanitize(actionValue.trim());
                 if (!isTwitchBot(actionValue)) {
                     addTwitchBot(actionValue);
                     saveBotList();
@@ -933,14 +933,14 @@
         }
 
         /**
-         * @commandpath ignoreremove - Remove a bot from the ignorebots.txt
+         * @commandpath ignoreremove [username] - Remove a bot from the ignorebots.txt
          */
         if (command.equalsIgnoreCase('ignoreremove')) {
             if (!actionValue) {
                 $.say($.whisperPrefix(sender) + $.lang.get('ignoreremove.usage'));
             } else {
                 actionValue = actionValue.toLowerCase();
-                actionValue = actionValue.trim();
+                actionValue = $.user.sanitize(actionValue.trim());
                 if (isTwitchBot(actionValue)) {
                     removeTwitchBot(actionValue);
                     saveBotList();

--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -433,7 +433,7 @@
                     // Replace everything that is not \w
                     actionArg1 = $.user.sanitize(actionArg1);
 
-                    if (!$.user.isKnown(actionArg1)) {
+                    if (!$.user.isKnown(actionArg1) || $.isTwitchBot(actionArg1)) {
                         $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', actionArg1));
                         return;
                     }
@@ -469,7 +469,7 @@
                     // Replace everything that is not \w
                     actionArg1 = $.user.sanitize(actionArg1);
 
-                    if (!$.user.isKnown(actionArg1)) {
+                    if (!$.user.isKnown(actionArg1) || $.isTwitchBot(actionArg1)) {
                         $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', actionArg1));
                         return;
                     }
@@ -498,7 +498,7 @@
                     // Replace everything that is not \w
                     actionArg1 = $.user.sanitize(actionArg1);
 
-                    if (!$.user.isKnown(actionArg1)) {
+                    if (!$.user.isKnown(actionArg1) || $.isTwitchBot(actionArg1)) {
                         $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', actionArg1));
                         return;
                     }
@@ -772,7 +772,7 @@
             // Replace everything that is not \w
             action = $.user.sanitize(action);
 
-            if (!$.user.isKnown(action)) {
+            if (!$.user.isKnown(action) || $.isTwitchBot(action)) {
                 $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.gift.404'));
                 return;
             }


### PR DESCRIPTION
This will block !gift !points add, take, give and set from adding removing or setting the points of a ignored bot but this does not stop the beta-panel from doing so

**Before:**
![image goes here](https://i.imgur.com/VHblS4Q.png)

**After:**
![image goes here](https://i.imgur.com/eTLLrl9.png)