### PR TITLE
Patch 70

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -771,20 +771,42 @@
      * @param {sub} subcommand
      * @returns 0 = good, 1 = command perm bad, 2 = subcommand perm bad
      */
-    function permCom(username, command, subcommand) {
+    function permCom(username, command, subcommand, tags) {
+        var commandGroup, allowed;
         if (subcommand === '') {
-            if ($.getCommandGroup(command) >= $.getUserGroupId(username)) {
-                return 0;
-            } else {
-                return 1;
-            }
+            commandGroup = $.getCommandGroup(command);
         } else {
-            if ($.getSubcommandGroup(command, subcommand) >= $.getUserGroupId(username)) {
-                return 0;
-            } else {
-                return 2;
-            }
+            commandGroup = $.getSubcommandGroup(command, subcommand);
         }
+        
+        switch(commandGroup) {
+            case 0:
+                allowed = $.isCaster(username);
+                break;
+            case 1:
+                allowed = $.isAdmin(username);
+                break;
+            case 2:
+                allowed = $.isModv3(username, tags);
+                break;
+            case 3:
+                allowed = $.isSubv3(username, tags) || $.isModv3(username, tags);
+                break;
+            case 4:
+                allowed = $.isDonator(username) || $.isModv3(username, tags);
+                break;
+            case 5:
+                allowed = $.isVIP(username, tags) || $.isModv3(username, tags);
+                break;
+            case 6:
+                allowed = $.isReg(username) || $.isModv3(username, tags);
+                break;
+            default:
+                allowed = true;
+                break;
+        }
+        
+        return allowed ? 0 : (subcommand === '' ? 1 : 2);
     }
 
     /*

--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -228,7 +228,7 @@
             } else if (commands[command].groupId == 4) {
                 group = 'Donator';
             } else if (commands[command].groupId == 5) {
-                group = 'Hoster';
+                group = 'VIP';
             } else if (commands[command].groupId == 6) {
                 group = 'Regular';
             } else if (commands[command].groupId == 7) {
@@ -278,7 +278,7 @@
             } else if (commands[command].subcommands[subcommand].groupId == 4) {
                 group = 'Donator';
             } else if (commands[command].subcommands[subcommand].groupId == 5) {
-                group = 'Hoster';
+                group = 'VIP';
             } else if (commands[command].subcommands[subcommand].groupId == 6) {
                 group = 'Regular';
             } else if (commands[command].subcommands[subcommand].groupId == 7) {

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -142,6 +142,20 @@
         }
     }
 
+    function equalsIgnoreCase(str1, str2) {
+        try {
+            return str1.equalsIgnoreCase(str2);
+        } catch (e) {
+            try {
+                return str1.toLowerCase() == str2.toLowerCase();
+            } catch (e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @function say
      * @export $
@@ -748,4 +762,5 @@
     $.getMessageWrites = getMessageWrites;
     $.sayWithTimeout = sayWithTimeout;
     $.paginateArrayDiscord = paginateArrayDiscord;
+    $.equalsIgnoreCase = equalsIgnoreCase;
 })();

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -228,7 +228,7 @@
      * @returns {boolean}
      */
     function isModv3(username, tags) {
-        return (tags != null && tags != '{}' && tags.get('user-type').length() > 0) || isModeratorCache(username.toLowerCase()) || isMod(username);
+        return (tags != null && tags != '{}' && tags.get('user-type').length() > 0) || isModeratorCache(username.toLowerCase()) || isOwner(username);
     }
 
     /**

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -228,7 +228,7 @@
      * @returns {boolean}
      */
     function isModv3(username, tags) {
-        return (tags != null && tags != '{}' && tags.get('user-type').length() > 0) || isModeratorCache(username.toLowerCase());
+        return (tags != null && tags != '{}' && tags.get('user-type').length() > 0) || isModeratorCache(username.toLowerCase()) || isMod(username);
     }
 
     /**
@@ -249,7 +249,7 @@
      * @returns {boolean}
      */
     function isSubv3(username, tags) {
-        return (tags != null && tags != '{}' && tags.get('subscriber').equals('1'));
+        return (tags != null && tags != '{}' && tags.get('subscriber').equals('1')) || isSub(username);
     }
 
     /**

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -151,7 +151,7 @@
         var idx = -1;
 
         for (var i = 0; i < list.length; i++) {
-            if (list[i] !== undefined && list[i].equalsIgnoreCase(value)) {
+            if (list[i] !== undefined && $.equalsIgnoreCase(list[i], value)) {
                 idx = i;
                 break;
             }

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -499,7 +499,7 @@
             } else
 
             // Check the command permission.
-            if ($.permCom(sender, command, subCommand) !== 0) {
+            if ($.permCom(sender, command, subCommand, event.getTags()) !== 0) {
                 $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('cmd.perm.404', (!$.subCommandExists(command, subCommand) ? $.getCommandGroupName(command) : $.getSubCommandGroupName(command, subCommand))), $.getIniDbBoolean('settings', 'permComMsgEnabled', false));
                 consoleDebug('Command !' + command + ' was not sent due to the user not having permission for it.');
                 return;

--- a/source/com/gmt2001/httpwsserver/HTTPWSServer.java
+++ b/source/com/gmt2001/httpwsserver/HTTPWSServer.java
@@ -56,6 +56,8 @@ public final class HTTPWSServer {
      */
     private Channel ch;
 
+    public boolean sslEnabled = false;
+
     /**
      * Gets the server instance.
      *
@@ -112,6 +114,7 @@ public final class HTTPWSServer {
                     tmf.init(ks);
 
                     sslCtx = SslContextBuilder.forServer(kmf).trustManager(tmf).build();
+                    sslEnabled = true;
                 }
             } else {
                 sslCtx = null;

--- a/source/com/gmt2001/httpwsserver/HTTPWSServerInitializer.java
+++ b/source/com/gmt2001/httpwsserver/HTTPWSServerInitializer.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
+import io.netty.handler.ssl.OptionalSslHandler;
 import io.netty.handler.ssl.SslContext;
 
 /**
@@ -58,14 +59,14 @@ class HTTPWSServerInitializer extends ChannelInitializer<SocketChannel> {
         ChannelPipeline pipeline = ch.pipeline();
 
         if (sslCtx != null) {
-            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+            pipeline.addLast(new HttpOptionalSslHandler(sslCtx));
         }
 
         pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new HttpObjectAggregator(65536));
         pipeline.addLast(new WebSocketServerCompressionHandler());
         pipeline.addLast(new WebSocketServerProtocolHandler("/ws", null, true, 65536, false, true));
-        pipeline.addLast(new HttpServerPageHandler());
-        pipeline.addLast(new WebSocketFrameHandler());
+        pipeline.addLast("pagehandler", new HttpServerPageHandler());
+        pipeline.addLast("wshandler", new WebSocketFrameHandler());
     }
 }

--- a/source/com/gmt2001/httpwsserver/HttpOptionalSslHandler.java
+++ b/source/com/gmt2001/httpwsserver/HttpOptionalSslHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016-2019 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.gmt2001.httpwsserver;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.ssl.OptionalSslHandler;
+import io.netty.handler.ssl.SslContext;
+
+/**
+ * Detects Non-SSL HTTP connections and activates the SSL Redirect handler, when SSL is enabled
+ *
+ * @author gmt2001
+ */
+public class HttpOptionalSslHandler extends OptionalSslHandler {
+
+    /**
+     * Default Constructor
+     */
+    HttpOptionalSslHandler(SslContext sslContext) {
+        super(sslContext);
+    }
+    
+    @Override
+    protected ChannelHandler newNonSslHandler(ChannelHandlerContext context) {
+        context.pipeline().replace("pagehandler", "httpsslredirect", new HttpSslRedirectHandler());
+        context.pipeline().replace("wshandler", "wssslerror", new WsSslErrorHandler());
+        return null;
+    }
+}

--- a/source/com/gmt2001/httpwsserver/HttpSslRedirectHandler.java
+++ b/source/com/gmt2001/httpwsserver/HttpSslRedirectHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016-2019 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.gmt2001.httpwsserver;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.sqlite.SQLiteConfig;
+
+/**
+ * Redirects HTTP requests to HTTPS, when SSL is enabled
+ *
+ * @author gmt2001
+ */
+public class HttpSslRedirectHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    /**
+     * Default Constructor
+     */
+    HttpSslRedirectHandler() {
+        super();
+    }
+
+    /**
+     * Redirects non-SSL requests to SSL
+     *
+     * @param ctx The {@link ChannelHandlerContext} of the session
+     * @param req The {@link FullHttpRequest} containing the request
+     * @throws Exception Passes any thrown exceptions up the stack
+     */
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) throws Exception {
+        if (!req.decoderResult().isSuccess()) {
+            HttpServerPageHandler.sendHttpResponse(ctx, req, HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.BAD_REQUEST, null, null));
+            return;
+        }
+        
+        String host = req.headers().get(HttpHeaderNames.HOST);
+        
+        if (host != null && !host.isBlank()) {
+            String uri = "https://" + host + req.uri();
+        
+            com.gmt2001.Console.debug.println("301: " + uri);
+
+            FullHttpResponse res = HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.MOVED_PERMANENTLY, null, null);
+        
+            res.headers().set(HttpHeaderNames.LOCATION, uri);
+        
+            HttpServerPageHandler.sendHttpResponse(ctx, req, res);
+        } else {
+            HttpServerPageHandler.sendHttpResponse(ctx, req, HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.FORBIDDEN, "HTTPS Required".getBytes(), null));
+        }
+    }
+
+    /**
+     * Handles exceptions that are thrown up the stack
+     *
+     * @param ctx The {@link ChannelHandlerContext} of the session
+     * @param cause The exception
+     */
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        com.gmt2001.Console.debug.printOrLogStackTrace(cause);
+        ctx.close();
+    }
+}

