### PR TITLE
Fixed blank section bug, while retaining ability to explicitly use it

### DIFF
--- a/source/com/gmt2001/datastore/DataStore.java
+++ b/source/com/gmt2001/datastore/DataStore.java
@@ -178,7 +178,6 @@ public class DataStore {
         throw new UnsupportedOperationException();
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     public long GetLong(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 
@@ -195,7 +194,6 @@ public class DataStore {
         SetString(fName, section, key, sval);
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     public int GetInteger(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 
@@ -212,7 +210,6 @@ public class DataStore {
         SetString(fName, section, key, sval);
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     public float GetFloat(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 
@@ -229,7 +226,6 @@ public class DataStore {
         SetString(fName, section, key, sval);
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     public double GetDouble(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 

--- a/source/com/gmt2001/datastore/DataStore.java
+++ b/source/com/gmt2001/datastore/DataStore.java
@@ -178,6 +178,7 @@ public class DataStore {
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     public long GetLong(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 
@@ -194,6 +195,7 @@ public class DataStore {
         SetString(fName, section, key, sval);
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     public int GetInteger(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 
@@ -210,6 +212,7 @@ public class DataStore {
         SetString(fName, section, key, sval);
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     public float GetFloat(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 
@@ -226,6 +229,7 @@ public class DataStore {
         SetString(fName, section, key, sval);
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     public double GetDouble(String fName, String section, String key) {
         String sval = GetString(fName, section, key);
 

--- a/source/com/gmt2001/datastore/DataStore.java
+++ b/source/com/gmt2001/datastore/DataStore.java
@@ -286,11 +286,11 @@ public class DataStore {
     }
 
     public boolean exists(String fName, String key) {
-        return HasKey(fName, "", key);
+        return HasKey(fName, null, key);
     }
 
     public String get(String fName, String key) {
-        return GetString(fName, "", key);
+        return GetString(fName, null, key);
     }
 
     public void set(String fName, String key, String value) {

--- a/source/com/gmt2001/datastore/H2Store.java
+++ b/source/com/gmt2001/datastore/H2Store.java
@@ -64,27 +64,21 @@ public class H2Store extends DataStore {
         return "DESC";
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeLimit(String limit) {
         try {
             int intValue = Integer.parseInt(limit);
             return String.valueOf(intValue);
-        } catch (NumberFormatException ex) {
-            return String.valueOf(Integer.MAX_VALUE);
-        } catch (NullPointerException ex) {
-            return String.valueOf(Integer.MAX_VALUE);
         } catch (Exception ex) {
             return String.valueOf(Integer.MAX_VALUE);
         }
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeOffset(String offset) {
         try {
             int intValue = Integer.parseInt(offset);
             return String.valueOf(intValue);
-        } catch (NumberFormatException ex) {
-            return "0";
-        } catch (NullPointerException ex) {
-            return "0";
         } catch (Exception ex) {
             return "0";
         }
@@ -118,6 +112,7 @@ public class H2Store extends DataStore {
     }
 
     @Override
+    @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
 
@@ -267,7 +262,7 @@ public class H2Store extends DataStore {
 
             DatabaseMetaData md = connection.getMetaData();
             try (ResultSet rs = md.getTables(null, null, "PHANTOMBOT_%", null)) {
-                ArrayList<String> s = new ArrayList<String>();
+                ArrayList<String> s = new ArrayList<>();
                 while (rs.next()) {
                     s.add(rs.getString(3).substring(11));
                 }
@@ -293,7 +288,7 @@ public class H2Store extends DataStore {
 
                 try (ResultSet rs = statement.executeQuery("SELECT section FROM phantombot_" + fName + " GROUP BY section;")) {
 
-                    ArrayList<String> s = new ArrayList<String>();
+                    ArrayList<String> s = new ArrayList<>();
 
                     while (rs.next()) {
                         s.add(rs.getString("section"));
@@ -317,14 +312,14 @@ public class H2Store extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -341,7 +336,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -366,14 +361,14 @@ public class H2Store extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable, value FROM phantombot_" + fName + " WHERE section=?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
+                        ArrayList<KeyValue> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -390,7 +385,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
+                        ArrayList<KeyValue> s = new ArrayList<>();
 
 
                         while (rs.next()) {
@@ -428,7 +423,7 @@ public class H2Store extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 if (isNumber) {
                     statementStr = "SELECT variable FROM phantombot_" + fName + " WHERE section=? ORDER BY CAST(variable as INTEGER) " + order + " LIMIT " + limit + " OFFSET " + offset + ";";
                 } else {
@@ -440,7 +435,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -462,7 +457,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -499,7 +494,7 @@ public class H2Store extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 if (isNumber) {
                     statementStr = "SELECT variable FROM phantombot_" + fName + " WHERE section=? ORDER BY CAST(value as INTEGER) " + order + " LIMIT " + limit + " OFFSET " + offset + ";";
                 } else {
@@ -511,7 +506,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -533,7 +528,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -558,14 +553,14 @@ public class H2Store extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND value LIKE ?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -581,7 +576,7 @@ public class H2Store extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -607,14 +602,14 @@ public class H2Store extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND variable LIKE ?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -630,7 +625,7 @@ public class H2Store extends DataStore {
                     statement.setString(1, search);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -659,14 +654,14 @@ public class H2Store extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND variable LIKE ? ORDER BY variable " + order + " LIMIT " + limit + " OFFSET " + offset + ";")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -682,7 +677,7 @@ public class H2Store extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -711,7 +706,7 @@ public class H2Store extends DataStore {
             return false;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT value FROM phantombot_" + fName + " WHERE section=? AND variable=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);
@@ -756,7 +751,7 @@ public class H2Store extends DataStore {
             return result;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND value=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);
@@ -803,7 +798,7 @@ public class H2Store extends DataStore {
             return result;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT value FROM phantombot_" + fName + " WHERE section=? AND variable=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);

--- a/source/com/gmt2001/datastore/H2Store.java
+++ b/source/com/gmt2001/datastore/H2Store.java
@@ -64,21 +64,27 @@ public class H2Store extends DataStore {
         return "DESC";
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeLimit(String limit) {
         try {
             int intValue = Integer.parseInt(limit);
             return String.valueOf(intValue);
+        } catch (NumberFormatException ex) {
+            return String.valueOf(Integer.MAX_VALUE);
+        } catch (NullPointerException ex) {
+            return String.valueOf(Integer.MAX_VALUE);
         } catch (Exception ex) {
             return String.valueOf(Integer.MAX_VALUE);
         }
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeOffset(String offset) {
         try {
             int intValue = Integer.parseInt(offset);
             return String.valueOf(intValue);
+        } catch (NumberFormatException ex) {
+            return "0";
+        } catch (NullPointerException ex) {
+            return "0";
         } catch (Exception ex) {
             return "0";
         }
@@ -112,7 +118,6 @@ public class H2Store extends DataStore {
     }
 
     @Override
-    @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
 
@@ -262,7 +267,7 @@ public class H2Store extends DataStore {
 
             DatabaseMetaData md = connection.getMetaData();
             try (ResultSet rs = md.getTables(null, null, "PHANTOMBOT_%", null)) {
-                ArrayList<String> s = new ArrayList<>();
+                ArrayList<String> s = new ArrayList<String>();
                 while (rs.next()) {
                     s.add(rs.getString(3).substring(11));
                 }
@@ -288,7 +293,7 @@ public class H2Store extends DataStore {
 
                 try (ResultSet rs = statement.executeQuery("SELECT section FROM phantombot_" + fName + " GROUP BY section;")) {
 
-                    ArrayList<String> s = new ArrayList<>();
+                    ArrayList<String> s = new ArrayList<String>();
 
                     while (rs.next()) {
                         s.add(rs.getString("section"));
@@ -319,7 +324,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -336,7 +341,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -368,7 +373,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<>();
+                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -385,7 +390,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<>();
+                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
 
 
                         while (rs.next()) {
@@ -435,7 +440,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -457,7 +462,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -506,7 +511,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -528,7 +533,7 @@ public class H2Store extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -560,7 +565,7 @@ public class H2Store extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -576,7 +581,7 @@ public class H2Store extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -609,7 +614,7 @@ public class H2Store extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -625,7 +630,7 @@ public class H2Store extends DataStore {
                     statement.setString(1, search);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -661,7 +666,7 @@ public class H2Store extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -677,7 +682,7 @@ public class H2Store extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));

--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -60,21 +60,27 @@ public class MySQLStore extends DataStore {
         return "DESC";
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeLimit(String limit) {
         try {
             int intValue = Integer.parseInt(limit);
             return String.valueOf(intValue);
+        } catch (NumberFormatException ex) {
+            return String.valueOf(Integer.MAX_VALUE);
+        } catch (NullPointerException ex) {
+            return String.valueOf(Integer.MAX_VALUE);
         } catch (Exception ex) {
             return String.valueOf(Integer.MAX_VALUE);
         }
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeOffset(String offset) {
         try {
             int intValue = Integer.parseInt(offset);
             return String.valueOf(intValue);
+        } catch (NumberFormatException ex) {
+            return "0";
+        } catch (NullPointerException ex) {
+            return "0";
         } catch (Exception ex) {
             return "0";
         }
@@ -109,7 +115,6 @@ public class MySQLStore extends DataStore {
     }
 
     @Override
-    @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
 
@@ -253,7 +258,7 @@ public class MySQLStore extends DataStore {
 
             DatabaseMetaData md = connection.getMetaData();
             try (ResultSet rs = md.getTables(null, null, "%", null)) {
-                ArrayList<String> s = new ArrayList<>();
+                ArrayList<String> s = new ArrayList<String>();
                 while (rs.next()) {
                     s.add(rs.getString(3));
                 }
@@ -279,7 +284,7 @@ public class MySQLStore extends DataStore {
 
                 try (ResultSet rs = statement.executeQuery("SELECT section FROM phantombot_" + fName + " GROUP BY section;")) {
 
-                    ArrayList<String> s = new ArrayList<>();
+                    ArrayList<String> s = new ArrayList<String>();
 
                     while (rs.next()) {
                         s.add(rs.getString("section"));
@@ -310,7 +315,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -327,7 +332,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -358,7 +363,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<KeyValue> s = new ArrayList<>();
+                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -375,7 +380,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<>();
+                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -423,7 +428,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -445,7 +450,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -495,7 +500,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -517,7 +522,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -549,7 +554,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -565,7 +570,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -598,7 +603,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -614,7 +619,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, search);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -650,7 +655,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -666,7 +671,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));

--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -60,27 +60,21 @@ public class MySQLStore extends DataStore {
         return "DESC";
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeLimit(String limit) {
         try {
             int intValue = Integer.parseInt(limit);
             return String.valueOf(intValue);
-        } catch (NumberFormatException ex) {
-            return String.valueOf(Integer.MAX_VALUE);
-        } catch (NullPointerException ex) {
-            return String.valueOf(Integer.MAX_VALUE);
         } catch (Exception ex) {
             return String.valueOf(Integer.MAX_VALUE);
         }
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeOffset(String offset) {
         try {
             int intValue = Integer.parseInt(offset);
             return String.valueOf(intValue);
-        } catch (NumberFormatException ex) {
-            return "0";
-        } catch (NullPointerException ex) {
-            return "0";
         } catch (Exception ex) {
             return "0";
         }
@@ -115,6 +109,7 @@ public class MySQLStore extends DataStore {
     }
 
     @Override
+    @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
 
@@ -258,7 +253,7 @@ public class MySQLStore extends DataStore {
 
             DatabaseMetaData md = connection.getMetaData();
             try (ResultSet rs = md.getTables(null, null, "%", null)) {
-                ArrayList<String> s = new ArrayList<String>();
+                ArrayList<String> s = new ArrayList<>();
                 while (rs.next()) {
                     s.add(rs.getString(3));
                 }
@@ -284,7 +279,7 @@ public class MySQLStore extends DataStore {
 
                 try (ResultSet rs = statement.executeQuery("SELECT section FROM phantombot_" + fName + " GROUP BY section;")) {
 
-                    ArrayList<String> s = new ArrayList<String>();
+                    ArrayList<String> s = new ArrayList<>();
 
                     while (rs.next()) {
                         s.add(rs.getString("section"));
@@ -308,14 +303,14 @@ public class MySQLStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -332,7 +327,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -357,13 +352,13 @@ public class MySQLStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable, value FROM phantombot_" + fName + " WHERE section=?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
+                        ArrayList<KeyValue> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -380,7 +375,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
+                        ArrayList<KeyValue> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -416,7 +411,7 @@ public class MySQLStore extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 if (isNumber) {
                     statementStr = "SELECT variable FROM phantombot_" + fName + " WHERE section=? ORDER BY CAST(variable as UNSIGNED) " + order + "  LIMIT " + limit + " OFFSET " + offset + ";";
                 } else {
@@ -428,7 +423,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -450,7 +445,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -488,7 +483,7 @@ public class MySQLStore extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 if (isNumber) {
                     statementStr = "SELECT variable FROM phantombot_" + fName + " WHERE section=? ORDER BY CAST(value as UNSIGNED) " + order + " LIMIT " + limit + " OFFSET " + offset + ";";
                 } else {
@@ -500,7 +495,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -522,7 +517,7 @@ public class MySQLStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -547,14 +542,14 @@ public class MySQLStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND value LIKE ?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -570,7 +565,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -596,14 +591,14 @@ public class MySQLStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND variable LIKE ?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -619,7 +614,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, search);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -648,14 +643,14 @@ public class MySQLStore extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND variable LIKE ? ORDER BY variable " + order + " LIMIT " + limit + " OFFSET " + offset + ";")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -671,7 +666,7 @@ public class MySQLStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -700,7 +695,7 @@ public class MySQLStore extends DataStore {
             return false;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT value FROM phantombot_" + fName + " WHERE section=? AND variable=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);
@@ -746,7 +741,7 @@ public class MySQLStore extends DataStore {
             return result;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND value=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);
@@ -793,7 +788,7 @@ public class MySQLStore extends DataStore {
             return result;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT value FROM phantombot_" + fName + " WHERE section=? AND variable=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);

--- a/source/com/gmt2001/datastore/SqliteStore.java
+++ b/source/com/gmt2001/datastore/SqliteStore.java
@@ -73,21 +73,27 @@ public class SqliteStore extends DataStore {
         return "DESC";
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeLimit(String limit) {
         try {
             int intValue = Integer.parseInt(limit);
             return String.valueOf(intValue);
+        } catch (NumberFormatException ex) {
+            return String.valueOf(Integer.MAX_VALUE);
+        } catch (NullPointerException ex) {
+            return String.valueOf(Integer.MAX_VALUE);
         } catch (Exception ex) {
             return String.valueOf(Integer.MAX_VALUE);
         }
     }
 
-    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeOffset(String offset) {
         try {
             int intValue = Integer.parseInt(offset);
             return String.valueOf(intValue);
+        } catch (NumberFormatException ex) {
+            return "0";
+        } catch (NullPointerException ex) {
+            return "0";
         } catch (Exception ex) {
             return "0";
         }
@@ -184,7 +190,6 @@ public class SqliteStore extends DataStore {
     }
 
     @Override
-    @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
 
@@ -341,7 +346,7 @@ public class SqliteStore extends DataStore {
 
             try (ResultSet rs = statement.executeQuery("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'phantombot_%';")) {
 
-                ArrayList<String> s = new ArrayList<>();
+                ArrayList<String> s = new ArrayList<String>();
 
                 while (rs.next()) {
                     s.add(rs.getString("name").substring(11));
@@ -370,7 +375,7 @@ public class SqliteStore extends DataStore {
 
                 try (ResultSet rs = statement.executeQuery("SELECT section FROM phantombot_" + fName + " GROUP BY section;")) {
 
-                    ArrayList<String> s = new ArrayList<>();
+                    ArrayList<String> s = new ArrayList<String>();
 
                     while (rs.next()) {
                         s.add(rs.getString("section"));
@@ -402,7 +407,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -419,7 +424,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -448,7 +453,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<KeyValue> s = new ArrayList<>();
+                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -465,7 +470,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<>();
+                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -512,7 +517,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -534,7 +539,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -583,7 +588,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -605,7 +610,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -638,7 +643,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -654,7 +659,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -688,7 +693,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -704,7 +709,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -741,7 +746,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -757,7 +762,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<>();
+                        ArrayList<String> s = new ArrayList<String>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));

--- a/source/com/gmt2001/datastore/SqliteStore.java
+++ b/source/com/gmt2001/datastore/SqliteStore.java
@@ -73,27 +73,21 @@ public class SqliteStore extends DataStore {
         return "DESC";
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeLimit(String limit) {
         try {
             int intValue = Integer.parseInt(limit);
             return String.valueOf(intValue);
-        } catch (NumberFormatException ex) {
-            return String.valueOf(Integer.MAX_VALUE);
-        } catch (NullPointerException ex) {
-            return String.valueOf(Integer.MAX_VALUE);
         } catch (Exception ex) {
             return String.valueOf(Integer.MAX_VALUE);
         }
     }
 
+    @SuppressWarnings("UseSpecificCatch")
     private String sanitizeOffset(String offset) {
         try {
             int intValue = Integer.parseInt(offset);
             return String.valueOf(intValue);
-        } catch (NumberFormatException ex) {
-            return "0";
-        } catch (NullPointerException ex) {
-            return "0";
         } catch (Exception ex) {
             return "0";
         }
@@ -190,6 +184,7 @@ public class SqliteStore extends DataStore {
     }
 
     @Override
+    @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
 
@@ -346,7 +341,7 @@ public class SqliteStore extends DataStore {
 
             try (ResultSet rs = statement.executeQuery("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'phantombot_%';")) {
 
-                ArrayList<String> s = new ArrayList<String>();
+                ArrayList<String> s = new ArrayList<>();
 
                 while (rs.next()) {
                     s.add(rs.getString("name").substring(11));
@@ -375,7 +370,7 @@ public class SqliteStore extends DataStore {
 
                 try (ResultSet rs = statement.executeQuery("SELECT section FROM phantombot_" + fName + " GROUP BY section;")) {
 
-                    ArrayList<String> s = new ArrayList<String>();
+                    ArrayList<String> s = new ArrayList<>();
 
                     while (rs.next()) {
                         s.add(rs.getString("section"));
@@ -400,14 +395,14 @@ public class SqliteStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -424,7 +419,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -447,13 +442,13 @@ public class SqliteStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable, value FROM phantombot_" + fName + " WHERE section=?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
+                        ArrayList<KeyValue> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -470,7 +465,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<KeyValue> s = new ArrayList<KeyValue>();
+                        ArrayList<KeyValue> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(new KeyValue(rs.getString("variable"), rs.getString("value")));
@@ -505,7 +500,7 @@ public class SqliteStore extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 if (isNumber) {
                     statementStr = "SELECT variable FROM phantombot_" + fName + " WHERE section=? ORDER BY CAST(variable as INTEGER) COLLATE NOCASE " + order + " LIMIT " + limit + " OFFSET " + offset + ";";
                 } else {
@@ -517,7 +512,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -539,7 +534,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -575,7 +570,7 @@ public class SqliteStore extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 if (isNumber) {
                     statementStr = "SELECT variable FROM phantombot_" + fName + " WHERE section=? ORDER BY CAST(value as INTEGER) COLLATE NOCASE " + order + " LIMIT " + limit + " OFFSET " + offset + ";";
                 } else {
@@ -588,7 +583,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -610,7 +605,7 @@ public class SqliteStore extends DataStore {
 
                     try (ResultSet rs = statement.executeQuery()) {
 
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while (rs.next()) {
                             s.add(rs.getString("variable"));
@@ -636,14 +631,14 @@ public class SqliteStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND value LIKE ?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -659,7 +654,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -686,14 +681,14 @@ public class SqliteStore extends DataStore {
         fName = validateFname(fName);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND variable LIKE ?;")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -709,7 +704,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -739,14 +734,14 @@ public class SqliteStore extends DataStore {
         offset = sanitizeOffset(offset);
 
         if (FileExists(fName)) {
-            if (section.length() > 0) {
+            if (section != null) {
                 try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND variable LIKE ? ORDER BY variable " + order + " LIMIT " + limit + " OFFSET " + offset + ";")) {
                     statement.setQueryTimeout(10);
                     statement.setString(1, section);
                     statement.setString(2, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -762,7 +757,7 @@ public class SqliteStore extends DataStore {
                     statement.setString(1, "%" + search + "%");
 
                     try (ResultSet rs = statement.executeQuery()) {
-                        ArrayList<String> s = new ArrayList<String>();
+                        ArrayList<String> s = new ArrayList<>();
 
                         while(rs.next()) {
                             s.add(rs.getString("variable"));
@@ -792,7 +787,7 @@ public class SqliteStore extends DataStore {
             return false;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT value FROM phantombot_" + fName + " WHERE section=? AND variable=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);
@@ -839,7 +834,7 @@ public class SqliteStore extends DataStore {
             return result;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT variable FROM phantombot_" + fName + " WHERE section=? AND value=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);
@@ -887,7 +882,7 @@ public class SqliteStore extends DataStore {
             return result;
         }
 
-        if (section.length() > 0) {
+        if (section != null) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT value FROM phantombot_" + fName + " WHERE section=? AND variable=?;")) {
                 statement.setQueryTimeout(10);
                 statement.setString(1, section);

--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -239,12 +239,11 @@ public class HTTPServerCommon {
      * table=tableName&getSortedRowsByValue&limit=n
      * table=tableName&getSortedRowsByValue&offset=n
      */
-    @SuppressWarnings("null")
     private static void handleDBQuery(String uriPath, String[] uriQueryList, HttpExchange exchange, Boolean hasPassword) {
         JSONStringer jsonObject = new JSONStringer();
         String[] keyValue;
         String   dbTable = null;
-        String   dbSection = "";
+        String   dbSection = null;
         Boolean  dbExists;
 
         if (!hasPassword) {
@@ -280,10 +279,8 @@ public class HTTPServerCommon {
             } else if (keyValue[0].equals("section")) {
                 if (keyValue.length > 1 && keyValue[1].length() > 0) {
                     dbSection = keyValue[1];
-                }
-                
-                if (dbSection.equalsIgnoreCase("null")) {
-                    dbSection = null;
+                } else {
+                    dbSection = "";
                 }
             } else {
                 // All other commands need the table.

--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -239,6 +239,7 @@ public class HTTPServerCommon {
      * table=tableName&getSortedRowsByValue&limit=n
      * table=tableName&getSortedRowsByValue&offset=n
      */
+    @SuppressWarnings("null")
     private static void handleDBQuery(String uriPath, String[] uriQueryList, HttpExchange exchange, Boolean hasPassword) {
         JSONStringer jsonObject = new JSONStringer();
         String[] keyValue;
@@ -279,6 +280,10 @@ public class HTTPServerCommon {
             } else if (keyValue[0].equals("section")) {
                 if (keyValue.length > 1 && keyValue[1].length() > 0) {
                     dbSection = keyValue[1];
+                }
+                
+                if (dbSection.equalsIgnoreCase("null")) {
+                    dbSection = null;
                 }
             } else {
                 // All other commands need the table.


### PR DESCRIPTION
Removed some redundant catches in sanitizeOffset
Removed some redundant catches in sanitizeLimit
Suppress FinalizeDeclaration warning (this warning is just a "Hey, you used this, be careful")
Suppress some UseSpecificCatch that we are okay with
Use diamond inference

The main change in this patch is to fix a bug with methods such as GetKeysByOrderInternal that causes a query for a blank section name (the default section used in tables) to instead just return all rows, including those that have made use of the section column, as noted in PR #2135 

I also included some minor suggested standard code changes that were noted by NetBeans and eliminated a few redundant catches in 2 methods that will not cause an issue.