### PR TITLE
Added exponential backoff to reconnect code

### DIFF
--- a/source/tv/phantombot/twitch/irc/TwitchSession.java
+++ b/source/tv/phantombot/twitch/irc/TwitchSession.java
@@ -32,7 +32,7 @@ public class TwitchSession extends MessageQueue {
     private final ReentrantLock lock = new ReentrantLock();
     private final ReentrantLock lock2 = new ReentrantLock();
     private static final long MAX_BACKOFF = 300000L;
-    private long lastReconnect = 0L;
+    private long lastReconnect;
     private long nextBackoff = 1000L;
 
     /**


### PR DESCRIPTION
Changed doReconnect to use a ReentrantLock instead of a boolean

This is a followup to PR #2168 to implement exponential backoff in the reconnect logic as [recommended](https://dev.twitch.tv/docs/irc/guide/#re-connecting-to-twitch-irc) by Twitch. This will prevent massive console spam of reconnects when certain conditions (such as a loss of internet connectivity) are present.

The backoff value starts at 1 second after the first failed reconnect and then doubles each time thereafter, maxing out at 5 minutes. Once a connection has been maintained for 10 minutes (MAX_BACKOFF * 2), the backoff resets.