### PR TITLE
Added Manual and Automatic Commercials

### DIFF
--- a/javascript-source/lang/english/systems/systems-commercialSystem.js
+++ b/javascript-source/lang/english/systems/systems-commercialSystem.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2019 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$.lang.register('commercialsystem.usage', 'Usage: !commercial (length_secs:30,60,90,120,150,180) [silent]  --or-- !commercial autotimer');
+$.lang.register('commercialsystem.run', 'Running a $1 second commercial');
+$.lang.register('commercialsystem.422', 'Commercials can only be run on partnered channels, once per 8 minutes, when the stream is live, for one of the following lengths: 30, 60, 90, 120, 150, 180');
+$.lang.register('commercialsystem.autotimer.status-off', 'Commercial autotimer is off. To enable: !commercial autotimer (interval_mins:8 or greater) (length_secs:30,60,90,120,150,180) [message]');
+$.lang.register('commercialsystem.autotimer.status-on', 'Commercial autotimer is on. $1 seconds of ads every $2 minutes. To disable: !commercial autotimer off --or-- To add/change a message: !commercial autotimer message (message) --or-- To remove message: !commercial autotimer nomessage');
+$.lang.register('commercialsystem.autotimer.bad-parm', 'Failed to set autotimer. Interval must be at least 8 minutes and length must be one of: 30, 60, 90, 120, 150, 180');
+$.lang.register('commercialsystem.autotimer.status-on-msg', 'The message sent when an auto commercial starts: $1');
+$.lang.register('commercialsystem.autotimer.status-on-nomsg', 'No message is sent when an auto commercial starts');
+$.lang.register('commercialsystem.autotimer.msg-set', 'Changed the message sent when an auto commercial starts to: $1');
+$.lang.register('commercialsystem.autotimer.msg-del', 'No longer sending a message when an auto commercial starts');

--- a/javascript-source/systems/commercialSystem.js
+++ b/javascript-source/systems/commercialSystem.js
@@ -27,16 +27,16 @@
      * @function startCommercialTimer
      */
     function startCommercialTimer() {
+        lastCommercial = $.systemTime();
+        
         interval = setInterval(function() {
-            lastCommercial = $.systemTime();
-            
             if (commercialTimer && $.bot.isModuleEnabled('./systems/commercialSystem.js')) {
                 if ((lastCommercial + (commercialInterval * 6e4)) <= $.systemTime()) {
                     if ($.isOnline($.channelName)) {
-                        $.twitch.RunCommercial($.channelName, commercialLength);
+                        var result = $.twitch.RunCommercial($.channelName, commercialLength);
                         lastCommercial = $.systemTime();
                         
-                        if (commercialMessage.length() > 0) {
+                        if (commercialMessage.length() > 0 && result.getInt("_http") !== 422) {
                             $.say(commercialMessage);
                         }
                     }

--- a/javascript-source/systems/commercialSystem.js
+++ b/javascript-source/systems/commercialSystem.js
@@ -174,5 +174,38 @@
             startCommercialTimer();
         }
     });
+
+    /**
+     * @event webPanelSocketUpdate
+     */
+    $.bind('webPanelSocketUpdate', function(event) {
+        if (event.getScript().equalsIgnoreCase('./systems/commercialSystem.js')) {
+            var action = event.getArgs()[0];
+
+            if (action.equalsIgnoreCase('setautotimer')) {
+                var msg = '';
+
+                if (event.getArgs().length > 3) {
+                    msg = event.getArgs().slice(3).join(' ');
+                }
+
+                $.inidb.set('commercialSettings', 'length', event.getArgs()[2]);
+                $.inidb.set('commercialSettings', 'interval', event.getArgs()[1]);
+                $.inidb.set('commercialSettings', 'message', msg);
+                $.inidb.set('commercialSettings', 'commercialtimer', true.toString());
+
+                commercialLength = parseInt(event.getArgs()[2]);
+                commercialInterval = parseInt(event.getArgs()[1]);
+                commercialMessage = msg;
+                commercialTimer = true;
+
+                startCommercialTimer();
+            } else if (action.equalsIgnoreCase('autotimeroff')) {
+                $.inidb.set('commercialSettings', 'commercialtimer', false.toString());
+                commercialTimer = false;
+                clearInterval(interval);
+            }
+        }
+    });
 })();
 

--- a/javascript-source/systems/commercialSystem.js
+++ b/javascript-source/systems/commercialSystem.js
@@ -157,17 +157,17 @@
         }
     });
 
