### PR TITLE
Added support for defining a section when performing dbquery requests…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -194,47 +194,8 @@
             <fileset dir="${build.dir}" />
         </copy>
     </target>
-    
-    <target depends="compile.src.test,post.compile,git.revision" name="jar.test">
-        <jar destfile="${build.dir}/${ant.project.name}.jar">
-            <fileset dir="${classes}" />
-            <manifest>
-                <attribute name="Bundle-Name" value="${ant.project.name}" />
-                <attribute name="Bundle-Version" value="${version}" />
-                <attribute name="Bundle-Revision" value="${git.revision}" />
-                <attribute name="Bundle-Date" value="${NOW}" />
-                <attribute name="Implementation-Title" value="${ant.project.name}" />
-                <attribute name="Implementation-Version" value="${version}" />
-                <attribute name="Implementation-Revision" value="${git.revision}" />
-                <attribute name="Implementation-URL" value="https://phantombot.tv" />
-                <attribute name="Class-Path" value="${mf.classpath}" />
-                <attribute name="Main-Class" value="tv.phantombot.PhantomBot" />
-            </manifest>
-        </jar>
 
-        <mkdir dir="${lib.dir}" />
-        <copy todir="${lib.dir}">
-            <fileset dir="./libraries" />
-        </copy>
-        <echo level="info" message="staging javascript-source into resources." />
-        <copy todir="./resources/scripts">
-            <fileset dir="./javascript-source" />
-        </copy>
-        <echo level="info" message="staging lib folder into resources." />
-        <copy todir="${res.dir}">
-            <fileset dir="./resources" />
-        </copy>
-        <replaceregexp
-            file="${build.dir}/web/panel/js/utils/helpers.js"
-            match="helpers\.PANEL_VERSION = &quot;(.*)&quot;;"
-            replace="helpers\.PANEL_VERSION = &quot;${webpanel.version}&quot;;" />
-        <echo level="info" message="staging files into distribution folder." />
-        <copy todir="${version.folder}">
-            <fileset dir="${build.dir}" />
-        </copy>
-    </target>
-
-    <target name="test" depends="jar.test" />
+    <target depends="compile.src.test,post.compile" name="test"/>
 
     <target name="run" depends="jar">
         <java fork="true" classname="tv.phantombot.PhantomBot" dir="${build.dir}">

--- a/build.xml
+++ b/build.xml
@@ -194,8 +194,47 @@
             <fileset dir="${build.dir}" />
         </copy>
     </target>
+    
+    <target depends="compile.src.test,post.compile,git.revision" name="jar.test">
+        <jar destfile="${build.dir}/${ant.project.name}.jar">
+            <fileset dir="${classes}" />
+            <manifest>
+                <attribute name="Bundle-Name" value="${ant.project.name}" />
+                <attribute name="Bundle-Version" value="${version}" />
+                <attribute name="Bundle-Revision" value="${git.revision}" />
+                <attribute name="Bundle-Date" value="${NOW}" />
+                <attribute name="Implementation-Title" value="${ant.project.name}" />
+                <attribute name="Implementation-Version" value="${version}" />
+                <attribute name="Implementation-Revision" value="${git.revision}" />
+                <attribute name="Implementation-URL" value="https://phantombot.tv" />
+                <attribute name="Class-Path" value="${mf.classpath}" />
+                <attribute name="Main-Class" value="tv.phantombot.PhantomBot" />
+            </manifest>
+        </jar>
 
-    <target depends="compile.src.test,post.compile" name="test"/>
+        <mkdir dir="${lib.dir}" />
+        <copy todir="${lib.dir}">
+            <fileset dir="./libraries" />
+        </copy>
+        <echo level="info" message="staging javascript-source into resources." />
+        <copy todir="./resources/scripts">
+            <fileset dir="./javascript-source" />
+        </copy>
+        <echo level="info" message="staging lib folder into resources." />
+        <copy todir="${res.dir}">
+            <fileset dir="./resources" />
+        </copy>
+        <replaceregexp
+            file="${build.dir}/web/panel/js/utils/helpers.js"
+            match="helpers\.PANEL_VERSION = &quot;(.*)&quot;;"
+            replace="helpers\.PANEL_VERSION = &quot;${webpanel.version}&quot;;" />
+        <echo level="info" message="staging files into distribution folder." />
+        <copy todir="${version.folder}">
+            <fileset dir="${build.dir}" />
+        </copy>
+    </target>
+
+    <target name="test" depends="jar.test" />
 
     <target name="run" depends="jar">
         <java fork="true" classname="tv.phantombot.PhantomBot" dir="${build.dir}">

