### PR TITLE
Remove Debug Information from Discord API for Voice Channel

### DIFF
--- a/source/tv/phantombot/discord/DiscordAPI.java
+++ b/source/tv/phantombot/discord/DiscordAPI.java
@@ -297,13 +297,10 @@ public class DiscordAPI extends DiscordUtil {
 
         @EventSubscriber
         public void onDiscordUserVoiceChannelJoinEvent(UserVoiceChannelJoinEvent event) {
-System.out.println("Join " + event.getUser().getName() + " " + event.getVoiceChannel().getName());
-            EventBus.instance().postAsync(new DiscordUserVoiceChannelJoinEvent(event.getUser(), event.getVoiceChannel()));
         }
           
         @EventSubscriber
         public void onDiscordUserVoiceChannelLeaveEvent(UserVoiceChannelLeaveEvent event) {
-System.out.println("Part " + event.getUser().getName() + " " + event.getVoiceChannel().getName());
             EventBus.instance().postAsync(new DiscordUserVoiceChannelPartEvent(event.getUser(), event.getVoiceChannel()));
         }
     }


### PR DESCRIPTION
**DiscordAPI.java**
- Remove print statements that were used to debug output from the events.