### PR TITLE
Updated text from Hosters -> VIPs for group changes

### DIFF
--- a/resources/web/panel/js/pages/audio/audioHooks.js
+++ b/resources/web/panel/js/pages/audio/audioHooks.js
@@ -209,7 +209,7 @@ $(run = function() {
                     .append(helpers.getInputGroup('command-audio', 'text', 'Audio Hook', '', e.audioCommands, 'Audio to be played. This cannot be edited.', true))
                     // Append a select option for the command permission.
                     .append(helpers.getDropdownGroup('command-permission', 'User Level', helpers.getGroupNameById(e.permcom),
-                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars', 'Viewers']))
+                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
                     // Add an advance section that can be opened with a button toggle.
                     .append($('<div/>', {
                         'class': 'collapse',
@@ -388,7 +388,7 @@ $(function() {
             .append(helpers.getDropdownGroup('command-audio', 'Audio Hook', 'Select an Audio Hook', audioNames, 'Audio hook to be played when the command is ran.'))
             // Append a select option for the command permission.
             .append(helpers.getDropdownGroup('command-permission', 'User Level', 'Viewers',
-                ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars', 'Viewers'], 'Users who can run the command.'))
+                ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers'], 'Users who can run the command.'))
             // Add an advance section that can be opened with a button toggle.
             .append($('<div/>', {
                 'class': 'collapse',

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -120,7 +120,7 @@ $(run = function() {
                     .append(helpers.getTextAreaGroup('command-response', 'text', 'Response', '', e.command, 'Response of the command. Use enter for multiple chat lines maximum is 5.'))
                     // Append a select option for the command permission.
                     .append(helpers.getDropdownGroup('command-permission', 'User Level', helpers.getGroupNameById(e.permcom),
-                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars', 'Viewers']))
+                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
                     // Add an advance section that can be opened with a button toggle.
                     .append($('<div/>', {
                         'class': 'collapse',
@@ -217,7 +217,7 @@ $(function() {
         .append(helpers.getTextAreaGroup('command-response', 'text', 'Response', 'Response example! Use enter for multiple chat lines maximum is 5.'))
         // Append a select option for the command permission.
         .append(helpers.getDropdownGroup('command-permission', 'User Level', 'Viewers',
-            ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars', 'Viewers']))
+            ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
         // Add an advance section that can be opened with a button toggle.
         .append($('<div/>', {
             'class': 'collapse',

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -120,7 +120,7 @@ $(function() {
                     .append(helpers.getInputGroup('command-name', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
                     // Append a select option for the command permission.
                     .append(helpers.getDropdownGroup('command-permission', 'User Level', helpers.getGroupNameById(e.permcom),
-                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars', 'Viewers']))
+                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
                     // Add an advance section that can be opened with a button toggle.
                     .append($('<div/>', {
                         'class': 'collapse',

--- a/resources/web/panel/js/pages/permissions/permissions.js
+++ b/resources/web/panel/js/pages/permissions/permissions.js
@@ -112,7 +112,7 @@ $(run = function() {
                 .append(helpers.getInputGroup('user-name', 'text', 'Username', '', username, 'Name of the user. This cannot be edited.', true))
                 // Append the group.
                 .append(helpers.getDropdownGroup('user-permission', 'Permission', helpers.getGroupNameById(e.group),
-                    ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars'])),
+                    ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars'])),
                 // callback once the user hits save.
                 function() {
                     let group = helpers.getGroupIdByName($('#user-permission').find(':selected').text());
@@ -143,7 +143,7 @@ $(function() {
         // Append user name.
         .append(helpers.getInputGroup('user-name', 'text', 'Username', 'PhantomBot', '', 'Name of the user to set the permissions on.'))
         // Append the group.
-        .append(helpers.getDropdownGroup('user-permission', 'Permission', 'Regulars', ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'Hosters', 'Regulars'])),
+        .append(helpers.getDropdownGroup('user-permission', 'Permission', 'Regulars', ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars'])),
         // callback once the user hits save.
         function() {
             let group = helpers.getGroupIdByName($('#user-permission').find(':selected').text()),

--- a/resources/web/panel/js/utils/helpers.js
+++ b/resources/web/panel/js/utils/helpers.js
@@ -800,8 +800,8 @@ $(function() {
             case 'donators':
             case 'donator':
                 return (asString ? '4' : 4);
-            case 'hosters':
-            case 'hoster':
+            case 'vips':
+            case 'vip':
                 return (asString ? '5' : 5);
             case 'regulars':
             case 'regular':
@@ -847,7 +847,7 @@ $(function() {
             case '4':
                 return 'Donators';
             case '5':
-                return 'Hosters';
+                return 'VIPs';
             case '6':
                 return 'Regulars';
             default:


### PR DESCRIPTION
Cleans up the dropdowns in the panel for permissions to reflect
the new VIP group name for group id == 5

![command_permission](https://user-images.githubusercontent.com/1137023/55663403-99285880-57eb-11e9-9690-b31982b6ffaf.png)
![permission_permissions](https://user-images.githubusercontent.com/1137023/55663405-9a598580-57eb-11e9-9d79-23ad7e75b857.png)
![audio_hook_permission](https://user-images.githubusercontent.com/1137023/55663408-9b8ab280-57eb-11e9-8f1a-7ec541d61659.png)
