### PR TITLE
Dockerfile pull from the correct build directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,17 +48,18 @@ ARG DATADIR=${BASEDIR}_data
 
 RUN mkdir -p "${BASEDIR}" "${DATADIR}" "${BASEDIR}/logs"
 
-COPY --from=builder "${BUILDDIR}/dist/build/." "${BASEDIR}/"
+COPY --from=builder "${BUILDDIR}/dist/${PROJECT_NAME}-3.0.0/." "${BASEDIR}/"
 
 RUN cd "${BASEDIR}" \
     && rm -rf \
     && mkdir "${DATADIR}/scripts" \
+    && mkdir "${DATADIR}/scripts/custom" \
     && mkdir "${DATADIR}/scripts/discord" \
     && mkdir "${DATADIR}/scripts/lang" \
     && mv "${BASEDIR}/addons" "${DATADIR}/" \
     && mv "${BASEDIR}/config" "${DATADIR}/" \
     && mv "${BASEDIR}/logs" "${DATADIR}/" \
-    && mv "${BASEDIR}/scripts/custom" "${DATADIR}/scripts/" \
+    && mv "${BASEDIR}/scripts/custom" "${DATADIR}/scripts/custom/" \
     && mv "${BASEDIR}/scripts/discord/custom" "${DATADIR}/scripts/discord/" \
     && mv "${BASEDIR}/scripts/lang/custom" "${DATADIR}/scripts/lang/" \
     && mkdir "${DATADIR}/dbbackup" \
@@ -66,7 +67,7 @@ RUN cd "${BASEDIR}" \
     && ln -s "${DATADIR}/config" \
     && ln -s "${DATADIR}/dbbackup" \
     && ln -s "${DATADIR}/logs" \
-    && ln -s "${DATADIR}/scripts/custom" "${BASEDIR}/scripts/" \
+    && ln -s "${DATADIR}/scripts/custom" "${BASEDIR}/scripts/custom" \
     && ln -s "${DATADIR}/scripts/discord/custom" "${BASEDIR}/scripts/discord/" \
     && ln -s "${DATADIR}/scripts/lang/custom" "${BASEDIR}/scripts/lang/"
 


### PR DESCRIPTION
Also move scripts/custom to a scripts/custom subdirectory
This way scripts/discord and scripts/lang are not
also pushed to scripts/custom as subdirectories

* Before changes
```
...
BUILD SUCCESSFUL
Total time: 10 seconds
Removing intermediate container 37a826804a97
 ---> d157ac55e6f9
Step 10/21 : FROM azul/zulu-openjdk-alpine:11.0.4-jre
 ---> b234cc35e837
Step 11/21 : ARG PROJECT_NAME=PhantomBot
 ---> Using cache
 ---> 9a87cdaac4dc
Step 12/21 : ARG BASEDIR=/opt/${PROJECT_NAME}
 ---> Using cache
 ---> 89ee81f56173
Step 13/21 : ARG BUILDDIR=${BASEDIR}_build
 ---> Using cache
 ---> d13dea7934fb
Step 14/21 : ARG DATADIR=${BASEDIR}_data
 ---> Using cache
 ---> 4ddc2281beb5
Step 15/21 : RUN mkdir -p "${BASEDIR}" "${DATADIR}" "${BASEDIR}/logs"
 ---> Using cache
 ---> 0458745e3694
Step 16/21 : COPY --from=builder "${BUILDDIR}/dist/build/." "${BASEDIR}/"
COPY failed: stat /home/docker/daemon/overlay2/e7613832a8965b821873e4c5f64ac220d07cae413e943713fe7f516d7fad0ad4/merged/opt/PhantomBot_build/dist/build: no such file or directory
```

* After Changes
```
Step 15/21 : RUN mkdir -p "${BASEDIR}" "${DATADIR}" "${BASEDIR}/logs"
 ---> Running in 053b15df18c4
Removing intermediate container 053b15df18c4
 ---> 9c7cf65a0006
Step 16/21 : COPY --from=builder "${BUILDDIR}/dist/${PROJECT_NAME}-3.0.0/." "${BASEDIR}/"
 ---> bb360a298791
Step 17/21 : RUN cd "${BASEDIR}"     && rm -rf     && mkdir "${DATADIR}/scripts"     && mkdir "${DATADIR}/scripts/custom"     && mkdir "${DATADIR}/scripts/discord"     && mkdir "${DATADIR}/scripts/lang"     && mv "${BASEDIR}/addons" "${DATADIR}/"     && mv "${BASEDIR}/config" "${DATADIR}/"     && mv "${BASEDIR}/logs" "${DATADIR}/"     && mv "${BASEDIR}/scripts/custom" "${DATADIR}/scripts/custom"     && mv "${BASEDIR}/scripts/discord/custom" "${DATADIR}/scripts/discord/"     && mv "${BASEDIR}/scripts/lang/custom" "${DATADIR}/scripts/lang/"     && mkdir "${DATADIR}/dbbackup"     && ln -s "${DATADIR}/addons"     && ln -s "${DATADIR}/config"     && ln -s "${DATADIR}/dbbackup"     && ln -s "${DATADIR}/logs"     && ln -s "${DATADIR}/scripts/custom" "${BASEDIR}/scripts/custom"     && ln -s "${DATADIR}/scripts/discord/custom" "${BASEDIR}/scripts/discord/"     && ln -s "${DATADIR}/scripts/lang/custom" "${BASEDIR}/scripts/lang/"
 ---> Running in f0c921fe041f
Removing intermediate container f0c921fe041f
 ---> 82d9411f42dc
Step 18/21 : VOLUME "${DATADIR}"
 ---> Running in 4e38e4c28514
Removing intermediate container 4e38e4c28514
 ---> da9114045a72
Step 19/21 : WORKDIR "${BASEDIR}"
 ---> Running in 4d6e290dc537
Removing intermediate container 4d6e290dc537
 ---> dc0860b04424
Step 20/21 : EXPOSE 25000
 ---> Running in 3ea581006ab0
Removing intermediate container 3ea581006ab0
 ---> 1e734ccc2140
Step 21/21 : CMD ["sh", "launch-service.sh"]
 ---> Running in 8ade6a848220
Removing intermediate container 8ade6a848220
 ---> 1055b95b8308
Successfully built 1055b95b8308
```

92fb858b025e963c9844ab7d03b8801e5d1de5a7 moves the contents of dist/build to dist/${PROJECT_NAME}-${VERSION}, which means we need to hardcode the version number into the Dockerfile, because Dockerfiles don't have full shells in them, so can't interpret things like `COPY --from=builder "${BUILDDIR}/dist/${PROJECT_NAME}-*/." "${BASEDIR}`