### PR TITLE
Fix Time Handling for Videos on !highlight Command

### DIFF
--- a/javascript-source/commands/highlightCommand.js
+++ b/javascript-source/commands/highlightCommand.js
@@ -55,12 +55,12 @@
                 return;
             }
 
-            uptime = $.getStreamUptime($.channelName);
+            uptime = $.getStreamUptimeSeconds($.channelName);
             twitchVODtime = $.makeTwitchVODTime(uptime);
             vodJsonObj = JSON.parse(vodJsonStr);
             vodURL = vodJsonObj.videos[0].url + twitchVODtime;
 
-            var streamUptimeMinutes = parseInt($.getStreamUptimeSeconds($.channelName) / 60),
+            var streamUptimeMinutes = parseInt(uptime / 60),
                 hours = parseInt(streamUptimeMinutes / 60),
                 minutes = (parseInt(streamUptimeMinutes % 60) < 10 ? '0' + parseInt(streamUptimeMinutes % 60) : parseInt(streamUptimeMinutes % 60)),
                 timestamp = hours + ':' + minutes,

--- a/javascript-source/commands/streamCommand.js
+++ b/javascript-source/commands/streamCommand.js
@@ -25,29 +25,11 @@
     /*
      * @function makeTwitchVODTime
      *
-     * @param  twitchUptime
+     * @param  twitchUptime - Number of seconds stream has been up.
      * @return twitchVODTime
      */
     function makeTwitchVODTime(twitchUptime) {
-        var hours,
-            minutes,
-            seconds;
-
-        /* Uptime contains hours, run regular expression match as such. */
-        if (twitchUptime.indexOf('hours') !== -1) {
-            match = twitchUptime.match(/(\d+) hours, (\d+) minutes, and (\d+) seconds/);
-            return '?t=' + match[1] + 'h' + match[2] + 'm' + match[3] + 's';
-
-            /* Uptime contains minutes, but not hours, run regular expression match as such. */
-        } else if (twitchUptime.indexOf('minutes') !== -1) {
-            match = twitchUptime.match(/(\d+) minutes, and (\d+) seconds/);
-            return '?t=' + match[1] + 'm' + match[2] + 's';
-
-            /* Uptime only contains seconds, run regular expression match as such. */
-        } else {
-            match = twitchUptime.match(/(\d+) seconds/);
-            return '?t=' + match[1] + 's';
-        }
+        return '?t=' + twitchUptime + 's';
     }
 
     /*


### PR DESCRIPTION
Fix Time Handling for Videos on !highlight Command

**highlightCommand.js**
- Retrieve the seconds stream has been up instead of a string.

**streamCommand.js**
- Just pass the seconds as the time parameter.  Verified in Twitch web page, this work ?t=NNNNNNNs
- Simplifes the logic

