### PR TITLE
DelTomix add alertImage support to chat events

### DIFF
--- a/javascript-source/handlers/bitsHandler.js
+++ b/javascript-source/handlers/bitsHandler.js
@@ -42,6 +42,7 @@
             bits = event.getBits(),
             ircMessage = event.getMessage(),
             emoteRegexStr = $.twitch.GetCheerEmotesRegex(),
+            alertImageFile = null,
             s = message;
 
         if (announceBits === false || toggle === false) {
@@ -69,8 +70,16 @@
             }
         }
 
+        if (s.match(/\(alert [,.\w\W]+\)/g)) {
+            alertImageFile = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+            s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
+        }
+
         if (bits >= minimum) {
             $.say(s);
+            if (alertImageFile) {
+                $.panelsocketserver.alertImage(alertImageFile);
+            }
         }
 
         $.writeToFile(username + ' ', './addons/bitsHandler/latestCheer.txt', false);

--- a/javascript-source/handlers/clipHandler.js
+++ b/javascript-source/handlers/clipHandler.js
@@ -37,6 +37,7 @@
     $.bind('twitchClip', function(event) {
         var creator = event.getCreator(),
             url = event.getClipURL(),
+            alertImageFile = null,
             s = message;
 
         /* Even though the Core won't even query the API if this is false, we still check here. */
@@ -50,6 +51,12 @@
 
         if (s.match(/\(url\)/g)) {
             s = $.replace(s, '(url)', url);
+        }
+
+        if (s.match(/\(alert [,.\w\W]+\)/g)) {
+            alertImageFile = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+            $.panelsocketserver.alertImage(alertImageFile);
+            s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
         }
 
         $.say(s);

--- a/javascript-source/handlers/donationHandler.js
+++ b/javascript-source/handlers/donationHandler.js
@@ -77,24 +77,22 @@
             donationUsername = donationJson.getString("name"),
             donationMsg = donationJson.getString("message");
 
+        var rewardPoints = Math.round(donationAmount * donationReward),
+            alertImageFile = null,
+            donationSay = donationMessage;
+
         if ($.inidb.exists('donations', donationID)) {
             return;
         }
 
         $.inidb.set('streamInfo', 'lastDonator', $.username.resolve(donationUsername));
-
         $.inidb.set('donations', donationID, donationJson);
-
         $.inidb.set('donations', 'last_donation', donationID);
-
         $.inidb.set('donations', 'last_donation_message', $.lang.get('main.donation.last.tip.message', donationUsername, donationCurrency, donationAmount.toFixed(2)));
 
         $.writeToFile(donationUsername + ": " + donationAmount.toFixed(2) + " ", donationAddonDir + "/latestDonation.txt", false);
 
         if (announceDonations && announceDonationsAllowed) {
-            var rewardPoints = Math.round(donationAmount * donationReward);
-            var donationSay = donationMessage;
-
             donationSay = donationSay.replace('(name)', donationUsername);
             donationSay = donationSay.replace('(amount)', donationAmount.toFixed(2));
             donationSay = donationSay.replace('(amount.toFixed(0))', donationAmount.toFixed(0));
@@ -102,6 +100,13 @@
             donationSay = donationSay.replace('(pointname)', (rewardPoints == 1 ? $.pointNameSingle : $.pointNameMultiple).toLowerCase());
             donationSay = donationSay.replace('(currency)', donationCurrency);
             donationSay = donationSay.replace('(message)', donationMsg);
+
+            if (donationSay.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = donationSay.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                donationSay = (donationSay + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
             $.say(donationSay);
         }
 

--- a/javascript-source/handlers/followHandler.js
+++ b/javascript-source/handlers/followHandler.js
@@ -70,6 +70,7 @@
      */
     $.bind('twitchFollow', function(event) {
         var follower = event.getFollower(),
+            alertImageParams = null,
             s = followMessage;
 
         if (announceFollows === true && followToggle === true) {
@@ -79,6 +80,12 @@
 
             if (s.match(/\(reward\)/)) {
                 s = $.replace(s, '(reward)', $.getPointsString(followReward));
+            }
+
+            if (s.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageParams = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageParams);
+                s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             if (s.match(/^\/w/)) {

--- a/javascript-source/handlers/hostHandler.js
+++ b/javascript-source/handlers/hostHandler.js
@@ -68,6 +68,7 @@
     $.bind('twitchAutoHosted', function(event) {
         var hoster = event.getHoster().toLowerCase(),
             viewers = parseInt(event.getUsers()),
+            alertImageFile = null,
             s = autoHostMessage;
 
         if (announceHosts === false) {
@@ -88,23 +89,30 @@
             };
         }
 
-        if (s.match(/\(name\)/)) {
-            s = $.replace(s, '(name)', $.username.resolve(hoster));
-        }
-
-        if (s.match(/\(reward\)/)) {
-            s = $.replace(s, '(reward)', autoHostReward.toString());
-        }
-
-        if (s.match(/\(viewers\)/)) {
-            s = $.replace(s, '(viewers)', viewers.toString());
-        }
-
-        if (s.match(/^\/w/)) {
-            s = s.replace('/w', ' /w');
-        }
-
         if (autoHostToggle === true && viewers >= hostMinCount) {
+
+            if (s.match(/\(name\)/)) {
+                s = $.replace(s, '(name)', $.username.resolve(hoster));
+            }
+
+            if (s.match(/\(reward\)/)) {
+                s = $.replace(s, '(reward)', autoHostReward.toString());
+            }
+
+            if (s.match(/\(viewers\)/)) {
+                s = $.replace(s, '(viewers)', viewers.toString());
+            }
+
+            if (s.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
+            if (s.match(/^\/w/)) {
+                s = s.replace('/w', ' /w');
+            }
+
             $.say(s);
         }
 
@@ -121,6 +129,7 @@
     $.bind('twitchHosted', function(event) {
         var hoster = event.getHoster().toLowerCase(),
             viewers = parseInt(event.getUsers()),
+            alertImageFile = null,
             s = hostMessage;
 
         // Always update the Host History even if announcements are off or if they recently
@@ -155,23 +164,30 @@
             };
         }
 
-        if (s.match(/\(name\)/)) {
-            s = $.replace(s, '(name)', $.username.resolve(hoster));
-        }
-
-        if (s.match(/\(reward\)/)) {
-            s = $.replace(s, '(reward)', hostReward.toString());
-        }
-
-        if (s.match(/\(viewers\)/)) {
-            s = $.replace(s, '(viewers)', viewers.toString());
-        }
-
-        if (s.match(/^\/w/)) {
-            s = s.replace('/w', ' /w');
-        }
-
         if (hostToggle === true && viewers >= hostMinCount) {
+
+            if (s.match(/\(name\)/)) {
+                s = $.replace(s, '(name)', $.username.resolve(hoster));
+            }
+
+            if (s.match(/\(reward\)/)) {
+                s = $.replace(s, '(reward)', hostReward.toString());
+            }
+
+            if (s.match(/\(viewers\)/)) {
+                s = $.replace(s, '(viewers)', viewers.toString());
+            }
+
+            if (s.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
+            if (s.match(/^\/w/)) {
+                s = s.replace('/w', ' /w');
+            }
+
             $.say(s);
         }
 

--- a/javascript-source/handlers/raidHandler.js
+++ b/javascript-source/handlers/raidHandler.js
@@ -151,6 +151,7 @@
             viewers = event.getViewers(),
             hasRaided = false,
             raidObj,
+            alertImageFile = null,
             message;
 
         if (raidToggle === true) {
@@ -187,6 +188,12 @@
 
             if (hasRaided && message.match(/\(times\)/)) {
                 message = $.replace(message, '(times)', raidObj.totalRaids);
+            }
+
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             $.say(message);

--- a/javascript-source/handlers/streamElementsHandler.js
+++ b/javascript-source/handlers/streamElementsHandler.js
@@ -67,6 +67,7 @@
             donationCurrency = paramObj.getString('currency'),
             donationMessage = (paramObj.has('message') ? paramObj.getString('message') : ''),
             donationAmount = paramObj.getInt('amount'),
+            alertImageFile = null,
             s = message;
 
         if ($.inidb.exists('donations', donationID)) {
@@ -106,6 +107,12 @@
 
             if (s.match(/\(reward\)/)) {
                 s = $.replace(s, '(reward)', $.getPointsString(Math.floor(parseFloat(donationAmount) * reward)));
+            }
+
+            if (s.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             $.say(s);

--- a/javascript-source/handlers/subscribeHandler.js
+++ b/javascript-source/handlers/subscribeHandler.js
@@ -98,6 +98,7 @@
     $.bind('twitchSubscriber', function(event) {
         var subscriber = event.getSubscriber(),
             tier = event.getPlan(),
+            alertImageFile = null,
             message = subMessage;
 
         if (subWelcomeToggle === true && announce === true) {
@@ -111,6 +112,12 @@
 
             if (message.match(/\(plan\)/g)) {
                 message = $.replace(message, '(plan)', getPlanName(tier));
+            }
+
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             $.say(message);
@@ -129,6 +136,7 @@
      */
     $.bind('twitchPrimeSubscriber', function(event) {
         var subscriber = event.getSubscriber(),
+            alertImageFile = null,
             message = primeSubMessage;
 
         if (primeSubWelcomeToggle === true && announce === true) {
@@ -138,6 +146,12 @@
 
             if (message.match(/\(reward\)/g)) {
                 message = $.replace(message, '(reward)', String(subReward));
+            }
+
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             $.say(message);
@@ -158,6 +172,7 @@
         var resubscriber = event.getReSubscriber(),
             months = event.getMonths(),
             tier = event.getPlan(),
+            alertImageFile = null,
             message = reSubMessage,
             emotes = [];
 
@@ -182,6 +197,13 @@
                 for (i = 0; i < months; i++, emotes.push(customEmote));
                 message = $.replace(message, '(customemote)', emotes.join(' '));
             }
+
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
             $.say(message);
             $.addSubUsersList(resubscriber);
             $.restoreSubscriberStatus(resubscriber);
@@ -202,6 +224,7 @@
             recipient = event.getRecipient(),
             months = event.getMonths(),
             tier = event.getPlan(),
+            alertImageFile = null,
             message = giftSubMessage;
 
         if (giftSubWelcomeToggle === true && announce === true) {
@@ -230,6 +253,12 @@
                 message = $.replace(message, '(customemote)', emotes.join(' '));
             }
 
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
             $.say(message);
 
             $.addSubUsersList(recipient);
@@ -254,6 +283,7 @@
         var gifter = event.getUsername(),
             amount = event.getAmount(),
             tier = event.getPlan(),
+            alertImageFile = null,
             message = massGiftSubMessage;
 
         if (massGiftSubWelcomeToggle === true && announce === true) {
@@ -273,6 +303,12 @@
                 message = $.replace(message, '(plan)', getPlanName(tier));
             }
 
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
             $.say(message);
 
             if (massGiftSubReward > 0) {
@@ -289,6 +325,7 @@
             recipient = event.getRecipient(),
             months = event.getMonths(),
             tier = event.getPlan(),
+            alertImageFile = null,
             message = giftAnonSubMessage;
 
         if (giftAnonSubWelcomeToggle === true && announce === true) {
@@ -312,6 +349,12 @@
                 message = $.replace(message, '(plan)', getPlanName(tier));
             }
 
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
+            }
+
             $.say(message);
 
             $.addSubUsersList(recipient);
@@ -333,6 +376,7 @@
         var gifter = event.getUsername(),
             amount = event.getAmount(),
             tier = event.getPlan(),
+            alertImageFile = null,
             message = massAnonGiftSubMessage;
 
         if (massAnonGiftSubWelcomeToggle === true && announce === true) {
@@ -346,6 +390,12 @@
 
             if (message.match(/\(plan\)/g)) {
                 message = $.replace(message, '(plan)', getPlanName(tier));
+            }
+
+            if (message.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = message.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                message = (message + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             $.say(message);

--- a/javascript-source/handlers/tipeeeStreamHandler.js
+++ b/javascript-source/handlers/tipeeeStreamHandler.js
@@ -76,6 +76,7 @@
             donationMessage = (paramObj.has('message') ? paramObj.getString('message') : ''),
             donationAmount = paramObj.getInt('amount'),
             donationFormattedAmount = donationObj.getString('formattedAmount'),
+            alertImageFile = null,
             s = message;
 
         if ($.inidb.exists('donations', donationID)) {
@@ -119,6 +120,12 @@
 
             if (s.match(/\(reward\)/)) {
                 s = $.replace(s, '(reward)', $.getPointsString(Math.floor(parseFloat(donationAmount) * reward)));
+            }
+
+            if (s.match(/\(alert [,.\w\W]+\)/g)) {
+                alertImageFile = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(alertImageFile);
+                s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
             }
 
             $.say(s);


### PR DESCRIPTION
**Purpose** 
This pull request is to add alertImage support to chat events, such that by adding an (alert...) tag in the alerts text for chat events, an animated gif and accompanying sound can be played. 

**Rationale;**
As we all know one of the greatest things about PhantomBot is that it is a fully capable self-hosted Twitch bot solution, with enough features and capability to replace other 3rd party Twitch chat-bots out there. Animated chat events are a nearly ubiquitous feature of Twitch Streams, as common as chat-bots themselves. Having this feature as part of PhantomBot's self-hosted solution negates the need to use 3rd party browser sources for that purpose, further adding to the self-hosting advantage. 

It seems reasonable that with most of the capability already available (i.e. the existing browser source, and '(alert alertimage)' functionality of commands), chat-event support should be available in the same way.

As a Twitch viewer I have often seen unreliability and unpredictable delays with animated alerts from 3rd parties. As a streamer I have been running my channel this way since a year now, and MUCH prefer the locally sourced event-alerts for their flexibility, performance, and predictable timings.

**Implementation**
The functionality is implemented very simply using an additional parse routine in each event and adds no bloat or load on resources. It fires exactly as the existing parse routine for the user-provided alert message. The parse routine was adapted from the existing parse routine for processing gif-alerts in custom commands. In each event handler it was implemented according to the conventions of the regular tags parsing in that handler. 

**Usage**
To use it, one may simply add the same alert tag in alert messages as one already does in custom commands. So for example a follower alert message such as;
`Hey (name)! THANK YOU for following!`
may be made to provide an alertimage such as;
`Hey (name)! THANK YOU for following! (alert followalert.gif,4,0.9,font-size: 40px; color: blue; width: 100%; text-align: center,(name) Is now Following!!!)`

This pull request implements this functionality for clip, host, raid, bits, follow, subscribe, and donation/tip events.

**Test session sequence;**
1) clear all log files in the test-build's folders
2) start recording in OBS with a scene including terminal window and browser source
3) launch the bot in the terminal window and wait for it to fully start
4) run a !quote command from the chat window to ensure the bot is responding
5) run through the available event-test commands;
    - raidtest
	- cliptest
	- hosttest
	- bitstest
	- followertest joefollower4
	- followerstest 6
	- subscribertest
	- primesubscribertest
	- resubscribertest
	- giftsubtest
	- botinfo
	- exit
6) The full text of the terminal console log shown in the video, as well as any logs generated in PhantomBot/logs folders from the session are attached here. 

[The video of this session showing the alert results is available on YouTube.](https://www.youtube.com/watch?v=hriKevc2_mM)

**Notes:**
There is one core-error entry that is UNRELATED to this pull request, which happens for me in stock builds as well - related to PanelSocketServer.java. However it is provided for completeness.

I had no way to test donation events, but they are implemented the exact same way and I see no reason why there would be an issue. If anyone has advice for means of testing let me know. 
[AlertsPanelSettings.txt](https://github.com/PhantomBot/PhantomBot/files/4269640/AlertsPanelSettings.txt)
[logs_chat_28-02-2020.txt](https://github.com/PhantomBot/PhantomBot/files/4269641/logs_chat_28-02-2020.txt)
[logs_core-error_28-02-2020.txt](https://github.com/PhantomBot/PhantomBot/files/4269642/logs_core-error_28-02-2020.txt)
[logs_event_28-02-2020.txt](https://github.com/PhantomBot/PhantomBot/files/4269643/logs_event_28-02-2020.txt)
[logs_private-messages_28-02-2020.txt](https://github.com/PhantomBot/PhantomBot/files/4269644/logs_private-messages_28-02-2020.txt)
[PhantomBotBuildLog-PR_AlertImageSupport.txt](https://github.com/PhantomBot/PhantomBot/files/4269645/PhantomBotBuildLog-PR_AlertImageSupport.txt)
[PhantomBotConsoleLog-PR_AlertImageSupport.txt](https://github.com/PhantomBot/PhantomBot/files/4269646/PhantomBotConsoleLog-PR_AlertImageSupport.txt)
