### PR TITLE
Updaed header copyright year to include 2019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #  
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 #  
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 
     <!--
 
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/audio.html
+++ b/development-resources/old/panel/audio.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/commands.html
+++ b/development-resources/old/panel/commands.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/cooldown.html
+++ b/development-resources/old/panel/cooldown.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/dashboard.html
+++ b/development-resources/old/panel/dashboard.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/discord.html
+++ b/development-resources/old/panel/discord.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/donations.html
+++ b/development-resources/old/panel/donations.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/gambling.html
+++ b/development-resources/old/panel/gambling.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/games.html
+++ b/development-resources/old/panel/games.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/greetings.html
+++ b/development-resources/old/panel/greetings.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/help.html
+++ b/development-resources/old/panel/help.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/hostraid.html
+++ b/development-resources/old/panel/hostraid.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/index.html
+++ b/development-resources/old/panel/index.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/audioPanel.js
+++ b/development-resources/old/panel/js/audioPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/commandsPanel.js
+++ b/development-resources/old/panel/js/commandsPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/cooldownPanel.js
+++ b/development-resources/old/panel/js/cooldownPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/dashboardPanel.js
+++ b/development-resources/old/panel/js/dashboardPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/disablePanel.js
+++ b/development-resources/old/panel/js/disablePanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/discordPanel.js
+++ b/development-resources/old/panel/js/discordPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/donationsPanel.js
+++ b/development-resources/old/panel/js/donationsPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/gamblingPanel.js
+++ b/development-resources/old/panel/js/gamblingPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/gamesPanel.js
+++ b/development-resources/old/panel/js/gamesPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/globalPanel.js
+++ b/development-resources/old/panel/js/globalPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/greetingsPanel.js
+++ b/development-resources/old/panel/js/greetingsPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/helpPanel.js
+++ b/development-resources/old/panel/js/helpPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/hostraidPanel.js
+++ b/development-resources/old/panel/js/hostraidPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/keywordsPanel.js
+++ b/development-resources/old/panel/js/keywordsPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/loggingPanel.js
+++ b/development-resources/old/panel/js/loggingPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/moderationPanel.js
+++ b/development-resources/old/panel/js/moderationPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/noticesPanel.js
+++ b/development-resources/old/panel/js/noticesPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/panelUtils.js
+++ b/development-resources/old/panel/js/panelUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/pointsPanel.js
+++ b/development-resources/old/panel/js/pointsPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/pollPanel.js
+++ b/development-resources/old/panel/js/pollPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/queuePanel.js
+++ b/development-resources/old/panel/js/queuePanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/quotesPanel.js
+++ b/development-resources/old/panel/js/quotesPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/ranksPanel.js
+++ b/development-resources/old/panel/js/ranksPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/timePanel.js
+++ b/development-resources/old/panel/js/timePanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/js/twitterPanel.js
+++ b/development-resources/old/panel/js/twitterPanel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/keywords.html
+++ b/development-resources/old/panel/keywords.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/logging.html
+++ b/development-resources/old/panel/logging.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/moderation.html
+++ b/development-resources/old/panel/moderation.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/notices.html
+++ b/development-resources/old/panel/notices.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/points.html
+++ b/development-resources/old/panel/points.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/poll.html
+++ b/development-resources/old/panel/poll.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/queue.html
+++ b/development-resources/old/panel/queue.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/quotes.html
+++ b/development-resources/old/panel/quotes.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/ranks.html
+++ b/development-resources/old/panel/ranks.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/time.html
+++ b/development-resources/old/panel/time.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/twitter.html
+++ b/development-resources/old/panel/twitter.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/old/panel/viewers.html
+++ b/development-resources/old/panel/viewers.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/development-resources/parse_commandpath.pl
+++ b/development-resources/parse_commandpath.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # 
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/development-resources/parse_commandpath_to_json.pl
+++ b/development-resources/parse_commandpath_to_json.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # 
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/development-resources/parse_discordcommandpath.pl
+++ b/development-resources/parse_discordcommandpath.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # 
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 #  
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 #  
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/deathctrCommand.js
+++ b/javascript-source/commands/deathctrCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/dualstreamCommand.js
+++ b/javascript-source/commands/dualstreamCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/highlightCommand.js
+++ b/javascript-source/commands/highlightCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/lastseenCommand.js
+++ b/javascript-source/commands/lastseenCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/nameConverter.js
+++ b/javascript-source/commands/nameConverter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/streamCommand.js
+++ b/javascript-source/commands/streamCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/commands/topCommand.js
+++ b/javascript-source/commands/topCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/commandPause.js
+++ b/javascript-source/core/commandPause.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/fileSystem.js
+++ b/javascript-source/core/fileSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/gameMessages.js
+++ b/javascript-source/core/gameMessages.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/initCommands.js
+++ b/javascript-source/core/initCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/jsTimers.js
+++ b/javascript-source/core/jsTimers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/keywordCoolDown.js
+++ b/javascript-source/core/keywordCoolDown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/lang.js
+++ b/javascript-source/core/lang.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/logging.js
+++ b/javascript-source/core/logging.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/panelCommands.js
+++ b/javascript-source/core/panelCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/panelHandler.js
+++ b/javascript-source/core/panelHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/streamInfo.js
+++ b/javascript-source/core/streamInfo.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/timeSystem.js
+++ b/javascript-source/core/timeSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/core/whisper.js
+++ b/javascript-source/core/whisper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/commands/customCommands.js
+++ b/javascript-source/discord/commands/customCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/accountLink.js
+++ b/javascript-source/discord/core/accountLink.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/commandCooldown.js
+++ b/javascript-source/discord/core/commandCooldown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/misc.js
+++ b/javascript-source/discord/core/misc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/moderation.js
+++ b/javascript-source/discord/core/moderation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/patternDetector.js
+++ b/javascript-source/discord/core/patternDetector.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/registerCommand.js
+++ b/javascript-source/discord/core/registerCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/core/roleManager.js
+++ b/javascript-source/discord/core/roleManager.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/8ball.js
+++ b/javascript-source/discord/games/8ball.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/gambling.js
+++ b/javascript-source/discord/games/gambling.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/kill.js
+++ b/javascript-source/discord/games/kill.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/random.js
+++ b/javascript-source/discord/games/random.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/roll.js
+++ b/javascript-source/discord/games/roll.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/roulette.js
+++ b/javascript-source/discord/games/roulette.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/games/slotMachine.js
+++ b/javascript-source/discord/games/slotMachine.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/bitsHandler.js
+++ b/javascript-source/discord/handlers/bitsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/clipHandler.js
+++ b/javascript-source/discord/handlers/clipHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/followHandler.js
+++ b/javascript-source/discord/handlers/followHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/hostHandler.js
+++ b/javascript-source/discord/handlers/hostHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/keywordHandler.js
+++ b/javascript-source/discord/handlers/keywordHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/streamElementsHandler.js
+++ b/javascript-source/discord/handlers/streamElementsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/streamHandler.js
+++ b/javascript-source/discord/handlers/streamHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/streamlabsHandler.js
+++ b/javascript-source/discord/handlers/streamlabsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/subscribeHandler.js
+++ b/javascript-source/discord/handlers/subscribeHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/tipeeeStreamHandler.js
+++ b/javascript-source/discord/handlers/tipeeeStreamHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/handlers/twitterHandler.js
+++ b/javascript-source/discord/handlers/twitterHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/systems/greetingsSystem.js
+++ b/javascript-source/discord/systems/greetingsSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/discord/systems/pointSystem.js
+++ b/javascript-source/discord/systems/pointSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/8ball.js
+++ b/javascript-source/games/8ball.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/gambling.js
+++ b/javascript-source/games/gambling.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/killCommand.js
+++ b/javascript-source/games/killCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/random.js
+++ b/javascript-source/games/random.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/roll.js
+++ b/javascript-source/games/roll.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/roulette.js
+++ b/javascript-source/games/roulette.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/games/slotMachine.js
+++ b/javascript-source/games/slotMachine.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/bitsHandler.js
+++ b/javascript-source/handlers/bitsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/clipHandler.js
+++ b/javascript-source/handlers/clipHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/dataServiceHandler.js
+++ b/javascript-source/handlers/dataServiceHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/donationHandler.js
+++ b/javascript-source/handlers/donationHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/emotesHandler.js
+++ b/javascript-source/handlers/emotesHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/followHandler.js
+++ b/javascript-source/handlers/followHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/gameScanHandler.js
+++ b/javascript-source/handlers/gameScanHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/hostHandler.js
+++ b/javascript-source/handlers/hostHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/keywordHandler.js
+++ b/javascript-source/handlers/keywordHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/raidHandler.js
+++ b/javascript-source/handlers/raidHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/streamElementsHandler.js
+++ b/javascript-source/handlers/streamElementsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/subscribeHandler.js
+++ b/javascript-source/handlers/subscribeHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/tipeeeStreamHandler.js
+++ b/javascript-source/handlers/tipeeeStreamHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/twitterHandler.js
+++ b/javascript-source/handlers/twitterHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/handlers/wordCounter.js
+++ b/javascript-source/handlers/wordCounter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-customCommands.js
+++ b/javascript-source/lang/english/commands/commands-customCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-deathctrCommand.js
+++ b/javascript-source/lang/english/commands/commands-deathctrCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-dualstreamCommand.js
+++ b/javascript-source/lang/english/commands/commands-dualstreamCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-highlightCommand.js
+++ b/javascript-source/lang/english/commands/commands-highlightCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-killCommand.js
+++ b/javascript-source/lang/english/commands/commands-killCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-lastseenCommand.js
+++ b/javascript-source/lang/english/commands/commands-lastseenCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-nameconverterCommand.js
+++ b/javascript-source/lang/english/commands/commands-nameconverterCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-streamCommands.js
+++ b/javascript-source/lang/english/commands/commands-streamCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/commands/commands-top10Command.js
+++ b/javascript-source/lang/english/commands/commands-top10Command.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/commands/commands-customCommand.js
+++ b/javascript-source/lang/english/discord/commands/commands-customCommand.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/core/core-accountLink.js
+++ b/javascript-source/lang/english/discord/core/core-accountLink.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/core/core-commandCooldown.js
+++ b/javascript-source/lang/english/discord/core/core-commandCooldown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/core/core-misc.js
+++ b/javascript-source/lang/english/discord/core/core-misc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/core/core-moderation.js
+++ b/javascript-source/lang/english/discord/core/core-moderation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/core/core-roleManager.js
+++ b/javascript-source/lang/english/discord/core/core-roleManager.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/games/games-gambling.js
+++ b/javascript-source/lang/english/discord/games/games-gambling.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/games/games-roll.js
+++ b/javascript-source/lang/english/discord/games/games-roll.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/games/games-slotMachine.js
+++ b/javascript-source/lang/english/discord/games/games-slotMachine.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-bitsHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-bitsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-clipsHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-clipsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-followHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-followHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-hostHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-hostHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-keywordHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-keywordHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-streamElementsHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-streamElementsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-streamHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-streamHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-streamlabsHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-streamlabsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-subscribeHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-subscribeHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-tipeeeStreamHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-tipeeeStreamHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/handlers/handlers-twitterHandler.js
+++ b/javascript-source/lang/english/discord/handlers/handlers-twitterHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/systems/systems-customCommandLogs.js
+++ b/javascript-source/lang/english/discord/systems/systems-customCommandLogs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/systems/systems-greetingsSystem.js
+++ b/javascript-source/lang/english/discord/systems/systems-greetingsSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/discord/systems/systems-pointSystem.js
+++ b/javascript-source/lang/english/discord/systems/systems-pointSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-8ball.js
+++ b/javascript-source/lang/english/games/games-8ball.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-adventureSystem.js
+++ b/javascript-source/lang/english/games/games-adventureSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-gambling.js
+++ b/javascript-source/lang/english/games/games-gambling.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-random.js
+++ b/javascript-source/lang/english/games/games-random.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-roll.js
+++ b/javascript-source/lang/english/games/games-roll.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-roulette.js
+++ b/javascript-source/lang/english/games/games-roulette.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/games/games-slotMachine.js
+++ b/javascript-source/lang/english/games/games-slotMachine.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-bitsHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-bitsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-clipHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-clipHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-dataServiceHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-dataServiceHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-donationHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-donationHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-followHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-followHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-gameScanHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-gameScanHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-hostHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-hostHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-keywordHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-keywordHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-raidHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-raidHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-streamElementsHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-streamElementsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-subscribeHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-subscribeHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-tipeeeStreamHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-tipeeeStreamHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-twitterHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-twitterHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/handlers/handlers-wordCounter.js
+++ b/javascript-source/lang/english/handlers/handlers-wordCounter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/main.js
+++ b/javascript-source/lang/english/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/system-bettingSystem.js
+++ b/javascript-source/lang/english/systems/system-bettingSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-auctionSystem.js
+++ b/javascript-source/lang/english/systems/systems-auctionSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-audioPanelSystem.js
+++ b/javascript-source/lang/english/systems/systems-audioPanelSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-cleanupSystem.js
+++ b/javascript-source/lang/english/systems/systems-cleanupSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-greetingSystem.js
+++ b/javascript-source/lang/english/systems/systems-greetingSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-noticeSystem.js
+++ b/javascript-source/lang/english/systems/systems-noticeSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-pointSystem.js
+++ b/javascript-source/lang/english/systems/systems-pointSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-pollSystem.js
+++ b/javascript-source/lang/english/systems/systems-pollSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-queueSystem.js
+++ b/javascript-source/lang/english/systems/systems-queueSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-quoteSystem.js
+++ b/javascript-source/lang/english/systems/systems-quoteSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-raffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-raffleSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-ranksSystem.js
+++ b/javascript-source/lang/english/systems/systems-ranksSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/systems/systems-youtubeplayer.js
+++ b/javascript-source/lang/english/systems/systems-youtubeplayer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/lang/english/util-gameMessages.js
+++ b/javascript-source/lang/english/util-gameMessages.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/auctionSystem.js
+++ b/javascript-source/systems/auctionSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/audioPanelSystem.js
+++ b/javascript-source/systems/audioPanelSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/cleanupSystem.js
+++ b/javascript-source/systems/cleanupSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/greetingSystem.js
+++ b/javascript-source/systems/greetingSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/pollSystem.js
+++ b/javascript-source/systems/pollSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/queueSystem.js
+++ b/javascript-source/systems/queueSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/ranksSystem.js
+++ b/javascript-source/systems/ranksSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/launch-service.sh
+++ b/resources/launch-service.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/resources/launch.bat
+++ b/resources/launch.bat
@@ -1,7 +1,7 @@
 @echo off
 
 REM  
