### PR TITLE
Fixed Invalid Date error when attempting to edit quotes with the panel

### DIFF
--- a/resources/web/panel/js/pages/quotes/quotes.js
+++ b/resources/web/panel/js/pages/quotes/quotes.js
@@ -118,7 +118,7 @@ $(run = function() {
                         'role': 'form'
                     })
                     // Append quote date.
-                    .append(helpers.getInputGroup('quote-date', 'text', 'Created On', '', helpers.getPaddedDateString(new Date(data[2]).toLocaleDateString()), 'Date the quote was created on.'))
+                    .append(helpers.getInputGroup('quote-date', 'text', 'Created On', '', helpers.getPaddedDateString(new Date(parseInt(data[2])).toLocaleDateString()), 'Date the quote was created on.'))
                     // Append quote creator
                     .append(helpers.getInputGroup('quote-user', 'text', 'Created By', '', data[0], 'The user who created the quote.'))
                     // Append quote game


### PR DESCRIPTION
Fixed a missing parseInt in the js for the quotes page on the web panel that was causing the Edit dialog to display **Invalid Date**

I tested the output of **new Date("123450000")** in a web editor with a time in millis that was a string (quotes) by itself vs adding a parseInt around the string and was able to replicate this.