-    // Set the interval to run commercials
-    if (commercialTimer) {
-        startCommercialTimer();
-    }
-
     /**
      * @event initReady
      */
     $.bind('initReady', function() {
         $.registerChatCommand('./systems/commercialSystem.js', 'commercial', 2);
         $.registerChatSubcommand('commercial', 'autotimer', 1);
+
+        // Set the interval to run commercials
+        if (commercialTimer) {
+            startCommercialTimer();
+        }
     });
 })();
 

--- a/javascript-source/systems/commercialSystem.js
+++ b/javascript-source/systems/commercialSystem.js
@@ -155,7 +155,7 @@
                     lastCommercial = $.systemTime();
                     
                     if (args.length < 2 || !args[1].equalsIgnoreCase("silent")) {
-                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.run', args[0]));
+                        $.say($.lang.get('commercialsystem.run', args[0]));
                     }
                 }
             }

--- a/javascript-source/systems/commercialSystem.js
+++ b/javascript-source/systems/commercialSystem.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2016-2019 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(function() {
+    var commercialLength = $.getSetIniDbNumber('commercialSettings', 'length', 30),
+        commercialInterval = $.getSetIniDbNumber('commercialSettings', 'interval', 10),
+        commercialMessage = $.getSetIniDbString('commercialSettings', 'message', ''),
+        commercialTimer = $.getSetIniDbBoolean('commercialSettings', 'commercialtimer', false),
+        lastCommercial = 0,
+        interval;
+
+    /**
+     * @function startCommercialTimer
+     */
+    function startCommercialTimer() {
+        interval = setInterval(function() {
+            lastCommercial = $.systemTime();
+            
+            if (commercialTimer && $.bot.isModuleEnabled('./systems/commercialSystem.js')) {
+                if ((lastCommercial + (commercialInterval * 6e4)) <= $.systemTime()) {
+                    if ($.isOnline($.channelName)) {
+                        $.twitch.RunCommercial($.channelName, commercialLength);
+                        lastCommercial = $.systemTime();
+                        
+                        if (commercialMessage.length() > 0) {
+                            $.say(commercialMessage);
+                        }
+                    }
+                }
+            }
+        }, 1e4, 'scripts::systems::commercialSystem.js');
+    };
+
+    /**
+     * @event command
+     */
+    $.bind('command', function(event) {
+        var sender = event.getSender(),
+            command = event.getCommand(),
+            argsString = event.getArguments().trim(),
+            args = event.getArgs(),
+            action = args[0];
+
+        /**
+         * @commandpath commercial - Command for manually running comemrcials or managing the commercial autotimer
+         */
+        if (command.equalsIgnoreCase('commercial')) {
+            if (args.length == 0) {
+                $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.usage'));
+                return;
+            }
+
+            /**
+             * @commandpath commercial autotimer - Manages the autotimer
+             */
+            if (action.equalsIgnoreCase('autotimer')) {
+                if (args.length <= 1) {
+                    if (commercialTimer) {
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-on', commercialLength, commercialInterval));
+                        if (commercialMessage.length() > 0) {
+                            $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-on-msg', commercialMessage));
+                        } else {
+                            $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-on-nomsg'));
+                        }
+                    } else {
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-off'));
+                    }
+                    return;
+                } else {
+                    /**
+                    * @commandpath commercial autotimer off - Disables the autotimer
+                    */
+                    if (args[1].equalsIgnoreCase("off")) {
+                        $.inidb.set('commercialSettings', 'commercialtimer', false.toString());
+                        commercialTimer = false;
+                        clearInterval(interval);
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-off'));
+                    /**
+                    * @commandpath commercial autotimer nomessage - Removes the message sent when autotimer starts a commercial
+                    */
+                    } else if (args[1].equalsIgnoreCase("nomessage")) {
+                        $.inidb.set('commercialSettings', 'message', '');
+                        commercialMessage = '';
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.msg-del'));
+                    /**
+                    * @commandpath commercial autotimer message (message) - Adds/changes the message sent when autotimer starts a commercial
+                    */
+                    } else if (args.length >= 3 && args[1].equalsIgnoreCase("message") && args[2].length() > 0) {
+                        argsString = args.slice(2).join(' ');
+                        $.inidb.set('commercialSettings', 'message', argsString);
+                        commercialMessage = argsString;
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.msg-set', argsString));
+                    /**
+                    * @commandpath commercial autotimer (interval_mins) (length_secs) [message] - Sets the autotimer
+                    */
+                    } else {
+                        var valid_lengths = ["30", "60", "90", "120", "150", "180"];
+                        if (args.length < 3 || isNaN(args[1]) || isNaN(args[2]) || args[1] < 8 || !valid_lengths.includes(args[2])) {
+                            $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.bad-parm'));
+                            return;
+                        }
+                        
+                        argsString = args.slice(3).join(' ');
+                        $.inidb.set('commercialSettings', 'length', args[2]);
+                        $.inidb.set('commercialSettings', 'interval', args[1]);
+                        $.inidb.set('commercialSettings', 'message', argsString);
+                        $.inidb.set('commercialSettings', 'commercialtimer', true.toString());
+                        
+                        commercialLength = parseInt(args[2]);
+                        commercialInterval = parseInt(args[1]);
+                        commercialMessage = argsString;
+                        commercialTimer = true;
+                        
+                        startCommercialTimer();
+                        
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-on', commercialLength, commercialInterval));
+                        if (commercialMessage.length() > 0) {
+                            $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-on-msg', commercialMessage));
+                        } else {
+                            $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.status-on-nomsg'));
+                        }
+                    }
+                    return;
+                }
+            }
+
+            /**
+             * @commandpath commercial (length) [silent] - Runs a commercial, optionally does not post a success message to chat
+             */
+            if (args.length >= 1 && !isNaN(args[0])) {
+                var result = $.twitch.RunCommercial($.channelName, args[0]);
+                
+                if (result.getInt("_http") === 422) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.422'));
+                } else {
+                    lastCommercial = $.systemTime();
+                    
+                    if (args.length < 2 || !args[1].equalsIgnoreCase("silent")) {
+                        $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.run', args[0]));
+                    }
+                }
+            }
+        }
+    });
+
+    // Set the interval to run commercials
+    if (commercialTimer) {
+        startCommercialTimer();
+    }
+
+    /**
+     * @event initReady
+     */
+    $.bind('initReady', function() {
+        $.registerChatCommand('./systems/commercialSystem.js', 'commercial', 2);
+        $.registerChatSubcommand('commercial', 'autotimer', 1);
+    });
+})();
+

