### PR TITLE
Declare `time` at the beginning of the rank system script

### DIFF
--- a/javascript-source/systems/ranksSystem.js
+++ b/javascript-source/systems/ranksSystem.js
@@ -25,6 +25,7 @@
 
     var rankEligableTime = $.getSetIniDbNumber('settings', 'rankEligableTime', 50),
         rankEligableCost = $.getSetIniDbNumber('settings', 'rankEligableCost', 200),
+        time,
         ranksTimeTable;
 
     /**


### PR DESCRIPTION
The error might not happen on some js environments because of the
missing `"use strict";` directive. To avoid such errors in the future it
is advised to put this at the beginning of *all* the other js files as
well.