### PR TITLE
Fixed stacktrace output from script event handlers

### DIFF
--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -314,7 +314,7 @@
             try {
                 hook.handlers[i].handler(event);
             } catch (ex) {
-                $.log.error('Error with Event Handler [' + hookName + '] Script [' + hook.handlers[i].scriptName + '] Stacktrace [' + ex.stack.trim().split('\n').join(' > ').replace(/anonymous\(\)@|callHook\(\)@/g, '') + '] Exception [' + ex + ']');
+                $.log.error('Error with Event Handler [' + hookName + '] Script [' + hook.handlers[i].scriptName + '] Stacktrace [' + ex.stack.trim().replace(/\r/g, '').split('\n').join(' > ').replace(/anonymous\(\)@|callHook\(\)@/g, '') + '] Exception [' + ex + ']');
             }
         } else {
             for (i in hook.handlers) {
@@ -322,7 +322,7 @@
                     try {
                         hook.handlers[i].handler(event);
                     } catch (ex) {
-                        $.log.error('Error with Event Handler [' + hookName + '] Script [' + hook.handlers[i].scriptName + '] Stacktrace [' + ex.stack.trim().split('\n').join(' > ').replace(/anonymous\(\)@|callHook\(\)@/g, '') + '] Exception [' + ex + ']');
+                        $.log.error('Error with Event Handler [' + hookName + '] Script [' + hook.handlers[i].scriptName + '] Stacktrace [' + ex.stack.trim().replace(/\r/g, '').split('\n').join(' > ').replace(/anonymous\(\)@|callHook\(\)@/g, '') + '] Exception [' + ex + ']');
                     }
                 }
             }


### PR DESCRIPTION
Fixed rogue \r causing cut off output of error in console
Fixed rogue \r causing unnecessary line breaks in log

Before

```
[08-11-2019 @ 18:31:35.292 GMT] [init.js:317] Error with Event Handler [command] Script [./custom/test.js] Stacktrace [test.js:31
 > init.js:315
 > init.js:527] Exception [InternalError: Java class "[Ljava.lang.String;" has no public instance field or method named "replace". (test.js#31)]
```

![2019-08-11 (1)](https://user-images.githubusercontent.com/3355471/62838234-697cd780-bc47-11e9-9697-1e82addc8f7e.png)

 After

```
[08-11-2019 @ 18:45:09.099 GMT] [init.js:317] Error with Event Handler [command] Script [./custom/test.js] Stacktrace [test.js:31 > init.js:315 > init.js:527] Exception [InternalError: Java class "[Ljava.lang.String;" has no public instance field or method named "replace". (test.js#31)]
```

![2019-08-11](https://user-images.githubusercontent.com/3355471/62838236-76013000-bc47-11e9-95f4-573f71a084be.png)