--- a/javascript-source/systems/commercialSystem.js
+++ b/javascript-source/systems/commercialSystem.js
@@ -113,8 +113,13 @@
                             $.say($.whisperPrefix(sender) + $.lang.get('commercialsystem.autotimer.bad-parm'));
                             return;
                         }
-                        
-                        argsString = args.slice(3).join(' ');
+
+                        argsString = '';
+
+                        if (args.length > 3) {
+                            argsString = args.slice(3).join(' ');
+                        }
+
                         $.inidb.set('commercialSettings', 'length', args[2]);
                         $.inidb.set('commercialSettings', 'interval', args[1]);
                         $.inidb.set('commercialSettings', 'message', argsString);

--- a/resources/web/panel/index.html
+++ b/resources/web/panel/index.html
@@ -328,6 +328,7 @@
                                 </span>
                             </a>
                             <ul class="treeview-menu">
+                                <li><a href="#commercials.html" data-folder="extra"><i class="fa fa-circle-o"></i> Automatic Commercials</a></li>
                                 <li><a href="#dualstream.html" data-folder="extra"><i class="fa fa-circle-o"></i> Dual Stream</a></li>
                                 <li><a href="#deathcounter.html" data-folder="extra"><i class="fa fa-circle-o"></i> Death Counter</a></li>
                                 <li><a href="#highlights.html" data-folder="extra"><i class="fa fa-circle-o"></i> Highlights</a></li>

