### PR TITLE
Fix commands sent as whisper

### DIFF
--- a/javascript-source/core/whisper.js
+++ b/javascript-source/core/whisper.js
@@ -85,7 +85,7 @@
             return;
         }
 
-        if (message.startsWith('!') && $.isMod(sender) && $.users.includes(sender)) {
+        if (message.startsWith('!') && $.isMod(sender) && $.userExists(sender)) {
             message = message.substring(1);
             if (message.includes(' ')) {
                 split = message.indexOf(' ');


### PR DESCRIPTION
When a command is sent via whisper, PhantomBot checks whether it's sent by a mod and if the mod is present in the chat. The chat present chat currently fails.

Before this change:
```
[02-13-2020 @ 22:01:35.586 CET] [WHISPER] mentalfs: !echo Test
[02-13-2020 @ 22:01:35.596 CET] [ERROR] [init.js:325] Error with Event Handler [ircPrivateMessage] Script [./core/whisper.js] Stacktrace [whisper.js:88 > init.js:323 > init.js:714] Exception [TypeError: Cannot find function includes in object chat_o_tron,mentalfs.]
```

After this change:
```
[02-13-2020 @ 22:11:46.046 CET] [WHISPER] mentalfs: !echo Test
[02-13-2020 @ 22:11:46.061 CET] [CHAT] Test
```

I fixed the  chat presence check, although I'm not really sure if it's necessary. Maybe it would be better to remove the presence check altogether, since the user list might not be filled properly after a restart, for larger channels, or just because of the usual JOIN/PART lag.
