### PR TITLE
Roll forward #2112 with the EvaluatorException fixed.

### DIFF
--- a/javascript-source/handlers/dataServiceHandler.js
+++ b/javascript-source/handlers/dataServiceHandler.js
@@ -23,10 +23,9 @@
      * @function drsTimer
      */
     function drsTimer() {
-        var keys,
+        var entries,
             parts,
             apiStatus,
-            commandValue,
             commandHelpData = {},
             commandHelpFileData,
             lastTime = parseInt($.getSetIniDbNumber('datarenderservice', 'last_time', 0)),
@@ -55,21 +54,21 @@
             commandHelpData[parts[0]] = parts[1];
         }
 
-        keys = $.inidb.GetKeyList('command', '');
+        entries = $.inidb.GetKeyValueList('command', '');
         jsonStringer = new JSONStringer();
         jsonStringer.object().key('commands').array();
-        for (var idx in keys) {
-            if (!$.inidb.exists('disabledCommands', keys[idx])) {
+        for (var idx in entries) {
+            var command = entries[idx].key, commandValue = entries[idx].value;
+            if (!$.inidb.exists('disabledCommands', command)) {
                 jsonStringer.object();
-                jsonStringer.key('command').value(keys[idx] + '');
+                jsonStringer.key('command').value(command);
 
-                if (commandHelpData[keys[idx]] === undefined) {
+                if (commandHelpData[command] === undefined) {
                     jsonStringer.key('help').value('');
                 } else {
-                    jsonStringer.key('help').value(commandHelpData[keys[idx]]);
+                    jsonStringer.key('help').value(commandHelpData[command]);
                 }
 
-                commandValue = String($.inidb.get('command', keys[idx]));
                 if (commandValue.match(reCustomAPI)) {
                     commandValue = commandValue.replace(reCustomAPI, '(customapi)');
                 }
@@ -84,13 +83,13 @@
         apiStatus = $.dataRenderServiceAPI.postData(jsonStringer.toString(), $.channelName, 'commands');
         $.log.event('DataRenderService: Commands API status : ' + apiStatus);
 
-        keys = $.inidb.GetKeyList('quotes', '');
+        entries = $.inidb.GetKeyValueList('quotes', '');
         jsonStringer = new JSONStringer();
         jsonStringer.object().key('quotes').array();
-        for (var idx in keys) {
-            var quoteObj = JSON.parse($.inidb.get('quotes', keys[idx]));
+        for (var idx in entries) {
+            var quoteObj = JSON.parse(entries[idx].value);
             jsonStringer.object();
-            jsonStringer.key('id').value(parseInt(keys[idx]));
+            jsonStringer.key('id').value(parseInt(entries[idx].key));
             jsonStringer.key('user').value(quoteObj[0] + '');
             jsonStringer.key('quote').value(quoteObj[1] + '');
             jsonStringer.endObject();
@@ -99,33 +98,34 @@
         apiStatus = $.dataRenderServiceAPI.postData(jsonStringer.toString(), $.channelName, 'quotes');
         $.log.event('DataRenderService: Quotes API status : ' + apiStatus);
 
-        keys = $.inidb.GetKeyList('points', '');
+        entries = $.inidb.GetKeyValueList('points', '');
         jsonStringer = new JSONStringer();
         jsonStringer.object().key('pointsName').value($.pointNameMultiple).key('points').array();
-        for (var idx in keys) {
+        for (var idx in entries) {
             jsonStringer.object();
-            jsonStringer.key('user').value(keys[idx] + '');
-            jsonStringer.key('points').value($.inidb.get('points', keys[idx]));
+            jsonStringer.key('user').value(entries[idx].key);
+            jsonStringer.key('points').value(entries[idx].value);
             jsonStringer.endObject();
         }
         jsonStringer.endArray().endObject();
         apiStatus = $.dataRenderServiceAPI.postData(jsonStringer.toString(), $.channelName, 'points');
         $.log.event('DataRenderService: Points API status : ' + apiStatus);
 
-        keys = $.inidb.GetKeyList('time', '');
+        entries = $.inidb.GetKeyValueList('time', '');
         jsonStringer = new JSONStringer();
         ranksJsonStringer = new JSONStringer();
         jsonStringer.object().key('times').array();
         ranksJsonStringer.object().key('ranks').array();
-        for (var idx in keys) {
+        for (var idx in entries) {
+            var user = entries[idx].key, time = entries[idx].value;
             jsonStringer.object();
-            jsonStringer.key('user').value(keys[idx] + '');
-            jsonStringer.key('time').value($.inidb.get('time', keys[idx]));
+            jsonStringer.key('user').value(user);
+            jsonStringer.key('time').value(time);
             jsonStringer.endObject();
 
             ranksJsonStringer.object();
-            ranksJsonStringer.key('user').value(keys[idx] + '');
-            ranksJsonStringer.key('rank').value($.getRank(keys[idx]));
+            ranksJsonStringer.key('user').value(user);
+            ranksJsonStringer.key('rank').value($.getRank(user, parseInt(time)));
             ranksJsonStringer.endObject();
         }
         jsonStringer.endArray().endObject();

--- a/javascript-source/handlers/dataServiceHandler.js
+++ b/javascript-source/handlers/dataServiceHandler.js
@@ -58,7 +58,9 @@
         jsonStringer = new JSONStringer();
         jsonStringer.object().key('commands').array();
         for (var idx in entries) {
-            var command = entries[idx].key, commandValue = entries[idx].value;
+            // commandValue is a Java string, but needs to be a JS string for the replace() calls
+            // below to work, so we cast it explicitly here.
+            var command = entries[idx].key, commandValue = String(entries[idx].value);
             if (!$.inidb.exists('disabledCommands', command)) {
                 jsonStringer.object();
                 jsonStringer.key('command').value(command);


### PR DESCRIPTION
This fixes the issue described at https://github.com/PhantomBot/PhantomBot/pull/2112#issuecomment-475930097.

`commandValue` used to be a JavaScript String, but #2112 inadvertently made it
a Java String, which broke the call to its `replace()` method -- obviously the
two classes have different APIs. This puts back the cast to JS String.