--- a/source/com/gmt2001/httpwsserver/WsSslErrorHandler.java
+++ b/source/com/gmt2001/httpwsserver/WsSslErrorHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016-2019 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.gmt2001.httpwsserver;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.HandshakeComplete;
+import org.json.JSONStringer;
+
+/**
+ * Processes WebSocket frames and passes successful ones to the appropriate registered final handler
+ *
+ * @author gmt2001
+ */
+public class WsSslErrorHandler extends SimpleChannelInboundHandler<WebSocketFrame> {
+
+    WsSslErrorHandler() {
+        super();
+    }
+
+    /**
+     * Handles incoming WebSocket frames and passes them to the appropriate {@link WsFrameHandler}
+     *
+     * @param ctx The {@link ChannelHandlerContext} of the session
+     * @param req The {@link WebSocketFrame} containing the request frame
+     * @throws Exception Passes any thrown exceptions up the stack
+     */
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
+
+    }
+
+    /**
+     * Captures {@link HandshakeComplete} events and saves the {@link WsFrameHandler} URI to the session
+     *
+     * If a handler is not available for the requested path, then {@code 404 NOT FOUND} is sent back to the client using JSON:API format
+     *
+     * @param ctx The {@link ChannelHandlerContext} of the session
+     * @param evt The event object
+     * @throws Exception Passes any thrown exceptions up the stack
+     */
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof HandshakeComplete) {
+            JSONStringer jsonObject = new JSONStringer();
+            jsonObject.object().key("errors").array().object()
+                    .key("status").value("403")
+                    .key("title").value("Forbidden")
+                    .key("detail").value("WSS Required")
+                    .endObject().endArray().endObject();
+
+            ctx.channel().writeAndFlush(new TextWebSocketFrame(jsonObject.toString()));
+            ctx.close();
+        }
+    }
+
+    /**
+     * Handles exceptions that are thrown up the stack
+     *
+     * @param ctx The {@link ChannelHandlerContext} of the session
+     * @param cause The exception
+     */
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        com.gmt2001.Console.debug.printOrLogStackTrace(cause);
+        ctx.close();
+    }
+}

--- a/source/com/gmt2001/httpwsserver/auth/WsSharedRWTokenAuthenticationHandler.java
+++ b/source/com/gmt2001/httpwsserver/auth/WsSharedRWTokenAuthenticationHandler.java
@@ -97,7 +97,7 @@ public class WsSharedRWTokenAuthenticationHandler implements WsAuthenticationHan
             try {
                 JSONObject jso = new JSONObject(tframe.text());
 
-                if (jso.has("authenticate")) {
+                if (jso.has("authenticate") || jso.has("readauth")) {
                     if (jso.getString("authenticate").equals(readWriteToken)) {
                         ctx.channel().attr(ATTR_AUTHENTICATED).set(Boolean.TRUE);
                         ctx.channel().attr(ATTR_IS_READ_ONLY).set(Boolean.FALSE);


### PR DESCRIPTION
- Fix WsSharedRWTokenAuthenticationHandler not authenticating readauth tokens
- Fix equalsIgnoreCase on undefined and Java vs JS for permissions.getKeyIndex
- Add handling for attempts to connect to HTTP/WS instead of HTTPS/WSS when SSL is enabled
- Add better response when attempting to send an authenticated request to an unauthenticated endpoint
- Fix $.permCom