### PR TITLE
Attempted Patch for Promote System Crash on profile_banner

### DIFF
--- a/javascript-source/discord/systems/promoteSystem.js
+++ b/javascript-source/discord/systems/promoteSystem.js
@@ -358,7 +358,10 @@
                 var twitchName = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('display_name');
                 var followers = jsonStreams.getJSONObject(i).getJSONObject('channel').getInt('followers');
                 var views = jsonStreams.getJSONObject(i).getJSONObject('channel').getInt('views');
-                var banner = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('profile_banner');
+                var banner = null;
+                if (jsonStreams.getJSONObject(i).getJSONObject('channel').has('profile_banner')) {
+                    banner = jsonStreams.getJSONObject(i).getJSONObject('channel').getString('profile_banner');
+                }
                 liveStreamers.push(twitchID);
 
                 if (title === null) {


### PR DESCRIPTION
**promoteSystem.js**
- Stack trace may indicate that the variable 'profile_banner' does not exist when there isn't a banner.
- Checking to see if variable exists now, with a default value of null applied.