### PR TITLE
Updated launch.bat to use the full path to the jar file

### DIFF
--- a/resources/launch.bat
+++ b/resources/launch.bat
@@ -27,6 +27,7 @@ IF %ERRORLEVEL% NEQ 0 (
     pause
     exit
 )
-java -Dinteractive -Xms1m -Dfile.encoding=UTF-8 -jar PhantomBot.jar %1
+SET mypath=%~dp0
+java -Dinteractive -Xms1m -Dfile.encoding=UTF-8 -jar "%mypath%PhantomBot.jar" %1
 endlocal
 pause


### PR DESCRIPTION
This patch makes the Windows launch.bat script use the full path to the jar file in the **java** launch line. This will allow users to properly use **Run as Administrator**

Resolves *Error: Unable to access jarfile PhantomBot.jar* when using **Run as Administrator**

Tested with both regular launch and Run as Admin launch