### PR TITLE
Don't let bot answer it's own questions.

### DIFF
--- a/javascript-source/core/whisper.js
+++ b/javascript-source/core/whisper.js
@@ -55,6 +55,9 @@
      * @returns {string}
      */
     function whisperPrefix(username, force) {
+        if (username.toLowerCase() == $.botName.toLowerCase()) {
+            return ''; 
+        }        
         if (whisperMode || force) {
             return '/w ' + username + ' ';
         }


### PR DESCRIPTION
Imagine you have a timer set up like `command:!poll` to let chat know about the ongoing poll.
This change will avoid the bot to to prefix the command with it's own name like "@botname, there's an ongoing poll…"