--- a/resources/web/panel/js/pages/dashboard/dashboard.js
+++ b/resources/web/panel/js/pages/dashboard/dashboard.js
@@ -22,8 +22,8 @@ var canScroll = true;
 $(function() {
     // Query our panel settings first.
     socket.getDBValues('panel_get_settings', {
-        tables: ['panelData', 'panelData'],
-        keys: ['isDark', 'isReverseSortEvents']
+        tables: ['panelData', 'panelData', 'modules'],
+        keys: ['isDark', 'isReverseSortEvents', './systems/commercialSystem.js']
     }, true, function(e) {
         helpers.isDark = e.isDark === 'true';
         helpers.isReverseSortEvents = e.isReverseSortEvents === 'true';
@@ -34,6 +34,11 @@ $(function() {
         $('#dark-mode-toggle').prop('checked', helpers.isDark);
         // Update event toggle.
         $('#toggle-reverse-events').prop('checked', helpers.isReverseSortEvents);
+
+        // Disable isntant commercials if the module is disabled
+        if (e['./systems/commercialSystem.js'] !== 'true') {
+            $('#grp-instant-commercial').addClass('hidden');
+        }
 
         // Query recent events.
         socket.getDBValue('dashboard_get_events', 'panelData', 'data', function(e) {

--- a/resources/web/panel/js/pages/dashboard/dashboard.js
+++ b/resources/web/panel/js/pages/dashboard/dashboard.js
@@ -305,6 +305,13 @@ $(function() {
         });
     });
 
+    // Handle running a commercial.
+    $('#dashboard-btn-instant-commercial').on('click', function() {
+        socket.sendCommand('instant_commercial', 'commercial ' + $('#instant-commercial-length').val() + ($('#instant-commercial-silent').is(':checked') ? ' silent' : ''), function() {
+            toastr.success('Successfully ran a commercial!');
+        });
+    });
+
     // Mouse hover/leave event log.
     $('.event-log').on('mouseenter mouseleave', function(event) {
         canScroll = event.type === 'mouseleave';

--- a/resources/web/panel/js/pages/extra/commercials.js
+++ b/resources/web/panel/js/pages/extra/commercials.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016-2019 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Function that querys all of the data we need.
+$(run = function() {
+    // Check if the module is enabled.
+    socket.getDBValues('commercials_module', {
+        tables: ['modules', 'commercialSettings', 'commercialSettings', 'commercialSettings', 'commercialSettings'],
+        keys: ['./systems/commercialSystem.js', 'commercialtimer', 'length', 'interval', 'message']
+    }, true, function(e) {
+        if (!helpers.getModuleStatus('commercialsModule', e['./systems/commercialSystem.js'], 'commercialsModuleToggle')) {
+            return;
+        }
+
+        if (e['commercialtimer'] === 'true') {
+            $('#commercials-autotimer-on').html($('<i/>', {
+                'class': 'fa fa-check'
+            })).append('&nbsp; Update Autotimer');
+            $('#commercials-autotimer-off').removeClass('hidden');
+        }
+
+        $('#commercial-interval').val(e['interval']);
+        $('#commercial-length').val(e['length']);
+        $('#commercial-message').val(e['message']);
+    });
+});
+
+// Function that handlers the loading of events.
+$(function() {
+    const COMMERCIAL_SCRIPT = './systems/commercialSystem.js';
+
+    // Toggle for the module.
+    $('#commercialModuleToggle').on('change', function() {
+        // Toggle the timer
+        socket.sendCommandSync('commercial_module_toggle_cmd',
+            'module ' + ($(this).is(':checked') ? 'enablesilent' : 'disablesilent') + ' ./systems/commercialSystem.js', run);
+    });
+
+    // Set/Update autotimer button.
+    $('#commercials-autotimer-on').on('click', function() {
+        let cinterval = $('#commercial-interval'),
+            clength = $('#commercial-length').find(':selected').text(),
+            cmessage = $('#commercial-message');
+
+        switch (false) {
+            case helpers.handleInputNumber(cinterval, 8):
+                break;
+            default:
+                socket.wsEvent('commercials_setautotimer_ws', COMMERCIAL_SCRIPT, null, ['setautotimer', cinterval.val(), clength, cmessage.val()], function() {
+                    toastr.success('Successfully set the autotimer!');
+                    // Update the button.
+                    $('#commercials-autotimer-on').html($('<i/>', {
+                        'class': 'fa fa-check'
+                    })).append('&nbsp; Update Autotimer');
+                    $('#commercials-autotimer-off').removeClass('hidden');
+                });
+        }
+    });
+
+    // Disable autotimer button.
+    $('#commercials-autotimer-off').on('click', function() {
+        socket.wsEvent('commercials_autotimeroff_ws', COMMERCIAL_SCRIPT, null, ['autotimeroff'], function() {
+            toastr.success('Successfully turned off autotimer!');
+            // Update the button.
+            $('#commercials-autotimer-on').html($('<i/>', {
+                'class': 'fa fa-check'
+            })).append('&nbsp; Set Autotimer');
+            $('#commercials-autotimer-off').addClass('hidden');
+        });
+    });
+});

--- a/resources/web/panel/js/pages/extra/commercials.js
+++ b/resources/web/panel/js/pages/extra/commercials.js
@@ -44,8 +44,8 @@ $(function() {
     const COMMERCIAL_SCRIPT = './systems/commercialSystem.js';
 
     // Toggle for the module.
-    $('#commercialModuleToggle').on('change', function() {
-        // Toggle the timer
+    $('#commercialsModuleToggle').on('change', function() {
+        // Toggle the module
         socket.sendCommandSync('commercial_module_toggle_cmd',
             'module ' + ($(this).is(':checked') ? 'enablesilent' : 'disablesilent') + ' ./systems/commercialSystem.js', run);
     });

--- a/resources/web/panel/pages/dashboard/dashboard.html
+++ b/resources/web/panel/pages/dashboard/dashboard.html
@@ -176,6 +176,33 @@
                                     <option></option>
                                 </select>
                             </div>
+                            
+                            <!-- Run commercial -->
+                            <div class="form-group">
+                                <label>Run Commercial</label>
+                                <div class="input-group input-group-md">
+                                    <select class="form-control select2" id="instant-commercial-length" data-toggle="tooltip" title="Commercial length, in seconds.">
+                                        <option selected="selected">30</option>
+                                        <option>60</option>
+                                        <option>90</option>
+                                        <option>120</option>
+                                        <option>150</option>
+                                        <option>180</option>
+                                    </select>
+                                    <span class="input-group-addon" style="border: 0;">
+                                        <div class="pretty p-icon">
+                                            <input id="instant-commercial-silent" type="checkbox" data-toggle="tooltip" title="If checked, the bot won't announce the commercial in chat.">
+                                            <div class="state p-default">
+                                                <i class="icon fa fa-check"></i>
+                                                <label>Silent</label>
+                                            </div>
+                                        </div>
+                                    </span>
+                                    <span class="input-group-btn">
+                                        <button type="button" class="btn btn-primary pull-right" id="dashboard-btn-instant-commercial" data-candisable="true">Run</button>
+                                    </span>
+                                </div>
+                            </div>
                         </div>
                     </form>
                 </div>

--- a/resources/web/panel/pages/dashboard/dashboard.html
+++ b/resources/web/panel/pages/dashboard/dashboard.html
@@ -178,7 +178,7 @@
                             </div>
                             
                             <!-- Run commercial -->
-                            <div class="form-group">
+                            <div class="form-group" id="grp-instant-commercial">
                                 <label>Run Commercial</label>
                                 <div class="input-group input-group-md">
                                     <select class="form-control select2" id="instant-commercial-length" data-toggle="tooltip" title="Commercial length, in seconds.">

--- a/resources/web/panel/pages/extra/commercials.html
+++ b/resources/web/panel/pages/extra/commercials.html
@@ -1,0 +1,80 @@
+<!--
+    Copyright (C) 2016-2019 phantombot.tv
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<main>
+    <!-- Header -->
+    <section class="content-header">
+        <h1>Automatic Commercials</h1>
+        <ol class="breadcrumb">
+            <li><a href="javascript:void(0);"><i class="fa fa-dashboard"></i> Home</a></li>
+            <li>Extra</li>
+            <li class="active">Automatic Commercials</li>
+        </ol>
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+    	<div class="box box-solid">
+            <div class="box-header with-border">
+            	<label class="switch" data-toggle="tooltip" title="Module toggle">
+  					<input type="checkbox" id="commercialsModuleToggle" checked="true">
+  					<span class="slider round"></span>
+				</label>
+
+                <h3 class="box-title">Automatic Commercials</h3>
+            </div>
+            <form role="form" id="commercialsModule">
+                <!-- Box content -->
+                <div class="box-body">
+                    <!-- Commercial Interval -->
+                    <div class="form-group">
+                        <label>Interval Between Automatic Commercials, in Minutes</label>
+                        <input type="number" class="form-control" id="commercial-interval" value="8" min="8" data-toggle="tooltip" title="Interval between commercials, minimum 8."/>
+                    </div>
+                    <!-- Commercial Length -->
+                    <div class="form-group">
+                        <label>Commercial Length, in Seconds</label>
+                        <select class="form-control" id="commercial-length">
+                            <option selected="selected">30</option>
+                            <option>60</option>
+                            <option>90</option>
+                            <option>120</option>
+                            <option>150</option>
+                            <option>180</option>
+                        </select>
+                    </div>
+                    
+                    <!-- Optional Commercial Message -->
+                    <div class="form-group">
+                        <label>Optional Message Posted to Chat</label>
+                        <input type="text" class="form-control" id="commercial-message" placeholder="Optional message posted to chat"
+                            data-toggle="tooltip" title="Optional message posted to chat."/>
+                    </div>
+                </div>
+                
+                <!-- Footer with buttons -->
+                <div class="box-footer">
+                    <div class="btn-toolbar">
+                        <button class="btn btn-success" type="button" id="commercials-autotimer-on"><i class="fa fa-check"></i>&nbsp; Set Autotimer</button>
+                        <button class="btn btn-danger hidden" type="button" id="commercials-autotimer-off"><i class="fa fa-trash"></i>&nbsp; Disable Autotimer</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </section>
+
+    <!-- commercials -->
+    <script src="panel/js/pages/extra/commercials.js"></script>
+</main>

--- a/resources/web/panel/pages/extra/commercials.html
+++ b/resources/web/panel/pages/extra/commercials.html
@@ -66,7 +66,7 @@
                 
                 <!-- Footer with buttons -->
                 <div class="box-footer">
-                    <div class="btn-toolbar">
+                    <div class="btn-toolbar pull-right">
                         <button class="btn btn-success" type="button" id="commercials-autotimer-on"><i class="fa fa-check"></i>&nbsp; Set Autotimer</button>
                         <button class="btn btn-danger hidden" type="button" id="commercials-autotimer-off"><i class="fa fa-trash"></i>&nbsp; Disable Autotimer</button>
                     </div>

--- a/source/com/gmt2001/TwitchAPIv5.java
+++ b/source/com/gmt2001/TwitchAPIv5.java
@@ -463,26 +463,28 @@ public class TwitchAPIv5 {
     }
 
     /**
-     * Runs a commercial
+     * Runs a commercial. Will fail if channel is not partnered, a commercial has been run in the last 8 minutes, or stream is offline
      *
      * @param channel
-     * @param length (30, 60, 90)
-     * @return
+     * @param length (30, 60, 90, 120, 150, 180)
+     * @return jsonObj.getInt("_http") == 422 if length is invalid or the channel is currently ineligible to run a commercial due to restrictions listed in the method description
      */
     public JSONObject RunCommercial(String channel, int length) {
         return RunCommercial(channel, length, this.oauth);
     }
 
     /**
-     * Runs a commercial
+     * Runs a commercial. Will fail if channel is not partnered, a commercial has been run in the last 8 minutes, or stream is offline
      *
      * @param channel
-     * @param length (30, 60, 90)
+     * @param length (30, 60, 90, 120, 150, 180)
      * @param oauth
-     * @return
+     * @return jsonObj.getInt("_http") == 422 if length is invalid or the channel is currently ineligible to run a commercial due to restrictions listed in the method description
      */
     public JSONObject RunCommercial(String channel, int length, String oauth) {
-        return GetData(request_type.POST, base_url + "/channels/" + getIDFromChannel(channel) + "/commercial", "length=" + length, oauth, false);
+        JSONObject j = new JSONObject("{}");
+        j.put("length", length);
+        return GetData(request_type.POST, base_url + "/channels/" + getIDFromChannel(channel) + "/commercial", j.toString(), oauth, true);
     }
 
     /**


### PR DESCRIPTION
I went back into my old PhantomBot code to lookup how I did automatic commercials and rewrote it into the current bot as its own system.

I additionally updated the TwitchAPIv5.RunCommercial method to properly execute the way the API documentation expects (send JSON instead of form encoded) and updated the JavaDoc info for it

This system is operated like so:

**A.** The command _!commercial (length) [silent]_ can be used (default moderators) to instantly run a commercial of the specified length. If the _silent_ option is not present, the bot will announce in chat _Running a $1 second commercial_

**B.** The command _!commercial autotimer (interval) (length) [message]_ can be used (default admin) to setup the autotimer to run commercials automatically. If the _message_ parameter is left out, the bot will not announce anything in chat.

The autotimer can be disabled by using _!commercial autotimer off_ and some commands are included to change/delete the message (technically you could also just issue the full _!commercial autotimer_ command at any point to change parameters)

When the autotimer is set it will run the first automatic commerical _length_ minutes after the time it was programmed, or _length_ minutes after bot startup (whichever is later)

Unfortunately I do not have a partnered channel or work with any partnered streamers that I could use to test out the commercial system, so if you guys can find someone willing to help us test it, I would appreciate that. I am confident that there are no issues on my end of the code, unless there is a minor typo somewhere (I did triple check for them).