### PR TITLE
Added (token) subtag for (customapi)

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -953,7 +953,7 @@
          * @commandpath tokencom [command] [token] - Stores a user/pass or API key to be replaced into a (customapi) tag. WARNING: This should be done from the bot console or web panel, if you run this from chat, anyone watching chat can copy your info!
          */
         if (command.equalsIgnoreCase('tokencom')) {
-            if (action === undefined || subAction === undefined) {
+            if (action === undefined) {
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.token.usage'));
                 return;
             }
@@ -981,7 +981,11 @@
                 $.say($.whisperPrefix(sender) + $.lang.get('customcommands.token.success', action));
             }
             
-            $.inidb.SetString('commandtoken', '', action, argsString);
+            if (argsString.length() === 0) {
+                $.inidb.RemoveKey('commandtoken', '', action);
+            } else {
+                $.inidb.SetString('commandtoken', '', action, argsString);
+            }
             return;
         }
 

--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -614,6 +614,10 @@
 
         // Get the URL for a customapi, if applicable, and process $1 - $9.  See below about that.
         if ((regExCheck = message.match(reCustomAPI))) {
+            if (regExCheck[1].indexOf('(token)') !== -1 && $.inidb.HasKey('commandtoken', '', command)) {
+                regExCheck[1] = regExCheck[1].replace(/\(token\)/gi, $.inidb.GetString('commandtoken', '', command));
+            }
+            
             if (regExCheck[1].indexOf('$1') != -1) {
                 for (var i = 1; i <= 9; i++) {
                     if (regExCheck[1].indexOf('$' + i) != -1) {
@@ -634,6 +638,10 @@
         // a custom JavaScript.  We limit $1 - $9 as well; 10 or more arguments being passed by users to an
         // API seems like overkill.  Even 9 does, to be honest.
         if ((regExCheck = message.match(reCustomAPIJson))) {
+            if (regExCheck[1].indexOf('(token)') !== -1 && $.inidb.HasKey('commandtoken', '', command)) {
+                regExCheck[1] = regExCheck[1].replace(/\(token\)/gi, $.inidb.GetString('commandtoken', '', command));
+            }
+            
             if (regExCheck[1].indexOf('$1') != -1) {
                 for (var i = 1; i <= 9; i++) {
                     if (regExCheck[1].indexOf('$' + i) != -1) {
@@ -938,6 +946,42 @@
             $.registerChatCommand('./commands/customCommands.js', action, 7);
             $.inidb.set('command', action, argsString);
             customCommands[action] = argsString;
+            return;
+        }
+
+        /*
+         * @commandpath tokencom [command] [token] - Stores a user/pass or API key to be replaced into a (customapi) tag. WARNING: This should be done from the bot console or web panel, if you run this from chat, anyone watching chat can copy your info!
+         */
+        if (command.equalsIgnoreCase('tokencom')) {
+            if (action === undefined || subAction === undefined) {
+                $.say($.whisperPrefix(sender) + $.lang.get('customcommands.token.usage'));
+                return;
+            }
+
+            action = action.replace('!', '').toLowerCase();
+            argsString = args.slice(1).join(' ');
+            
+            var silent = false;
+            if (action.startsWith('silent@')) {
+                silent = true;
+                action = action.substr(7);
+            }
+
+            if (!$.commandExists(action)) {
+                $.say($.whisperPrefix(sender) + $.lang.get('cmd.404', action));
+                return;
+            } else if ($.inidb.get('command', action).match(/\(adminonlyedit\)/) && !$.isAdmin(sender)) {
+                if ($.getIniDbBoolean('settings', 'permComMsgEnabled', true)) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('cmd.perm.404', $.getGroupNameById('1')));
+                }
+                return;
+            }
+
+            if (!silent) {
+                $.say($.whisperPrefix(sender) + $.lang.get('customcommands.token.success', action));
+            }
+            
+            $.inidb.SetString('commandtoken', '', action, argsString);
             return;
         }
 
@@ -1371,6 +1415,7 @@
         $.registerChatCommand('./commands/customCommands.js', 'delalias', 2);
         $.registerChatCommand('./commands/customCommands.js', 'delcom', 2);
         $.registerChatCommand('./commands/customCommands.js', 'editcom', 2);
+        $.registerChatCommand('./commands/customCommands.js', 'tokencom', 2);
         $.registerChatCommand('./commands/customCommands.js', 'permcom', 1);
         $.registerChatCommand('./commands/customCommands.js', 'commands', 7);
         $.registerChatCommand('./commands/customCommands.js', 'disablecom', 1);

--- a/javascript-source/lang/english/commands/commands-customCommands.js
+++ b/javascript-source/lang/english/commands/commands-customCommands.js
@@ -49,6 +49,8 @@ $.lang.register('customcommands.404.no.commands', 'There are no custom commands,
 $.lang.register('customcommands.cmds', 'Current custom commands: $1');
 $.lang.register('customcommands.edit.usage', 'Usage: !editcom (command) (message)');
 $.lang.register('customcommands.edit.success', 'Command !$1 has been edited!');
+$.lang.register('customcommands.token.usage', 'Usage: !tokencom (command) (token) -- WARNING: This should be done from the bot console or web panel, if you run this from chat, anyone watching chat can copy your info!');
+$.lang.register('customcommands.token.success', 'Token set for command !$1! Make sure you put a (token) subtag in the customapi url for this command in the spot you want it to appear');
 $.lang.register('customcommands.touser.offline', 'Sorry, but $1 appears to be offline!');
 $.lang.register('customcommands.customapi.404', 'The !$1 command requires parameters.');
 $.lang.register('customcommands.customapijson.err', '!$1: An error occurred processing the API.');

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -49,14 +49,6 @@ $(run = function() {
                         'html': $('<i/>', {
                             'class': 'fa fa-edit'
                         })
-                    })).append($('<button/>', {
-                        'type': 'button',
-                        'class': 'btn btn-xs btn-info',
-                        'style': 'float: right',
-                        'data-command': results[i].key,
-                        'html': $('<i/>', {
-                            'class': 'fa fa-unlock-alt'
-                        })
                     })).html()
                 ]);
             }
@@ -200,47 +192,6 @@ $(run = function() {
                         }
                     }).modal('toggle');
                 });
