### PR TITLE
Return correct MIME type for .js files

### DIFF
--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -742,6 +742,8 @@ public class HTTPServerCommon {
     private static String inferContentType(String path) {
         if (path.endsWith(".html") || path.endsWith(".htm")) {
             return "text/html";
+        } else if (path.endsWith(".js")) {
+            return "application/javascript";
         } else if (path.endsWith(".css")) {
             return "text/css";
         } else if (path.endsWith(".png")) {


### PR DESCRIPTION
Fixes the HTTPServer to send the correct MIME type for .js files
Fixes browser console warnings about wrong MIME type "text/text" for .js files