### PR TITLE
Added "setdefault" handler to greeting system

### DIFF
--- a/javascript-source/lang/english/systems/systems-greetingSystem.js
+++ b/javascript-source/lang/english/systems/systems-greetingSystem.js
@@ -18,9 +18,10 @@
 $.lang.register('greetingsystem.set.autogreet.enabled', 'Auto Greeting Enabled. $1 will now greet viewers with a greeting configured.');
 $.lang.register('greetingsystem.set.autogreet.disabled', 'Auto Greeting Disabled');
 $.lang.register('greetingsystem.set.autogreet.noname', 'Please use the (name) tag in the default greeting.');
+$.lang.register('greetingsystem.set.default.success', 'Changed the default greeting to "$1".');
 $.lang.register('greetingsystem.set.personal.success', 'Changed your personal greeting to "$1".');
 $.lang.register('greetingsystem.remove.personal.success', 'Successfully removed your personal greeting message.');
-$.lang.register('greetingsystem.generalusage.admin', 'Usage: !greeting [toggle | enable [default | message text] | disable ]. Tags for message text: (name)');
+$.lang.register('greetingsystem.generalusage.admin', 'Usage: !greeting [toggle | enable [default | message text] | disable | setdefault ]. Tags for message text: (name)');
 $.lang.register('greetingsystem.generalusage.other', 'Usage: !greeting [ enable [default | message text] | disable ]. Tags for message text: (name)');
 $.lang.register('greetingsystem.cooldown.usage', 'Usage: !greeting cooldown [hours]');
 $.lang.register('greetingsystem.cooldown.success', 'Greetings cooldown set to $1 hours.');

--- a/javascript-source/systems/greetingSystem.js
+++ b/javascript-source/systems/greetingSystem.js
@@ -138,6 +138,22 @@
             }
 
             /**
+             * @commandpath greeting setdefault - Set the default greeting message
+             */
+            if (action.equalsIgnoreCase('setdefault')) {
+                message = args.splice(1, args.length - 1).join(' ');
+
+                if (!message) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('greetingsystem.generalusage.admin'));
+                    return;
+                }
+
+                $.inidb.set('greeting', 'defaultJoin', message);
+                defaultJoinMessage = message;
+                $.say($.whisperPrefix(sender) + $.lang.get('greetingsystem.set.default.success', defaultJoinMessage));
+            }
+
+            /**
              * @commandpath greeting enable [default | message] - Enable greetings and use the default or set a message.
              */
             if (action.equalsIgnoreCase('enable')) {


### PR DESCRIPTION
Added handler to actually utilize the "!greeting setdefault" command functionality

![image](https://user-images.githubusercontent.com/1137023/73123940-5fcffd80-3f63-11ea-9ef1-1df913b57b2a.png)

TODO: Check for (name) in the new default greeting and respond with greetingsystem.set.autogreet.noname if it's not in there
