### PR TITLE
Change string appending methodology in DataStore.IncreaseBatchString

### DIFF
--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -903,19 +903,31 @@ public class MySQLStore extends DataStore {
             Statement statement = connection.createStatement();
             statement.addBatch("UPDATE phantombot_" + fName + " SET value = CAST(value AS INTEGER) + " + value + " WHERE section = '" + section + "' AND variable IN ('" + String.join("', '", keys) + "');");
 
-            String s = "INSERT IGNORE INTO phantombot_" + fName + " (section, variable, value) VALUES ";
+            StringBuilder sb = new StringBuilder(66 + fName.length() + (keys.length * (keys[0].length() + 17 + section.length() + value.length())));
+            
+            sb.append("INSERT IGNORE INTO phantombot_");
+            sb.append(fName);
+            sb.append(" (section, variable, value) VALUES ");
 
             boolean first = true;
             for (String k : keys) {
                 if (!first) {
-                    s += ",";
+                    sb.append(",");
                 }
 
                 first = false;
-                s += "('" + section + "', '" + k + "', " + value + ")";
+                sb.append("('");
+                sb.append(section);
+                sb.append("', '");
+                sb.append(k);
+                sb.append("', ");
+                sb.append(value);
+                sb.append(")");
             }
+            
+            sb.append(";");
 
-            statement.addBatch(s + ";");
+            statement.addBatch(sb.toString());
             statement.executeBatch();
         } catch (SQLException ex) {
             com.gmt2001.Console.err.printStackTrace(ex);

--- a/source/com/gmt2001/datastore/SqliteStore.java
+++ b/source/com/gmt2001/datastore/SqliteStore.java
@@ -1032,19 +1032,31 @@ public class SqliteStore extends DataStore {
             Statement statement = connection.createStatement();
             statement.addBatch("UPDATE phantombot_" + fName + " SET value = CAST(value AS INTEGER) + " + value + " WHERE section = '" + section + "' AND variable IN ('" + String.join("', '", keys) + "');");
 
-            String s = "INSERT OR IGNORE INTO phantombot_" + fName + " (section, variable, value) VALUES ";
+            StringBuilder sb = new StringBuilder(69 + fName.length() + (keys.length * (keys[0].length() + 17 + section.length() + value.length())));
+            
+            sb.append("INSERT OR IGNORE INTO phantombot_");
+            sb.append(fName);
+            sb.append(" (section, variable, value) VALUES ");
 
             boolean first = true;
             for (String k : keys) {
                 if (!first) {
-                    s += ",";
+                    sb.append(",");
                 }
 
                 first = false;
-                s += "('" + section + "', '" + k + "', " + value + ")";
+                sb.append("('");
+                sb.append(section);
+                sb.append("', '");
+                sb.append(k);
+                sb.append("', ");
+                sb.append(value);
+                sb.append(")");
             }
+            
+            sb.append(";");
 
-            statement.addBatch(s + ";");
+            statement.addBatch(sb.toString());
             statement.executeBatch();
         } catch (SQLException ex) {
             com.gmt2001.Console.err.printStackTrace(ex);


### PR DESCRIPTION
Change string appending methodology in DataStore.IncreaseBatchString for a massive performance increase

Improves performance of IncreaseBatchString in SqliteStore and MySQLStore massively. For 176,000 entries, the execution time drops from potentially 920,000ms down to 1,500ms.

The performance gains are achieved by switching from the + operator to a StringBuilder with a preset capacity (dynamically determined by the input data) that should be more than enough to hold the entire output string, thus eliminating a ton of unnecessary copy operations and object instantiations that would normally eat up CPU time like nobody's business.

Before
![2019-08-24 (3)](https://user-images.githubusercontent.com/3355471/63634182-ea14de00-c620-11e9-84fd-f60ddac00866.png)

After
![2019-08-24 (4)](https://user-images.githubusercontent.com/3355471/63634185-f00abf00-c620-11e9-93d8-dfa61ceb7901.png)

Tested in the dota2ti channel while TI2019 was live with over 300,000 viewers
