### PR TITLE
Fixed commas cutting off text under alert images

### DIFF
--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -255,6 +255,9 @@ $(function() {
                         case 4:
                             gifText = value;
                             break;
+                        default:
+                            gifText = gifText + ',' + value;
+                            break;
                     }
                 });
             } else {


### PR DESCRIPTION
Easy fix for the bug described in [this](https://community.phantom.bot/t/gif-commands-echo-argument-bug/7029) forum post