### PR TITLE
Allow users to disable builtin adventure stories in custom language files

### DIFF
--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -42,13 +42,15 @@
     };
 
     /**
+     * Loads stories from the prefixes 'adventuresystem.stories.default' (only if the language
+     * property of 'adventuresystem.stories.default.enabled' is set to 'true') and
+     * 'adventuresystem.stories'.
+     * 
+     * Clears any previously loaded stories.
+     * 
      * @function loadStories
      */
     function loadStories() {
-        var storyId = 1,
-            chapterId,
-            lines;
-
         currentAdventure.users = [];
         currentAdventure.survivors = [];
         currentAdventure.caught = [];
@@ -56,20 +58,14 @@
 
         stories = [];
 
-        for (storyId; $.lang.exists('adventuresystem.stories.' + storyId + '.title'); storyId++) {
-            lines = [];
-            for (chapterId = 1; $.lang.exists('adventuresystem.stories.' + storyId + '.chapter.' + chapterId); chapterId++) {
-                lines.push($.lang.get('adventuresystem.stories.' + storyId + '.chapter.' + chapterId));
-            }
-
-            stories.push({
-                game: ($.lang.exists('adventuresystem.stories.' + storyId + '.game') ? $.lang.get('adventuresystem.stories.' + storyId + '.game') : null),
-                title: $.lang.get('adventuresystem.stories.' + storyId + '.title'),
-                lines: lines,
-            });
+        // For backwards compatibility, load default stories if the variable is not set
+        if (!$.lang.exists('adventuresystem.stories.default') || $.lang.get('adventuresystem.stories.default') === 'true') {
+            loadStoriesFromPrefix('adventuresystem.stories');
         }
 
-        $.consoleDebug($.lang.get('adventuresystem.loaded', storyId - 1));
+        loadStoriesFromPrefix('adventuresystem.stories.custom');
+
+        $.consoleDebug($.lang.get('adventuresystem.loaded', stories.length));
 
         for (var i in stories) {
             if (stories[i].game === null) {
@@ -79,6 +75,37 @@
 
         $.log.warn('You must have at least one adventure that doesn\'t require a game to be set.');
         currentAdventure.gameState = 2;
+    };
+
+    /**
+     * Loads stories from a specific prefix in the language table and adds them to the
+     * global stories array.
+     * 
+     * @param {string} prefix - The prefix underneath which the stories can be found
+     * @example
+     * // Import stories with adventuresystem.stories.custom.X.title as title and
+     * // adventuresystem.stories.custom.X.chapter.Y as chapters
+     * loadStoriesFromPrefix('adventuresystem.stories.custom');
+     */
+    function loadStoriesFromPrefix(prefix) {
+        var storyId = 1,
+            chapterId,
+            lines;
+
+         for (storyId; $.lang.exists(prefix + '.' + storyId + '.title'); storyId++) {
+            lines = [];
+            for (chapterId = 1; $.lang.exists(prefix + '.' + storyId + '.chapter.' + chapterId); chapterId++) {
+                lines.push($.lang.get(prefix + '.' + storyId + '.chapter.' + chapterId));
+            }
+
+            stories.push({
+                game: ($.lang.exists(prefix + '.' + storyId + '.game') ? $.lang.get(prefix + '.' + storyId + '.game') : null),
+                title: $.lang.get(prefix + '.' + storyId + '.title'),
+                lines: lines,
+            });
+        }
+
+        $.consoleDebug($.lang.get('adventuresystem.loaded.prefix', storyId - 1, prefix));
     };
 
     /**

--- a/javascript-source/lang/english/games/games-adventureSystem.js
+++ b/javascript-source/lang/english/games/games-adventureSystem.js
@@ -26,6 +26,7 @@ $.lang.register('adventuresystem.join.needpoints', 'You can not join with $1, yo
 $.lang.register('adventuresystem.join.notpossible', 'You can not join now.');
 $.lang.register('adventuresystem.join.success', 'You have joined the adventure with $1!');
 $.lang.register('adventuresystem.loaded', 'Loaded adventure stories (found $1).');
+$.lang.register('adventuresystem.loaded.prefix', 'Loaded $1 adventure stories from $2.');
 $.lang.register('adventuresystem.payoutwhisper', 'Adventure completed, $1 + $2 has been added to your balance.');
 $.lang.register('adventuresystem.runstory', 'Starting adventure "$1" with $2 player(s).');
 $.lang.register('adventuresystem.set.success', 'Set $1 to $2.');
@@ -36,6 +37,7 @@ $.lang.register('adventuresystem.top5', 'The top 5 adventurers are: $1.');
 $.lang.register('adventuresystem.top5.empty', 'There haven\'t been any adventure winners recorded yet.');
 $.lang.register('adventuresystem.reset', 'The adventure has now cooled off! Use "!adventure [$1]" to start a new adventure!');
 
+$.lang.register('adventuresystem.stories.default', 'true');
 
 $.lang.register('adventuresystem.stories.1.title', 'Time Heist');
 $.lang.register('adventuresystem.stories.1.chapter.1', 'Your memory is vague, on the table a small laptop is playing a video: "My name is The Architect. The bank of Karabraxos is the most secure bank in the universe. You will rob the bank of Karabraxos!"');
@@ -60,10 +62,17 @@ $.lang.register('adventuresystem.stories.4.chapter.4', '(survivors) run away. Le
 
 
 /*
+ * Using the stories that come with PhantomBot:
+ *
+ * - All stories that are bundled with the bot are in the namespace adventuresystem.stories.*
+ * - If you do not want to use these stories, set the following in your custom language file:
+ *     $.lang.register('adventuresystem.stories.default', 'false');
+ *
  * Rules on writing your own adventure story:
  *
- * - Stories are automatically loaded from this file by their sequence number (adventuresystem.stories.[This number]).
- * - Keep the format of your story as shown above.
+ * - Stories are automatically loaded from the language file by their sequence number (adventuresystem.stories.custom.[This number]).
+ * - It is recommended to use a custom language file for your own stories.
+ * - Keep the format of your story as shown above, adding the '.custom' portion of the identifier.
  * - There can be an unlimited number of stories, IF you keep their subsequence numbers 1, 2, 3, 4, 5...
  * - A story must have a title.
  * - A story can have an unlimited number of chapters, IF you keep their subsequence numbers 1, 2, 3, 4, 5...
@@ -74,14 +83,14 @@ $.lang.register('adventuresystem.stories.4.chapter.4', '(survivors) run away. Le
  * - Add $.lang.register('adventuresystem.stories.NUMBER.game', 'GAME NAME IN LOWER CASE'); on top of the story chapter.
 
  * Example >
- * $.lang.register('adventuresystem.stories.5.game', 'programming');
- * $.lang.register('adventuresystem.stories.5.title', 'Talk Shows');
- * $.lang.register('adventuresystem.stories.5.chapter.1', 'random story...');
+ * $.lang.register('adventuresystem.stories.custom.1.game', 'programming');
+ * $.lang.register('adventuresystem.stories.custom.1.title', 'Talk Shows');
+ * $.lang.register('adventuresystem.stories.custom.1.chapter.1', 'random story...');
  *
  * Underneath is a template for your first custom story, just remove the preceding slashes.
  */
 
-//$.lang.register('adventuresystem.stories.5.title', '');
-//$.lang.register('adventuresystem.stories.5.chapter.1', '');
-//$.lang.register('adventuresystem.stories.5.chapter.2', '');
-//$.lang.register('adventuresystem.stories.5.chapter.3', '');
+//$.lang.register('adventuresystem.stories.custom.1.title', '');
+//$.lang.register('adventuresystem.stories.custom.1.chapter.1', '');
+//$.lang.register('adventuresystem.stories.custom.1.chapter.2', '');
+//$.lang.register('adventuresystem.stories.custom.1.chapter.3', '');


### PR DESCRIPTION
The adventure sytem uses the language system to manage stories. Added a way to load custom stories independently of the builtin ones. That way updates to the bot that add or remove stories don't break custom stories. Also allows users to disable the builtin stories if they want to only use their own.

**adventureSystem.js**
- Split loading between the two namesapces
- Disable loading from the default namespace if configured

**games-adventureSystem.js**
- Add additional language variables to disable builtin stories
- Update description for creating custom stories

The way this is implemented will not break existing (custom) language files. If the new variables aren't used, the behavior is the same as before.

Tested manually the following scenarios:
- No custom language file (loads builtin stories as usual)
- Custom language file which does not disable builtin stories (loads all of them)
- Custom language file which does disable builtin stories (loads only custom stories)
- Custom language file which has no custom stories and disables builtin ones (loads no stories, adventure system disabled)