-            });
-
-            // On token button.
-            table.on('click', '.btn-info', function() {
-                let command = $(this).data('command'),
-                    t = $(this);
-
-                // Get advance modal from our util functions in /utils/helpers.js
-                helpers.getAdvanceModal('token-command', 'Set Command Token', 'Save', $('<form/>', {
-                    'role': 'form'
-                })
-                .append('This dialog stores a user/pass or API key to be replaced into a (customapi) tag.\n\
-                <br /> NOTE: This is only useful if you place a (token) subtag into the URL of a (customapi) or (customapijson) command tag.\n\
-                <br /> Example (using the bot\s chat commands for demonstration purposes):\n\
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!addcom myapicommand (customapi http://(token)@example.com/myapi)\n\
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!tokencom myapicommand myuser:mypass\n\
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<i>The command now effectively calls http://myuser:mypass@example.com/myapi while reducing exposure of your user/pass</i>')
-                // Append input box for the command name. This one is disabled.
-                .append(helpers.getInputGroup('command-tname', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
-                // Append a text box for the command token.
-                .append(helpers.getnputGroup('command-token', 'text', 'Token', '', 'The token value for the command.')), function() {
-                    let commandName = $('#command-tname'),
-                        commandToken = $('#command-token');
-
-                    // Remove the ! and spaces.
-                    commandName.val(commandName.val().replace(/(\!|\s)/g, '').toLowerCase());
-
-                    // Handle each input to make sure they have a value.
-                    switch (false) {
-                        case helpers.handleInputString(commandName):
-                            break;
-                        default:
-                        // Update command token.
-                        socket.sendCommand('command_settoken_cmd', 'tokencom silent@' + commandName.val() + ' ' + commandToken.val(), function() {
-                            // Close the modal.
-                            $('#token-command').modal('hide');
-                            // Tell the user the command was edited.
-                            toastr.success('Successfully changed token for command !' + commandName.val());
-                        });
-                    }
-                }).modal('toggle');
             });
         });
     });

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -75,7 +75,7 @@ $(run = function() {
                 'lengthChange': false,
                 'data': tableData,
                 'columnDefs': [
-                    { 'className': 'default-table', 'orderable': false, 'targets': 2 },
+                    { 'className': 'default-table w65px', 'orderable': false, 'targets': 2 },
                     { 'width': '15%', 'targets': 0 }
                 ],
                 'columns': [
@@ -207,8 +207,8 @@ $(run = function() {
                 let command = $(this).data('command'),
                     t = $(this);
 
-                // Get advance modal from our util functions in /utils/helpers.js
-                helpers.getAdvanceModal('token-command', 'Set Command Token', 'Save', $('<form/>', {
+                // Get modal from our util functions in /utils/helpers.js
+                helpers.getModal('token-command', 'Set Command Token', 'Save', $('<form/>', {
                     'role': 'form'
                 })
                 .append('This dialog stores a user/pass or API key to be replaced into a (customapi) tag.\n\
@@ -220,7 +220,7 @@ $(run = function() {
                 // Append input box for the command name. This one is disabled.
                 .append(helpers.getInputGroup('command-tname', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
                 // Append a text box for the command token.
-                .append(helpers.getnputGroup('command-token', 'text', 'Token', '', 'The token value for the command.')), function() {
+                .append(helpers.getInputGroup('command-token', 'text', 'Token', '', 'The token value for the command.')), function() {
                     let commandName = $('#command-tname'),
                         commandToken = $('#command-token');
 

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -75,7 +75,7 @@ $(run = function() {
                 'lengthChange': false,
                 'data': tableData,
                 'columnDefs': [
-                    { 'className': 'default-table w65px', 'orderable': false, 'targets': 2 },
+                    { 'className': 'default-table', 'orderable': false, 'targets': 2 },
                     { 'width': '15%', 'targets': 0 }
                 ],
                 'columns': [
@@ -207,8 +207,8 @@ $(run = function() {
                 let command = $(this).data('command'),
                     t = $(this);
 
-                // Get modal from our util functions in /utils/helpers.js
-                helpers.getModal('token-command', 'Set Command Token', 'Save', $('<form/>', {
+                // Get advance modal from our util functions in /utils/helpers.js
+                helpers.getAdvanceModal('token-command', 'Set Command Token', 'Save', $('<form/>', {
                     'role': 'form'
                 })
                 .append('This dialog stores a user/pass or API key to be replaced into a (customapi) tag.\n\
@@ -220,7 +220,7 @@ $(run = function() {
                 // Append input box for the command name. This one is disabled.
                 .append(helpers.getInputGroup('command-tname', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
                 // Append a text box for the command token.
-                .append(helpers.getInputGroup('command-token', 'text', 'Token', '', 'The token value for the command.')), function() {
+                .append(helpers.getnputGroup('command-token', 'text', 'Token', '', 'The token value for the command.')), function() {
                     let commandName = $('#command-tname'),
                         commandToken = $('#command-token');
 

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -110,10 +110,19 @@ $(run = function() {
                 }, function(e) {
                     let cooldownJson = (e.cooldown === null ? { isGlobal: 'true', seconds: 0 } : JSON.parse(e.cooldown));
 
-                    let tokenLink = '';
+                    let tokenButton = '';
                     
                     if (e.command.match(/\(customapi/gi) !== null) {
-                        tokenLink = '<a href="#" onclick="tokenEditModal(\'' + command + '\');">Add/Edit Command Token</a>';
+                        tokenButton = $('<button/>', {
+                            'type': 'button',
+                            'class': 'btn',
+                            'style': 'float: right; position: relative; bottom: 6px;',
+                            'data-command': command,
+                            'click': function() {
+                                tokenEditModal($(this).data('command'));
+                            },
+                            'text': 'Add/Edit Command Token'
+                        });
                     }
 
                     // Get advance modal from our util functions in /utils/helpers.js
@@ -124,6 +133,7 @@ $(run = function() {
                     .append(helpers.getInputGroup('command-name', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
                     // Append a text box for the command response.
                     .append(helpers.getTextAreaGroup('command-response', 'text', 'Response', '', e.command, 'Response of the command. Use enter for multiple chat lines maximum is 5.'))
+                    .append(tokenButton)
                     // Append a select option for the command permission.
                     .append(helpers.getDropdownGroup('command-permission', 'User Level', helpers.getGroupNameById(e.permcom),
                         ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
@@ -134,7 +144,6 @@ $(run = function() {
                         'html': $('<form/>', {
                                 'role': 'form'
                             })
-                            .append(tokenLink)
                             // Append input box for the command cost.
                             .append(helpers.getInputGroup('command-cost', 'number', 'Cost', '0', helpers.getDefaultIfNullOrUndefined(e.pricecom, '0'),
                                 'Cost in points that will be taken from the user when running the command.'))

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -49,6 +49,14 @@ $(run = function() {
                         'html': $('<i/>', {
                             'class': 'fa fa-edit'
                         })
+                    })).append($('<button/>', {
+                        'type': 'button',
+                        'class': 'btn btn-xs btn-info',
+                        'style': 'float: right',
+                        'data-command': results[i].key,
+                        'html': $('<i/>', {
+                            'class': 'fa fa-unlock-alt'
+                        })
                     })).html()
                 ]);
             }
@@ -192,6 +200,47 @@ $(run = function() {
                         }
                     }).modal('toggle');
                 });
+            });
+
+            // On token button.
+            table.on('click', '.btn-info', function() {
+                let command = $(this).data('command'),
+                    t = $(this);
+
+                // Get advance modal from our util functions in /utils/helpers.js
+                helpers.getAdvanceModal('token-command', 'Set Command Token', 'Save', $('<form/>', {
+                    'role': 'form'
+                })
+                .append('This dialog stores a user/pass or API key to be replaced into a (customapi) tag.\n\
+                <br /> NOTE: This is only useful if you place a (token) subtag into the URL of a (customapi) or (customapijson) command tag.\n\
+                <br /> Example (using the bot\s chat commands for demonstration purposes):\n\
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!addcom myapicommand (customapi http://(token)@example.com/myapi)\n\
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;!tokencom myapicommand myuser:mypass\n\
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<i>The command now effectively calls http://myuser:mypass@example.com/myapi while reducing exposure of your user/pass</i>')
+                // Append input box for the command name. This one is disabled.
+                .append(helpers.getInputGroup('command-tname', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
+                // Append a text box for the command token.
+                .append(helpers.getnputGroup('command-token', 'text', 'Token', '', 'The token value for the command.')), function() {
+                    let commandName = $('#command-tname'),
+                        commandToken = $('#command-token');
+
+                    // Remove the ! and spaces.
+                    commandName.val(commandName.val().replace(/(\!|\s)/g, '').toLowerCase());
+
+                    // Handle each input to make sure they have a value.
+                    switch (false) {
+                        case helpers.handleInputString(commandName):
+                            break;
+                        default:
+                        // Update command token.
+                        socket.sendCommand('command_settoken_cmd', 'tokencom silent@' + commandName.val() + ' ' + commandToken.val(), function() {
+                            // Close the modal.
+                            $('#token-command').modal('hide');
+                            // Tell the user the command was edited.
+                            toastr.success('Successfully changed token for command !' + commandName.val());
+                        });
+                    }
+                }).modal('toggle');
             });
         });
     });

--- a/resources/web/panel/pages/commands/custom.html
+++ b/resources/web/panel/pages/commands/custom.html
@@ -12,12 +12,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<style type="text/css">
-    .w65px {
-        width: 65px;
-        min-width: 65px;
-    }
-</style>
+
 <main>
     <!-- Header -->
     <section class="content-header">

--- a/resources/web/panel/pages/commands/custom.html
+++ b/resources/web/panel/pages/commands/custom.html
@@ -12,7 +12,12 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-
+<style type="text/css">
+    .w65px {
+        width: 65px;
+        min-width: 65px;
+    }
+</style>
 <main>
     <!-- Header -->
     <section class="content-header">


### PR DESCRIPTION
This patch adds the (token) subtag for (customapi)/(customapijson) as discussed in PR #2148 

I am not 100% that my method of fixing the column width for the panel is acceptable for you guys. I am also not sure if you want it added separately this way or just want it added to the edit dialog. Please let me know.

This tag is only parsed inside of a (customapi) or (customapijson) tag. It's purpose is to hide an HTTP Basic Auth user:pass or an API key from viewers/moderators who may be editing commands from chat (or using the panel, if someone shares it among trusted users against the teams advice).

To add a token from chat (not recommended) or from the bot console, the command is _!tokencom command token_

To add a token from the panel, click the new blue lock icon under the **Actions** column on the **Custom Commands** page

At runtime, if a (token) tag is detected inside of a (customapi) or (customapijson) tag, it will be replaced with the stored token value from the database in the temporary URL string that gets passed into $.customApi

![Untitled](https://user-images.githubusercontent.com/3355471/57729292-d17d4b00-7663-11e9-88a3-022f00b65f18.png)

The first test (!test3) is using the url _https://guest:guest@jigsaw.w3.org/HTTP/Basic/_ without attempting to use the new (token) subtag

The second test (!test5) is using the url _https://(token)@jigsaw.w3.org/HTTP/Basic/_ but failing to set the token value with !tokencom or the panel

The final test (!test4) is the same as the second test, but this command has had it's token set using the panel