### PR TITLE
Anchor link whitelist matching at TLD

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -143,7 +143,8 @@
         warning = '',
         youtubeLinks = new RegExp('(youtube.com|youtu.be)', 'i'),
         i,
-        j;
+        j,
+        k;
 
     /**
      * @function reloadModeration
@@ -494,10 +495,24 @@
      * @param {string} message
      */
     function checkWhiteList(message) {
+        function checkLink(link, whiteListItem) {
+            var baseLink = link.match(/[^.]*[^/]*/)[0];
+            var itemRe = RegExp(whiteListItem.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g');
+            var matches = Array.from(link.matchAll(itemRe));
+            for (k = 0; k < matches.length; k++) {
+                var matchStart = matches[k].index;
+                var matchEnd = matches[k].index + matches[k][0].length;
+                if (matchStart < baseLink.length && matchEnd >= baseLink.length) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         var links = $.patternDetector.getLinks(message);
-        for (i in whiteList) {
+        for (i = 0; i < whiteList.length; i++) {
             for (j = 0; j < links.length; j++) {
-                if (links[j].indexOf(whiteList[i]) !== -1) {
+                if (checkLink(links[j], whiteList[i])) {
                     links.splice(j--, 1);
                 }
             }

--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -497,7 +497,7 @@
     function checkWhiteList(message) {
         function checkLink(link, whiteListItem) {
             var baseLink = link.match(/[^.]*[^/]*/)[0];
-            var itemRe = RegExp(whiteListItem.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g');
+            var itemRe = new RegExp(whiteListItem.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g');
             var matches = Array.from(link.matchAll(itemRe));
             for (k = 0; k < matches.length; k++) {
                 var matchStart = matches[k].index;


### PR DESCRIPTION
As explained in #2212, the current implementation of the links white list is still vulnerable in a sense that it, probably for most users unexpectedly, permits some links. 

Examples and tests can be found here: https://github.com/PhantomBot/PhantomBot/pull/2212#issuecomment-603141513

To clarify how this works: It makes sure that the TLD (e.g. `.com`) of the URL is part of the white-listed link match.