### PR TITLE
Fix for (age) tag response

### DIFF
--- a/javascript-source/core/streamInfo.js
+++ b/javascript-source/core/streamInfo.js
@@ -379,7 +379,7 @@
         if (days > 0) {
             $.say($.lang.get('common.get.age.days', $.userPrefix(event.getSender(), true), (!event.getArgs()[0] ? event.getSender() : $.user.sanitize(event.getArgs()[0])), dateFinal, days));
         } else {
-            $.say($.lang.get('common.get.age.days', $.userPrefix(event.getSender(), true), (!event.getArgs()[0] ? event.getSender() : $.user.sanitize(event.getArgs()[0])), dateFinal));
+            $.say($.lang.get('common.get.age', $.userPrefix(event.getSender(), true), (!event.getArgs()[0] ? event.getSender() : $.user.sanitize(event.getArgs()[0])), dateFinal));
         }
     }
 


### PR DESCRIPTION
Fix for `(age)` tag response when age is less than 1 day

### Before:
```
age onnnmk
onnnmk has been on Twitch since February 18, 2019. (Joined $4 days ago)
```

### After:
```
age onnnmk
onnnmk has been on Twitch since February 18, 2019.
```