### PR TITLE
Fixed pollSystem display in Panel

### DIFF
--- a/javascript-source/systems/pollSystem.js
+++ b/javascript-source/systems/pollSystem.js
@@ -111,7 +111,7 @@
         $.inidb.setAutoCommit(false);
         for (var i = 0; i < poll.options.length; i++) {
             optionsStr += (i + 1) + ") " + poll.options[i] + " ";
-            $.inidb.set('pollVotes', poll.options[i].replace(/\s/, '%space_option%'), 0);
+            $.inidb.set('pollVotes', poll.options[i], 0);
             objOBS.push({
                 'label': poll.options[i],
                 'votes': 0
@@ -135,7 +135,7 @@
         }));
 
         $.inidb.set('pollPanel', 'title', question);
-        $.inidb.set('pollPanel', 'options', options.join('%space_option%'));
+        $.inidb.set('pollPanel', 'options', options.join(','));
         $.inidb.set('pollPanel', 'isActive', 'true');
         return true;
     };
@@ -174,7 +174,7 @@
             'new_vote': 'true',
             'data': JSON.stringify(objOBS)
         }));
-        $.inidb.incr('pollVotes', poll.options[optionIndex].replace(/\s/, '%space_option%'), 1);
+        $.inidb.incr('pollVotes', poll.options[optionIndex], 1);
     };
 
     /**

--- a/resources/web/panel/js/pages/extra/polls.js
+++ b/resources/web/panel/js/pages/extra/polls.js
@@ -36,16 +36,12 @@ $(function() {
                     // Set the chart title.
                     chartConfig.options.title.text = e.title;
                     // Set the labels.
-                    chartConfig.data.labels = e.options.split('%space_option%');
+                    chartConfig.data.labels = e.options.split(',');
 
                     // Get all the data.
-                    let ops = e.options.split('%space_option%');
+                    let ops = e.options.split(',');
 
                     for (let i = 0; i < ops.length; i++) {
-                        if (ops[i].indexOf(' ') !== -1) {
-                            ops[i] = ops[i].split(' ').join('%space_option%');
-                        }
-
                         for (let j = 0; j < votes.length; j++) {
                             if (votes[j].key === ops[i]) {
                                 chartConfig.data.datasets[0].data.push(parseInt(votes[j].value));
@@ -87,16 +83,12 @@ $(function() {
             socket.getDBValue('get_poll_options_update', 'pollPanel', 'options', function(e) {
                 socket.getDBTableValues('get_poll_votes_update', 'pollVotes', function(votes) {
                     // Get all the data.
-                    let ops = e.pollPanel.split('%space_option%');
+                    let ops = e.pollPanel.split(',');
 
                     // Remove current data.
                     chartConfig.data.datasets[0].data = [];
 
                     for (let i = 0; i < ops.length; i++) {
-                        if (ops[i].indexOf(' ') !== -1) {
-                            ops[i] = ops[i].split(' ').join('%space_option%');
-                        }
-
                         for (let j = 0; j < votes.length; j++) {
                             if (votes[j].key === ops[i]) {
                                 chartConfig.data.datasets[0].data.push(parseInt(votes[j].value));


### PR DESCRIPTION
Removed useless, buggy string replace

pollSystem was doing a useless, buggy replacement of spaces in poll options with `%space_option%`, which was not properly handled on either side (Twitch, Panel) and caused the pie chart on the panel to appear incorrectly (Strikethrough on options, Votes appearing to be attributed to the wrong option)

This patch fixes it.

NOTE: The OBS Poll Chart was not affected because it followed a PubSub model over the WebSocket that was not using this string replace

Before
![2019-10-04 (3)](https://user-images.githubusercontent.com/3355471/66185989-13c51a00-e64f-11e9-82d6-c1468b8cb78e.png)

After
![2019-10-04 (2)](https://user-images.githubusercontent.com/3355471/66185993-16c00a80-e64f-11e9-9125-38b8271951a6.png)
