### PR TITLE
Fix multi link exploit

### DIFF
--- a/development-resources/DEVSETUP.md
+++ b/development-resources/DEVSETUP.md
@@ -8,7 +8,7 @@ This section is for all IDE's not mentioned in this guide.
 It's very global, so you might need to take some extra steps to get it to work for you.
 
 1. Fork the [PhantomBot repository](https://github.com/PhantomBot/PhantomBot).
-2. Check out your for and open it in your favorite IDE.
+2. Check out your fork and open it in your favorite IDE.
 2. Set the project Java SDK to [1.8](http://www.oracle.com/technetwork/java/javase/overview/index.html).
 3. Import `build.xml` into your [ANT](http://ant.apache.org/) task manager.
 

--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -142,7 +142,8 @@
         messageTime = $.systemTime(),
         warning = '',
         youtubeLinks = new RegExp('(youtube.com|youtu.be)', 'i'),
-        i;
+        i,
+        j;
 
     /**
      * @function reloadModeration
@@ -493,8 +494,14 @@
      * @param {string} message
      */
     function checkWhiteList(message) {
+        var links = $.patternDetector.getLinks(message);
         for (i in whiteList) {
-            if (message.indexOf(whiteList[i]) !== -1) {
+            for (j = 0; j < links.length; j++) {
+                if (links[j].indexOf(whiteList[i]) !== -1) {
+                    links.splice(j--, 1);
+                }
+            }
+            if (links.length === 0) {
                 return true;
             }
         }

--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -50,7 +50,10 @@
      * @returns {string[]}
      */
     function getLinks(event) {
-        var matches = Array.from(event.getMessage().matchAll(patterns.link));
+        // turn Java String into JavaScript string
+        // https://github.com/mozilla/rhino/issues/638
+        var message = event.getMessage() + '';
+        var matches = Array.from(message.matchAll(patterns.link));
         return matches.map(function(m) { return m[0] });
     }
 

--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -53,8 +53,7 @@
         // turn Java String into JavaScript string
         // https://github.com/mozilla/rhino/issues/638
         var message = event.getMessage() + '';
-        var matches = Array.from(message.matchAll(patterns.link));
-        return matches.map(function(m) { return m[0] });
+        return message.match(patterns.link);
     }
 
     /**

--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -23,7 +23,7 @@
  */
 (function() {
     var patterns = {
-        link: new RegExp('((?:(http|https|rtsp):\\/\\/(?:(?:[a-z0-9\\$\\-\\_\\.\\+\\!\\*\\\'\\(\\)' + '\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,64}(?:\\:(?:[a-z0-9\\$\\-\\_' + '\\.\\+\\!\\*\\\'\\(\\)\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,25})?\\@)?)?' + '((?:(?:[a-z0-9][a-z0-9\\-]{0,64}\\.)+' + '(?:' + '(?:aero|a[cdefgilmnoqrstuwxz])' + '|(?:biz|bike|bot|b[abdefghijmnorstvwyz])' + '|(?:com|c[acdfghiklmnoruvxyz])' + '|d[ejkmoz]' + '|(?:edu|e[cegrstu])' + '|(?:fyi|f[ijkmor])' + '|(?:gov|g[abdefghilmnpqrstuwy])' + '|(?:how|h[kmnrtu])' + '|(?:info|i[delmnoqrst])' + '|(?:jobs|j[emop])' + '|k[eghimnrwyz]' + '|l[abcikrstuvy]' + '|(?:mil|mobi|moe|m[acdeghklmnopqrstuvwxyz])' + '|(?:name|net|n[acefgilopruz])' + '|(?:org|om)' + '|(?:pro|p[aefghklmnrstwy])' + '|qa' + '|(?:r[eouw])' + '|(?:s[abcdeghijklmnortuvyz])' + '|(?:t[cdfghjklmnoprtvwz])' + '|u[agkmsyz]' + '|(?:vote|v[ceginu])' + '|(?:xxx)' + '|(?:watch|w[fs])' + '|y[etu]' + '|z[amw]))' + '|(?:(?:25[0-5]|2[0-4]' + '[0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9])\\.(?:25[0-5]|2[0-4][0-9]' + '|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1]' + '[0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}' + '|[1-9][0-9]|[0-9])))' + '(?:\\:\\d{1,5})?)' + '(\\/(?:(?:[a-z0-9\\;\\/\\?\\:\\@\\&\\=\\#\\~' + '\\-\\.\\+\\!\\*\\\'\\(\\)\\,\\_])|(?:\\%[a-fA-F0-9]{2}))*)?' + '(?:\\b|$)' + '|(\\.[a-z]+\\/|magnet:\/\/|mailto:\/\/|ed2k:\/\/|irc:\/\/|ircs:\/\/|skype:\/\/|ymsgr:\/\/|xfire:\/\/|steam:\/\/|aim:\/\/|spotify:\/\/)', 'i'),
+        link: new RegExp('((?:(http|https|rtsp):\\/\\/(?:(?:[a-z0-9\\$\\-\\_\\.\\+\\!\\*\\\'\\(\\)' + '\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,64}(?:\\:(?:[a-z0-9\\$\\-\\_' + '\\.\\+\\!\\*\\\'\\(\\)\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,25})?\\@)?)?' + '((?:(?:[a-z0-9][a-z0-9\\-]{0,64}\\.)+' + '(?:' + '(?:aero|a[cdefgilmnoqrstuwxz])' + '|(?:biz|bike|bot|b[abdefghijmnorstvwyz])' + '|(?:com|c[acdfghiklmnoruvxyz])' + '|d[ejkmoz]' + '|(?:edu|e[cegrstu])' + '|(?:fyi|f[ijkmor])' + '|(?:gov|g[abdefghilmnpqrstuwy])' + '|(?:how|h[kmnrtu])' + '|(?:info|i[delmnoqrst])' + '|(?:jobs|j[emop])' + '|k[eghimnrwyz]' + '|l[abcikrstuvy]' + '|(?:mil|mobi|moe|m[acdeghklmnopqrstuvwxyz])' + '|(?:name|net|n[acefgilopruz])' + '|(?:org|om)' + '|(?:pro|p[aefghklmnrstwy])' + '|qa' + '|(?:r[eouw])' + '|(?:s[abcdeghijklmnortuvyz])' + '|(?:t[cdfghjklmnoprtvwz])' + '|u[agkmsyz]' + '|(?:vote|v[ceginu])' + '|(?:xxx)' + '|(?:watch|w[fs])' + '|y[etu]' + '|z[amw]))' + '|(?:(?:25[0-5]|2[0-4]' + '[0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9])\\.(?:25[0-5]|2[0-4][0-9]' + '|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1]' + '[0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}' + '|[1-9][0-9]|[0-9])))' + '(?:\\:\\d{1,5})?)' + '(\\/(?:(?:[a-z0-9\\;\\/\\?\\:\\@\\&\\=\\#\\~' + '\\-\\.\\+\\!\\*\\\'\\(\\)\\,\\_])|(?:\\%[a-fA-F0-9]{2}))*)?' + '(?:\\b|$)' + '|(\\.[a-z]+\\/|magnet:\/\/|mailto:\/\/|ed2k:\/\/|irc:\/\/|ircs:\/\/|skype:\/\/|ymsgr:\/\/|xfire:\/\/|steam:\/\/|aim:\/\/|spotify:\/\/)', 'ig'),
         emotes: new RegExp('([0-9][0-9]-[0-9][0-9])|([0-9]-[0-9])', 'g'),
         repeatedSeq: /(.)(\1+)/ig,
         nonAlphaSeq: /([^a-z0-9 ])(\1+)/ig,
@@ -37,11 +37,21 @@
      * @function hasLinks
      * @export $.patternDetector
      * @param {Object} event
-     * @param {boolean} [aggressive]
      * @returns {boolean}
      */
     function hasLinks(event) {
         return patterns.link.test(event.getMessage());
+    }
+
+    /**
+     * @function getLinks
+     * @export $.patternDetector
+     * @param {Object} event
+     * @returns {string[]}
+     */
+    function getLinks(event) {
+        var matches = Array.from(event.getMessage().matchAll(patterns.link));
+        return matches.map(function(m) { return m[0] });
     }
 
     /**

--- a/javascript-source/core/patternDetector.js
+++ b/javascript-source/core/patternDetector.js
@@ -194,6 +194,7 @@
     /** Export functions to API */
     $.patternDetector = {
         hasLinks: hasLinks,
+        getLinks: getLinks,
         getLongestRepeatedSequence: getLongestRepeatedSequence,
         getLongestNonLetterSequence: getLongestNonLetterSequence,
         getNumberOfNonLetters: getNumberOfNonLetters,


### PR DESCRIPTION
There is a potential exploit in the code.  
Suppose you have links moderated and "clips.twitch.tv" on your whitelist. If someone now sends a message like "evil.link.example.com oh, and also clips.twitch.tv", it wouldn't get moderated because one of the links is on the whiteList.

I am really sorry, but I couldn't get this project to build so I tested my modifications stand-alone with nodejs. I know this project is running Rhino, but as said, after hours of fiddling around I gave up. Here's what I tested in nodejs:

```javascript
var linksRe = new RegExp('((?:(http|https|rtsp):\\/\\/(?:(?:[a-z0-9\\$\\-\\_\\.\\+\\!\\*\\\'\\(\\)' + '\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,64}(?:\\:(?:[a-z0-9\\$\\-\\_' + '\\.\\+\\!\\*\\\'\\(\\)\\,\\;\\?\\&\\=]|(?:\\%[a-fA-F0-9]{2})){1,25})?\\@)?)?' + '((?:(?:[a-z0-9][a-z0-9\\-]{0,64}\\.)+' + '(?:' + '(?:aero|a[cdefgilmnoqrstuwxz])' + '|(?:biz|bike|bot|b[abdefghijmnorstvwyz])' + '|(?:com|c[acdfghiklmnoruvxyz])' + '|d[ejkmoz]' + '|(?:edu|e[cegrstu])' + '|(?:fyi|f[ijkmor])' + '|(?:gov|g[abdefghilmnpqrstuwy])' + '|(?:how|h[kmnrtu])' + '|(?:info|i[delmnoqrst])' + '|(?:jobs|j[emop])' + '|k[eghimnrwyz]' + '|l[abcikrstuvy]' + '|(?:mil|mobi|moe|m[acdeghklmnopqrstuvwxyz])' + '|(?:name|net|n[acefgilopruz])' + '|(?:org|om)' + '|(?:pro|p[aefghklmnrstwy])' + '|qa' + '|(?:r[eouw])' + '|(?:s[abcdeghijklmnortuvyz])' + '|(?:t[cdfghjklmnoprtvwz])' + '|u[agkmsyz]' + '|(?:vote|v[ceginu])' + '|(?:xxx)' + '|(?:watch|w[fs])' + '|y[etu]' + '|z[amw]))' + '|(?:(?:25[0-5]|2[0-4]' + '[0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9])\\.(?:25[0-5]|2[0-4][0-9]' + '|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1]' + '[0-9]{2}|[1-9][0-9]|[1-9]|0)\\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}' + '|[1-9][0-9]|[0-9])))' + '(?:\\:\\d{1,5})?)' + '(\\/(?:(?:[a-z0-9\\;\\/\\?\\:\\@\\&\\=\\#\\~' + '\\-\\.\\+\\!\\*\\\'\\(\\)\\,\\_])|(?:\\%[a-fA-F0-9]{2}))*)?' + '(?:\\b|$)' + '|(\\.[a-z]+\\/|magnet:\/\/|mailto:\/\/|ed2k:\/\/|irc:\/\/|ircs:\/\/|skype:\/\/|ymsgr:\/\/|xfire:\/\/|steam:\/\/|aim:\/\/|spotify:\/\/)', 'ig');
function hasLinks(message) {
    return linksRe.test(message);
}
function getLinks(message) {
    var matches = Array.from(message.matchAll(linksRe));
    return matches.map(function(m) { return m[0] });
}
function checkWhiteList(message) {
    var links = getLinks(message);
    for (i in whiteList) {
        for (j = 0; j < links.length; j++) {
            if (links[j].indexOf(whiteList[i]) !== -1) {
                links.splice(j--, 1);
            }
        }
        if (links.length === 0) {
            return true;
        }
    }
    return false;
}
whiteList = ['example.com']
checkWhiteList('http://example.com')
checkWhiteList('http://example.org')
checkWhiteList('http://example.com and http://example.org')
whiteList = ['example.com', 'example.org']
checkWhiteList('http://example.com')
checkWhiteList('http://example.org')
checkWhiteList('http://example.com and http://example.org')
```

While I'm at it, I hope you are aware that this method of checking for white-listed links is also not bulletproof. Imagine someone sending a link like `https://www.twitch.tv/myNiceChannel?whatever=whitelisted.example.com`. Most sites don't care about unknown url parameters. A similar attack would be possible using the url fragment (the part after the `#`).