### PR TITLE
Added HTTP Basic Auth support to HttpRequest

### DIFF
--- a/source/com/gmt2001/HttpRequest.java
+++ b/source/com/gmt2001/HttpRequest.java
@@ -56,6 +56,11 @@ public class HttpRequest {
 
             HttpURLConnection h = (HttpURLConnection) u.openConnection();
 
+            if (u.getUserInfo() != null) {
+                String basicAuth = "Basic " + new String(new Base64().encode(u.getUserInfo().getBytes()));
+                h.setRequestProperty("Authorization", basicAuth);
+            }
+
             headers.entrySet().stream().forEach((e) -> {
                 h.addRequestProperty(e.getKey(), e.getValue());
             });

--- a/source/com/gmt2001/HttpRequest.java
+++ b/source/com/gmt2001/HttpRequest.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 
 /**


### PR DESCRIPTION
This patch adds HTTP Basic Auth support to com.gmt2001.HttpRequest, and by extension to (customapi) and (customapijson)

Link to the demo's I used to test this: https://jigsaw.w3.org/HTTP/

![TestResult](https://user-images.githubusercontent.com/3355471/57520641-262f6780-72ec-11e9-9000-b90932675cd1.png)