-REM Copyright (C) 2016-2018 phantombot.tv
+REM Copyright (C) 2016-2019 phantombot.tv
 REM  
 REM This program is free software: you can redistribute it and/or modify
 REM it under the terms of the GNU General Public License as published by

--- a/resources/launch.sh
+++ b/resources/launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2016-2018 phantombot.tv
+# Copyright (C) 2016-2019 phantombot.tv
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/resources/web/alerts/index.html
+++ b/resources/web/alerts/index.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (C) 2016-2018 phantombot.tv
+ Copyright (C) 2016-2019 phantombot.tv
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/index.html
+++ b/resources/web/index.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/resources/web/panel/index.html
+++ b/resources/web/panel/index.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/index.js
+++ b/resources/web/panel/js/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/alerts/alerts.js
+++ b/resources/web/panel/js/pages/alerts/alerts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/audio/audioHooks.js
+++ b/resources/web/panel/js/pages/audio/audioHooks.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/commands/aliases.js
+++ b/resources/web/panel/js/pages/commands/aliases.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/dashboard/dashboard.js
+++ b/resources/web/panel/js/pages/dashboard/dashboard.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/discord/discordAlerts.js
+++ b/resources/web/panel/js/pages/discord/discordAlerts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/discord/discordCustomCommands.js
+++ b/resources/web/panel/js/pages/discord/discordCustomCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/discord/discordDefaultCommands.js
+++ b/resources/web/panel/js/pages/discord/discordDefaultCommands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/discord/discordGames.js
+++ b/resources/web/panel/js/pages/discord/discordGames.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/discord/discordKeywords.js
+++ b/resources/web/panel/js/pages/discord/discordKeywords.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/discord/discordLogs.js
+++ b/resources/web/panel/js/pages/discord/discordLogs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/extra/betting.js
+++ b/resources/web/panel/js/pages/extra/betting.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/extra/deathcounter.js
+++ b/resources/web/panel/js/pages/extra/deathcounter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/extra/dualstream.js
+++ b/resources/web/panel/js/pages/extra/dualstream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/extra/highlights.js
+++ b/resources/web/panel/js/pages/extra/highlights.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/extra/polls.js
+++ b/resources/web/panel/js/pages/extra/polls.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/extra/queue.js
+++ b/resources/web/panel/js/pages/extra/queue.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/games/games.js
+++ b/resources/web/panel/js/pages/games/games.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/giveaways/auction.js
+++ b/resources/web/panel/js/pages/giveaways/auction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/giveaways/raffle.js
+++ b/resources/web/panel/js/pages/giveaways/raffle.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/global.js
+++ b/resources/web/panel/js/pages/global.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/help/help.js
+++ b/resources/web/panel/js/pages/help/help.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/history/hostHistory.js
+++ b/resources/web/panel/js/pages/history/hostHistory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/history/raidHistory.js
+++ b/resources/web/panel/js/pages/history/raidHistory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/history/tipsHistory.js
+++ b/resources/web/panel/js/pages/history/tipsHistory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/keywords/keywords.js
+++ b/resources/web/panel/js/pages/keywords/keywords.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/loyalty/currency.js
+++ b/resources/web/panel/js/pages/loyalty/currency.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/loyalty/leaderboard.js
+++ b/resources/web/panel/js/pages/loyalty/leaderboard.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/loyalty/loyalty.js
+++ b/resources/web/panel/js/pages/loyalty/loyalty.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/moderation/blacklist.js
+++ b/resources/web/panel/js/pages/moderation/blacklist.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/moderation/filters.js
+++ b/resources/web/panel/js/pages/moderation/filters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/moderation/whitelist.js
+++ b/resources/web/panel/js/pages/moderation/whitelist.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/permissions/permissions.js
+++ b/resources/web/panel/js/pages/permissions/permissions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/quotes/quotes.js
+++ b/resources/web/panel/js/pages/quotes/quotes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/ranking/customRanks.js
+++ b/resources/web/panel/js/pages/ranking/customRanks.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/ranking/globalRanks.js
+++ b/resources/web/panel/js/pages/ranking/globalRanks.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/settings/botSettings.js
+++ b/resources/web/panel/js/pages/settings/botSettings.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/settings/commandSettings.js
+++ b/resources/web/panel/js/pages/settings/commandSettings.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/settings/localization.js
+++ b/resources/web/panel/js/pages/settings/localization.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/settings/moduleList.js
+++ b/resources/web/panel/js/pages/settings/moduleList.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/pages/timers/timers.js
+++ b/resources/web/panel/js/pages/timers/timers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/utils/ajaxLoader.js
+++ b/resources/web/panel/js/utils/ajaxLoader.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/js/utils/helpers.js
+++ b/resources/web/panel/js/utils/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/alerts/alerts.html
+++ b/resources/web/panel/pages/alerts/alerts.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/alerts/stream.html
+++ b/resources/web/panel/pages/alerts/stream.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/audio/audioHooks.html
+++ b/resources/web/panel/pages/audio/audioHooks.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/commands/aliases.html
+++ b/resources/web/panel/pages/commands/aliases.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/commands/custom.html
+++ b/resources/web/panel/pages/commands/custom.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/commands/default.html
+++ b/resources/web/panel/pages/commands/default.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/dashboard/dashboard.html
+++ b/resources/web/panel/pages/dashboard/dashboard.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/discord/discordAlerts.html
+++ b/resources/web/panel/pages/discord/discordAlerts.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/discord/discordCustomCommands.html
+++ b/resources/web/panel/pages/discord/discordCustomCommands.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/discord/discordDefaultCommands.html
+++ b/resources/web/panel/pages/discord/discordDefaultCommands.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/discord/discordGames.html
+++ b/resources/web/panel/pages/discord/discordGames.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/discord/discordKeywords.html
+++ b/resources/web/panel/pages/discord/discordKeywords.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/discord/discordLogs.html
+++ b/resources/web/panel/pages/discord/discordLogs.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/extra/betting.html
+++ b/resources/web/panel/pages/extra/betting.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/extra/deathcounter.html
+++ b/resources/web/panel/pages/extra/deathcounter.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/extra/dualstream.html
+++ b/resources/web/panel/pages/extra/dualstream.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/extra/highlights.html
+++ b/resources/web/panel/pages/extra/highlights.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/extra/polls.html
+++ b/resources/web/panel/pages/extra/polls.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/extra/queue.html
+++ b/resources/web/panel/pages/extra/queue.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/games/games.html
+++ b/resources/web/panel/pages/games/games.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/giveaways/auction.html
+++ b/resources/web/panel/pages/giveaways/auction.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/giveaways/raffle.html
+++ b/resources/web/panel/pages/giveaways/raffle.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/giveaways/ticketRaffle.html
+++ b/resources/web/panel/pages/giveaways/ticketRaffle.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/help/help.html
+++ b/resources/web/panel/pages/help/help.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/history/hostHistory.html
+++ b/resources/web/panel/pages/history/hostHistory.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/history/raidHistory.html
+++ b/resources/web/panel/pages/history/raidHistory.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/history/tipsHistory.html
+++ b/resources/web/panel/pages/history/tipsHistory.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/keywords/keywords.html
+++ b/resources/web/panel/pages/keywords/keywords.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/loyalty/currency.html
+++ b/resources/web/panel/pages/loyalty/currency.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/loyalty/leaderboard.html
+++ b/resources/web/panel/pages/loyalty/leaderboard.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/loyalty/loyalty.html
+++ b/resources/web/panel/pages/loyalty/loyalty.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/moderation/blacklist.html
+++ b/resources/web/panel/pages/moderation/blacklist.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/moderation/filters.html
+++ b/resources/web/panel/pages/moderation/filters.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/moderation/whitelist.html
+++ b/resources/web/panel/pages/moderation/whitelist.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/permissions/permissions.html
+++ b/resources/web/panel/pages/permissions/permissions.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/quotes/quotes.html
+++ b/resources/web/panel/pages/quotes/quotes.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/ranking/customRanks.html
+++ b/resources/web/panel/pages/ranking/customRanks.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/ranking/globalRanks.html
+++ b/resources/web/panel/pages/ranking/globalRanks.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/settings/botSettings.html
+++ b/resources/web/panel/pages/settings/botSettings.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/settings/commandSettings.html
+++ b/resources/web/panel/pages/settings/commandSettings.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/settings/localization.html
+++ b/resources/web/panel/pages/settings/localization.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/settings/moduleList.html
+++ b/resources/web/panel/pages/settings/moduleList.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/panel/pages/timers/timers.html
+++ b/resources/web/panel/pages/timers/timers.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2016-2018 phantombot.tv
+    Copyright (C) 2016-2019 phantombot.tv
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/resources/web/playlist/css/style.css
+++ b/resources/web/playlist/css/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/playlist/index.html
+++ b/resources/web/playlist/index.html
@@ -1,6 +1,6 @@
 <!--
 
