### PR TITLE
Ticketraffle multiplier fix

### DIFF
--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -178,7 +178,7 @@
         if (!$.inidb.exists('entered', user.toLowerCase())) {
             totalEntries++;
         }
-
+	price = times;
         if (tags.getTags().containsKey('subscriber') && tags.getTags().get('subscriber').equals('1')) {
             times *= subTMulti;
         } else if ($.isReg(user)) {
@@ -186,7 +186,7 @@
         }
 
         totalTickets += times;
-        $.inidb.decr('points', user, (times * cost));
+        $.inidb.decr('points', user, (price * cost));
         incr(user.toLowerCase(), times);
 
         for (var i = 0; i < times; i++) {


### PR DESCRIPTION
A very small fix for the ticketraffle.

### Problem:


When a ticketraffle with a x times multiplier for subs or regulars is activated, the sub/regular gets attributed the extra tickets but also get deducted the points for the extra tickets.

**Expected behaviour:**

normal user buys 1 ticket at 1 point and gets charged 1 point and gets 1 ticket
regular/sub buys 1 ticket with 2x multiplier and gets charged 1 point and gets 2 tickets.

**Current behaviour**

normal user buys 1 ticket at 1 point and gets charged 1 point and gets 1 ticket
regular/sub buys 1 ticket with 2x multiplier and gets charged 2 points and gets 2 tickets.

### Fix:

added a extra variable for the cost to calculate the real cost.

Test see screenshot. 

BeardBEBot is running the fix
BeardBEBottest is the latest normal nightly build

![phantombot](https://user-images.githubusercontent.com/228763/58312796-54dd3000-7e0c-11e9-906f-524701383210.png)
