### PR TITLE
convert (enter) to \r\n to allow better formatting of on-the-fly tweets using '!twitter post'

### DIFF
--- a/javascript-source/handlers/twitterHandler.js
+++ b/javascript-source/handlers/twitterHandler.js
@@ -435,7 +435,7 @@
                     $.say($.whisperPrefix(sender) + $.lang.get('twitter.post.usage'));
                     return;
                 }
-                var retval = $.twitter.updateStatus(args.splice(1).join(' ')) + '';
+                var retval = $.twitter.updateStatus(String(args.splice(1).join(' ')).replace(/\(enter\)/g, '\r\n')) + '';
                 if (retval.equals('true')) {
                     $.say($.whisperPrefix(sender) + $.lang.get('twitter.post.sent', args.splice(1).join(' ')));
                 } else {


### PR DESCRIPTION
'!twitter post' now converts (enter) to \r\n to allow better formatting of on-the-fly tweets

[from feature request](https://community.phantom.bot/t/enter-in-twitter-post-command-to-be-replaced-with-carriage-return/6998/5?u=lurk24)