-Copyright (C) 2016-2018 phantombot.tv
+Copyright (C) 2016-2019 phantombot.tv
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/resources/web/playlist/js/ytPlaylist.js
+++ b/resources/web/playlist/js/ytPlaylist.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/style.css
+++ b/resources/web/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/ytplayer/css/style.css
+++ b/resources/web/ytplayer/css/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/ytplayer/index.html
+++ b/resources/web/ytplayer/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2016-2018 phantombot.tv
+  Copyright (C) 2016-2019 phantombot.tv
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/resources/web/ytplayer/js/index.js
+++ b/resources/web/ytplayer/js/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/resources/web/ytplayer/js/util/socket.js
+++ b/resources/web/ytplayer/js/util/socket.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Console/debug.java
+++ b/source/com/gmt2001/Console/debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Console/err.java
+++ b/source/com/gmt2001/Console/err.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Console/in.java
+++ b/source/com/gmt2001/Console/in.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Console/logTimestamp.java
+++ b/source/com/gmt2001/Console/logTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Console/out.java
+++ b/source/com/gmt2001/Console/out.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Console/warn.java
+++ b/source/com/gmt2001/Console/warn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/HttpRequest.java
+++ b/source/com/gmt2001/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/HttpResponse.java
+++ b/source/com/gmt2001/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/Logger.java
+++ b/source/com/gmt2001/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/TwitchAPIv5.java
+++ b/source/com/gmt2001/TwitchAPIv5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/UncaughtExceptionHandler.java
+++ b/source/com/gmt2001/UncaughtExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/YouTubeAPIv3.java
+++ b/source/com/gmt2001/YouTubeAPIv3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/datastore/DataStore.java
+++ b/source/com/gmt2001/datastore/DataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/datastore/DataStoreConverter.java
+++ b/source/com/gmt2001/datastore/DataStoreConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/datastore/H2Store.java
+++ b/source/com/gmt2001/datastore/H2Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/datastore/IniStore.java
+++ b/source/com/gmt2001/datastore/IniStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/gmt2001/datastore/SqliteStore.java
+++ b/source/com/gmt2001/datastore/SqliteStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/BTTVAPIv2.java
+++ b/source/com/illusionaryone/BTTVAPIv2.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/BitlyAPIv4.java
+++ b/source/com/illusionaryone/BitlyAPIv4.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/DataRenderServiceAPIv1.java
+++ b/source/com/illusionaryone/DataRenderServiceAPIv1.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/FrankerZAPIv1.java
+++ b/source/com/illusionaryone/FrankerZAPIv1.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/GameWispAPIv1.java
+++ b/source/com/illusionaryone/GameWispAPIv1.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/GitHubAPIv3.java
+++ b/source/com/illusionaryone/GitHubAPIv3.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/GoogleURLShortenerAPIv1.java
+++ b/source/com/illusionaryone/GoogleURLShortenerAPIv1.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/ImgDownload.java
+++ b/source/com/illusionaryone/ImgDownload.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/NoticeTimer.java
+++ b/source/com/illusionaryone/NoticeTimer.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/SimpleScramble.java
+++ b/source/com/illusionaryone/SimpleScramble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/SocketIOExample.java
+++ b/source/com/illusionaryone/SocketIOExample.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/TwitchAlertsAPIv1.java
+++ b/source/com/illusionaryone/TwitchAlertsAPIv1.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/illusionaryone/TwitterAPI.java
+++ b/source/com/illusionaryone/TwitterAPI.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/scaniatv/BotImporter.java
+++ b/source/com/scaniatv/BotImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/scaniatv/CustomAPI.java
+++ b/source/com/scaniatv/CustomAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/scaniatv/GenerateLogs.java
+++ b/source/com/scaniatv/GenerateLogs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/scaniatv/LangFileUpdater.java
+++ b/source/com/scaniatv/LangFileUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/scaniatv/StreamElementsAPIv2.java
+++ b/source/com/scaniatv/StreamElementsAPIv2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/com/scaniatv/TipeeeStreamAPIv1.java
+++ b/source/com/scaniatv/TipeeeStreamAPIv1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/RepoVersion.java
+++ b/source/tv/phantombot/RepoVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/DonationsCache.java
+++ b/source/tv/phantombot/cache/DonationsCache.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 --mode=java */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/EmotesCache.java
+++ b/source/tv/phantombot/cache/EmotesCache.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 --mode=java */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/FollowersCache.java
+++ b/source/tv/phantombot/cache/FollowersCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/SteamCache.java
+++ b/source/tv/phantombot/cache/SteamCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/StreamElementsCache.java
+++ b/source/tv/phantombot/cache/StreamElementsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/TipeeeStreamCache.java
+++ b/source/tv/phantombot/cache/TipeeeStreamCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/TwitchCache.java
+++ b/source/tv/phantombot/cache/TwitchCache.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 --mode=java */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/TwitchTeamsCache.java
+++ b/source/tv/phantombot/cache/TwitchTeamsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/TwitterCache.java
+++ b/source/tv/phantombot/cache/TwitterCache.java
@@ -1,7 +1,7 @@
 /* astyle --style=java --indent=spaces=4 --mode=java */
 
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/UsernameCache.java
+++ b/source/tv/phantombot/cache/UsernameCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/cache/ViewerListCache.java
+++ b/source/tv/phantombot/cache/ViewerListCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/console/ConsoleEventHandler.java
+++ b/source/tv/phantombot/console/ConsoleEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/console/ConsoleInputListener.java
+++ b/source/tv/phantombot/console/ConsoleInputListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/discord/DiscordAPI.java
+++ b/source/tv/phantombot/discord/DiscordAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/discord/util/DiscordUtil.java
+++ b/source/tv/phantombot/discord/util/DiscordUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/Event.java
+++ b/source/tv/phantombot/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/EventBus.java
+++ b/source/tv/phantombot/event/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ExceptionHandler.java
+++ b/source/tv/phantombot/event/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/Listener.java
+++ b/source/tv/phantombot/event/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/command/CommandEvent.java
+++ b/source/tv/phantombot/event/command/CommandEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/console/ConsoleEvent.java
+++ b/source/tv/phantombot/event/console/ConsoleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/console/ConsoleInputEvent.java
+++ b/source/tv/phantombot/event/console/ConsoleInputEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/DiscordEvent.java
+++ b/source/tv/phantombot/event/discord/DiscordEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelCommandEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelCommandEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelJoinEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelJoinEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelMessageEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/channel/DiscordChannelPartEvent.java
+++ b/source/tv/phantombot/event/discord/channel/DiscordChannelPartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/reaction/DiscordMessageReactionEvent.java
+++ b/source/tv/phantombot/event/discord/reaction/DiscordMessageReactionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/reaction/DiscordReactionEvent.java
+++ b/source/tv/phantombot/event/discord/reaction/DiscordReactionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/ready/DiscordReadyEvent.java
+++ b/source/tv/phantombot/event/discord/ready/DiscordReadyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/role/DiscordRoleCreatedEvent.java
+++ b/source/tv/phantombot/event/discord/role/DiscordRoleCreatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/role/DiscordRoleDeletedEvent.java
+++ b/source/tv/phantombot/event/discord/role/DiscordRoleDeletedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/role/DiscordRoleEvent.java
+++ b/source/tv/phantombot/event/discord/role/DiscordRoleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/role/DiscordRoleUpdatedEvent.java
+++ b/source/tv/phantombot/event/discord/role/DiscordRoleUpdatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/uservoicechannel/DiscordUserVoiceChannelEvent.java
+++ b/source/tv/phantombot/event/discord/uservoicechannel/DiscordUserVoiceChannelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/uservoicechannel/DiscordUserVoiceChannelJoinEvent.java
+++ b/source/tv/phantombot/event/discord/uservoicechannel/DiscordUserVoiceChannelJoinEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/discord/uservoicechannel/DiscordUserVoiceChannelPartEvent.java
+++ b/source/tv/phantombot/event/discord/uservoicechannel/DiscordUserVoiceChannelPartEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/emotes/EmotesEvent.java
+++ b/source/tv/phantombot/event/emotes/EmotesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/emotes/EmotesGetEvent.java
+++ b/source/tv/phantombot/event/emotes/EmotesGetEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/IrcEvent.java
+++ b/source/tv/phantombot/event/irc/IrcEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/channel/IrcChannelEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/channel/IrcChannelJoinEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelJoinEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/channel/IrcChannelLeaveEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelLeaveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUserModeEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUserModeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/clearchat/IrcClearchatEvent.java
+++ b/source/tv/phantombot/event/irc/clearchat/IrcClearchatEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/complete/IrcCompleteEvent.java
+++ b/source/tv/phantombot/event/irc/complete/IrcCompleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/complete/IrcConnectCompleteEvent.java
+++ b/source/tv/phantombot/event/irc/complete/IrcConnectCompleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/complete/IrcJoinCompleteEvent.java
+++ b/source/tv/phantombot/event/irc/complete/IrcJoinCompleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/message/IrcChannelMessageEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcChannelMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/message/IrcMessageEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/message/IrcModerationEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcModerationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/irc/message/IrcPrivateMessageEvent.java
+++ b/source/tv/phantombot/event/irc/message/IrcPrivateMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/PubSubEvent.java
+++ b/source/tv/phantombot/event/pubsub/PubSubEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/moderation/PubSubModerationBanEvent.java
+++ b/source/tv/phantombot/event/pubsub/moderation/PubSubModerationBanEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/moderation/PubSubModerationDeleteEvent.java
+++ b/source/tv/phantombot/event/pubsub/moderation/PubSubModerationDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/moderation/PubSubModerationEvent.java
+++ b/source/tv/phantombot/event/pubsub/moderation/PubSubModerationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/moderation/PubSubModerationTimeoutEvent.java
+++ b/source/tv/phantombot/event/pubsub/moderation/PubSubModerationTimeoutEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/moderation/PubSubModerationUnBanEvent.java
+++ b/source/tv/phantombot/event/pubsub/moderation/PubSubModerationUnBanEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/pubsub/moderation/PubSubModerationUnTimeoutEvent.java
+++ b/source/tv/phantombot/event/pubsub/moderation/PubSubModerationUnTimeoutEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamelements/StreamElementsEvent.java
+++ b/source/tv/phantombot/event/streamelements/StreamElementsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamelements/donate/StreamElementsDonateEvent.java
+++ b/source/tv/phantombot/event/streamelements/donate/StreamElementsDonateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamelements/donate/StreamElementsDonationEvent.java
+++ b/source/tv/phantombot/event/streamelements/donate/StreamElementsDonationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamelements/donate/StreamElementsDonationInitializedEvent.java
+++ b/source/tv/phantombot/event/streamelements/donate/StreamElementsDonationInitializedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamlabs/StreamLabsEvent.java
+++ b/source/tv/phantombot/event/streamlabs/StreamLabsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamlabs/donate/StreamLabsDonateEvent.java
+++ b/source/tv/phantombot/event/streamlabs/donate/StreamLabsDonateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamlabs/donate/StreamLabsDonationEvent.java
+++ b/source/tv/phantombot/event/streamlabs/donate/StreamLabsDonationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/streamlabs/donate/StreamLabsDonationInitializedEvent.java
+++ b/source/tv/phantombot/event/streamlabs/donate/StreamLabsDonationInitializedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/tipeeestream/TipeeeStreamEvent.java
+++ b/source/tv/phantombot/event/tipeeestream/TipeeeStreamEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/tipeeestream/donate/TipeeeStreamDonateEvent.java
+++ b/source/tv/phantombot/event/tipeeestream/donate/TipeeeStreamDonateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/tipeeestream/donate/TipeeeStreamDonationEvent.java
+++ b/source/tv/phantombot/event/tipeeestream/donate/TipeeeStreamDonationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/tipeeestream/donate/TipeeeStreamDonationInitializedEvent.java
+++ b/source/tv/phantombot/event/tipeeestream/donate/TipeeeStreamDonationInitializedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/TwitchEvent.java
+++ b/source/tv/phantombot/event/twitch/TwitchEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/bits/TwitchBitsEvent.java
+++ b/source/tv/phantombot/event/twitch/bits/TwitchBitsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/clip/TwitchClipEvent.java
+++ b/source/tv/phantombot/event/twitch/clip/TwitchClipEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/follower/TwitchFollowEvent.java
+++ b/source/tv/phantombot/event/twitch/follower/TwitchFollowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/follower/TwitchFollowerEvent.java
+++ b/source/tv/phantombot/event/twitch/follower/TwitchFollowerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/follower/TwitchFollowsInitializedEvent.java
+++ b/source/tv/phantombot/event/twitch/follower/TwitchFollowsInitializedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/follower/TwitchUnfollowEvent.java
+++ b/source/tv/phantombot/event/twitch/follower/TwitchUnfollowEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/gamechange/TwitchGameChangeEvent.java
+++ b/source/tv/phantombot/event/twitch/gamechange/TwitchGameChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/host/TwitchAutoHostedEvent.java
+++ b/source/tv/phantombot/event/twitch/host/TwitchAutoHostedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/host/TwitchHostEvent.java
+++ b/source/tv/phantombot/event/twitch/host/TwitchHostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/host/TwitchHostedEvent.java
+++ b/source/tv/phantombot/event/twitch/host/TwitchHostedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/host/TwitchHostsInitializedEvent.java
+++ b/source/tv/phantombot/event/twitch/host/TwitchHostsInitializedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/offline/TwitchOfflineEvent.java
+++ b/source/tv/phantombot/event/twitch/offline/TwitchOfflineEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/online/TwitchOnlineEvent.java
+++ b/source/tv/phantombot/event/twitch/online/TwitchOnlineEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/raid/TwitchRaidEvent.java
+++ b/source/tv/phantombot/event/twitch/raid/TwitchRaidEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchAnonymousSubscriptionGiftEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchAnonymousSubscriptionGiftEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchMassAnonymousSubscriptionGiftedEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchMassAnonymousSubscriptionGiftedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchMassSubscriptionGiftedEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchMassSubscriptionGiftedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchPrimeSubscriberEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchPrimeSubscriberEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchReSubscriberEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchReSubscriberEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchSubscriberEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchSubscriberEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/subscriber/TwitchSubscriptionGiftEvent.java
+++ b/source/tv/phantombot/event/twitch/subscriber/TwitchSubscriptionGiftEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitch/titlechange/TwitchTitleChangeEvent.java
+++ b/source/tv/phantombot/event/twitch/titlechange/TwitchTitleChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitter/TwitterEvent.java
+++ b/source/tv/phantombot/event/twitter/TwitterEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/twitter/TwitterRetweetEvent.java
+++ b/source/tv/phantombot/event/twitter/TwitterRetweetEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/webpanel/WebPanelEvent.java
+++ b/source/tv/phantombot/event/webpanel/WebPanelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/webpanel/websocket/WebPanelSocketEvent.java
+++ b/source/tv/phantombot/event/webpanel/websocket/WebPanelSocketEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/webpanel/websocket/WebPanelSocketUpdateEvent.java
+++ b/source/tv/phantombot/event/webpanel/websocket/WebPanelSocketUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerConnectEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerConnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerCurrentIdEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerCurrentIdEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerDeleteCurrentEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerDeleteCurrentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerDeletePlaylistByIDEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerDeletePlaylistByIDEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerDeleteSREvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerDeleteSREvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerDisconnectEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerDisconnectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerLoadPlaylistEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerLoadPlaylistEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerRandomizeEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerRandomizeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerRequestCurrentSongEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerRequestCurrentSongEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerRequestPlaylistEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerRequestPlaylistEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerRequestSonglistEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerRequestSonglistEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerSkipSongEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerSkipSongEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerSongRequestEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerSongRequestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerStateEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerStateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerStealSongEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerStealSongEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/event/ytplayer/YTPlayerVolumeEvent.java
+++ b/source/tv/phantombot/event/ytplayer/YTPlayerVolumeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/httpserver/HTTPSServer.java
+++ b/source/tv/phantombot/httpserver/HTTPSServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/httpserver/HTTPServer.java
+++ b/source/tv/phantombot/httpserver/HTTPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/httpserver/HTTPServerCommon.java
+++ b/source/tv/phantombot/httpserver/HTTPServerCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/panel/NewPanelSocketServer.java
+++ b/source/tv/phantombot/panel/NewPanelSocketServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/panel/PanelSocketSecureServer.java
+++ b/source/tv/phantombot/panel/PanelSocketSecureServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/panel/PanelSocketServer.java
+++ b/source/tv/phantombot/panel/PanelSocketServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ObservingDebugger.java
+++ b/source/tv/phantombot/script/ObservingDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ScriptApi.java
+++ b/source/tv/phantombot/script/ScriptApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ScriptDestroyable.java
+++ b/source/tv/phantombot/script/ScriptDestroyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ScriptEventHandler.java
+++ b/source/tv/phantombot/script/ScriptEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ScriptEventManager.java
+++ b/source/tv/phantombot/script/ScriptEventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ScriptFileWatcher.java
+++ b/source/tv/phantombot/script/ScriptFileWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/script/ScriptManager.java
+++ b/source/tv/phantombot/script/ScriptManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/scripts/core/Moderation.java
+++ b/source/tv/phantombot/scripts/core/Moderation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/scripts/core/ModerationUtil.java
+++ b/source/tv/phantombot/scripts/core/ModerationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/scripts/core/Permissions.java
+++ b/source/tv/phantombot/scripts/core/Permissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/scripts/core/User.java
+++ b/source/tv/phantombot/scripts/core/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/api/Helix.java
+++ b/source/tv/phantombot/twitch/api/Helix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/api/TwitchValidate.java
+++ b/source/tv/phantombot/twitch/api/TwitchValidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/TwitchSession.java
+++ b/source/tv/phantombot/twitch/irc/TwitchSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/TwitchWSIRC.java
+++ b/source/tv/phantombot/twitch/irc/TwitchWSIRC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/TwitchWSIRCParser.java
+++ b/source/tv/phantombot/twitch/irc/TwitchWSIRCParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/chat/utils/Message.java
+++ b/source/tv/phantombot/twitch/irc/chat/utils/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/chat/utils/MessageQueue.java
+++ b/source/tv/phantombot/twitch/irc/chat/utils/MessageQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/chat/utils/SubscriberBulkGifter.java
+++ b/source/tv/phantombot/twitch/irc/chat/utils/SubscriberBulkGifter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/irc/host/TwitchWSHostIRC.java
+++ b/source/tv/phantombot/twitch/irc/host/TwitchWSHostIRC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/twitch/pubsub/TwitchPubSub.java
+++ b/source/tv/phantombot/twitch/pubsub/TwitchPubSub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/ytplayer/YTPlayerState.java
+++ b/source/tv/phantombot/ytplayer/YTPlayerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/ytplayer/YTWebSocketSecureServer.java
+++ b/source/tv/phantombot/ytplayer/YTWebSocketSecureServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/tv/phantombot/ytplayer/YTWebSocketServer.java
+++ b/source/tv/phantombot/ytplayer/YTWebSocketServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 phantombot.tv
+ * Copyright (C) 2016-2019 phantombot.tv
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Just a simple cleanup to include 2019 in the copyright header in all files

Command run: 
```find . \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i 's/(C) 2016-2018/(C) 2016-2019/g'```