### PR TITLE
FIX: Twitchv5 doesn't send _total in JSON response

### DIFF
--- a/javascript-source/discord/systems/promoteSystem.js
+++ b/javascript-source/discord/systems/promoteSystem.js
@@ -339,11 +339,7 @@
             start += 100;
             end += 100;
 
-            if (!jsonObject.has('_total') || !jsonObject.has('streams')) {
-                return;
-            }
-    
-            if (jsonObject.getInt('_total') === 0) {
+            if (!jsonObject.has('streams')) {
                 return;
             }
     


### PR DESCRIPTION
**BUG:** Going-Live notices for promoted streams not posted in designated Discord streamchannel

**Expected behavior:** When a channel in the promoteadm's promoted list goes live on Twitch, it should result in a Discord post indicative thereof. 

**Actual behavior:**  No reaction is observed when the promoted stream goes live, no Discord post is made. 

**Solution:**
Since approximately Feb 17, going-live notices in the promoteSystem stopped functioning completely. I discovered it was due to Twitch's JSON response not including the '_total' token. Removing a check for this token restored functionality. The check was also unnecessary in light of other checks, and the token was otherwise unused in this code.

I have tested this fix in a live Phantombot instance built from current master with no issues. The going live notices are now functioning as expected with the Discord messages being posted properly. By stacking the promoteadm list with multiple streams that were live at time of testing I was able to check cases for both a single as well as multiple stream results in the response. 

I analyzed the JSON response as well as verifying that this check was blocking the response, in order to be certain that this is the correct fix. If Twitch for whatever reason resumes sending the _total token it should not affect operation. 

I have provided a console log of a complete session, in which 

1. The bot was launched, 
2. debugon was set from the console, 
3. A promoteadm add command was initiated from Discord to add a Twitch channel that was known to be live at the time, so as to trigger a going-live response. 
4. Shortly after the console line indicates the channel was picked up and announced. The attached screenshot shows the resulting Discord post. 
5. debugoff was set from the console
6. exit was called from the console and the bot shut down. 

There is also a build log attached. 

[PhantombotBuild.log](https://github.com/PhantomBot/PhantomBot/files/4265643/PhantombotBuild.log)
[PhantombotConsole.log](https://github.com/PhantomBot/PhantomBot/files/4265644/PhantombotConsole.log)
![PRTEST-PromoteSystemFix_DiscordPost_Screenshot_2020-02-28_01-49-49](https://user-images.githubusercontent.com/51912858/75517931-d67e7180-59cd-11ea-803b-972aa5612806.png)
