### PR TITLE
Fixed infinite modal causing divs to block page

### DIFF
--- a/resources/web/panel/js/utils/helpers.js
+++ b/resources/web/panel/js/utils/helpers.js
@@ -385,6 +385,7 @@ $(function() {
     helpers.getModal = function(id, title, btn, body, onClose) {
         return $('<div/>', {
             'class': 'modal fade',
+            'tabindex': '99',
             'id': id
         }).append($('<div/>', {
             'class': 'modal-dialog'
@@ -415,7 +416,9 @@ $(function() {
             'type': 'button',
             'text': 'Cancel',
             'data-dismiss': 'modal'
-        }))))).on('hidden.bs.modal', function() {
+        }))))).on('shown.bs.modal', function() {
+            $('#' + id).focus();
+        }).on('hidden.bs.modal', function() {
             $('#' + id).remove();
         });
     };
@@ -433,6 +436,7 @@ $(function() {
     helpers.getAdvanceModal = function(id, title, btn, body, onClose) {
         return $('<div/>', {
             'class': 'modal fade',
+            'tabindex': '99',
             'id': id
         }).append($('<div/>', {
             'class': 'modal-dialog'
@@ -475,7 +479,9 @@ $(function() {
             'type': 'button',
             'text': 'Cancel',
             'data-dismiss': 'modal'
-        }))))).on('hidden.bs.modal', function() {
+        }))))).on('shown.bs.modal', function() {
+            $('#' + id).focus();
+        }).on('hidden.bs.modal', function() {
             $('#' + id).remove();
         }).on('show.bs.collapse', function() {
             $(this).find('.glyphicon').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');


### PR DESCRIPTION
Fixes the bug described in [this](https://community.phantom.bot/t/multiple-dialogue-boxes-can-be-opened-forcing-users-to-refresh-before-being-able-to-continue-using-the-panel/7055) forum post