--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -264,7 +264,7 @@ public class HTTPServerCommon {
             }
 
             if (keyValue[0].equals("table")) {
-                if (keyValue[1] == null) {
+                if (keyValue.length == 1 || keyValue[1].length() == 0) {
                     sendHTMLError(400, "Bad Request", exchange);
                     return;
                 }
@@ -275,11 +275,9 @@ public class HTTPServerCommon {
                 }
                 dbTable = keyValue[1];
             } else if (keyValue[0].equals("section")) {
-                if (keyValue[1] == null) {
-                    sendHTMLError(400, "Bad Request", exchange);
-                    return;
+                if (keyValue.length > 1 && keyValue[1].length() > 0) {
+                    dbSection = keyValue[1];
                 }
-                dbSection = keyValue[1];
             } else {
                 // All other commands need the table.
                 if (dbTable == null) {

--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -241,6 +241,7 @@ public class HTTPServerCommon {
         JSONStringer jsonObject = new JSONStringer();
         String[] keyValue;
         String   dbTable = null;
+        String   dbSection = "";
         Boolean  dbExists;
 
         if (!hasPassword) {
@@ -273,6 +274,12 @@ public class HTTPServerCommon {
                     return;
                 }
                 dbTable = keyValue[1];
+            } else if (keyValue[0].equals("section")) {
+                if (keyValue[1] == null) {
+                    sendHTMLError(400, "Bad Request", exchange);
+                    return;
+                }
+                dbSection = keyValue[1];
             } else {
                 // All other commands need the table.
                 if (dbTable == null) {
@@ -299,7 +306,7 @@ public class HTTPServerCommon {
             // { "table" : { "table_name": "tableName", "key" : "keyString", "keyExists": true } }
             if (keyValue[0].equals("keyExists")) {
                 if (keyValue.length > 1) {
-                    dbExists = PhantomBot.instance().getDataStore().exists(dbTable, keyValue[1]);
+                    dbExists = PhantomBot.instance().getDataStore().HasKey(dbTable, dbSection, keyValue[1]);
                     jsonObject.object().key("table");
                     jsonObject.object();
                     jsonObject.key("table_name").value(dbTable);
@@ -320,7 +327,7 @@ public class HTTPServerCommon {
             // { "table" : { "table_name": "tableName", "key" : "keyString", "value": "valueString" } }
             if (keyValue[0].equals("getData")) {
                 if (keyValue.length > 1) {
-                    String dbString = PhantomBot.instance().getDataStore().GetString(dbTable, "", keyValue[1]);
+                    String dbString = PhantomBot.instance().getDataStore().GetString(dbTable, dbSection, keyValue[1]);
                     jsonObject.object().key("table");
                     jsonObject.object();
                     jsonObject.key("table_name").value(dbTable);
@@ -345,7 +352,7 @@ public class HTTPServerCommon {
                 jsonObject.key("table_name").value(dbTable);
                 jsonObject.key("keylist").array();
 
-                String[] dbKeys = PhantomBot.instance().getDataStore().GetKeyList(dbTable, "");
+                String[] dbKeys = PhantomBot.instance().getDataStore().GetKeyList(dbTable, dbSection);
 
                 for (String dbKey : dbKeys) {
                     jsonObject.object();
@@ -376,7 +383,7 @@ public class HTTPServerCommon {
                 jsonObject.key("results").array();
 
                 if (keyValue[0].equals("getAllRows")) {
-                    dbKeys = PhantomBot.instance().getDataStore().GetKeyList(dbTable, "");
+                    dbKeys = PhantomBot.instance().getDataStore().GetKeyList(dbTable, dbSection);
                 } else {
                     for (String sortOptions : uriQueryList) {
                         String[] sortOption = sortOptions.split("=");
@@ -403,9 +410,9 @@ public class HTTPServerCommon {
                     }
 
                     if (keyValue[0].equals("getSortedRows")) {
-                        dbKeys = PhantomBot.instance().getDataStore().GetKeysByOrder(dbTable, "", sortOrder, sortLimit, sortOffset);
+                        dbKeys = PhantomBot.instance().getDataStore().GetKeysByOrder(dbTable, dbSection, sortOrder, sortLimit, sortOffset);
                     } else {
-                        dbKeys = PhantomBot.instance().getDataStore().GetKeysByOrderValue(dbTable, "", sortOrder, sortLimit, sortOffset);
+                        dbKeys = PhantomBot.instance().getDataStore().GetKeysByOrderValue(dbTable, dbSection, sortOrder, sortLimit, sortOffset);
                     }
 
                 }
@@ -413,7 +420,7 @@ public class HTTPServerCommon {
                 for (String dbKey : dbKeys) {
                     jsonObject.object();
                     jsonObject.key("key").value(dbKey);
-                    jsonObject.key("value").value(PhantomBot.instance().getDataStore().GetString(dbTable, "", dbKey));
+                    jsonObject.key("value").value(PhantomBot.instance().getDataStore().GetString(dbTable, dbSection, dbKey));
                     jsonObject.endObject();
                 }
                 jsonObject.endArray();


### PR DESCRIPTION
… through the HTTP API

I defined a variable here to replace the hard-coded section parameter strings that defaults to an empty string, which will provide the same behavior/response as before, however, the user can define a *section* GET parameter to override it and retrieve any section they want from the requested table.

I had to change keyExists to use the Full DataStore API method *HasKey* as part of this implementation.

I will post the tests in a reply here once I have them available for you.