### PR TITLE
Gameonly timers

### DIFF
--- a/javascript-source/lang/english/systems/systems-noticeSystem.js
+++ b/javascript-source/lang/english/systems/systems-noticeSystem.js
@@ -26,7 +26,7 @@ $.lang.register('noticehandler.notice-remove-success', 'Notice removed!');
 $.lang.register('noticehandler.notice-add-success', 'Notice added!');
 $.lang.register('noticehandler.notice-add-usage', 'Usage: !notice add (message)');
 $.lang.register('noticehandler.notice-interval-usage', 'Usage: !notice interval (interval)');
-$.lang.register('noticehandler.notice-interval-404', 'Notice interval needs to be more then 2 minutes.');
+$.lang.register('noticehandler.notice-interval-404', 'Notice interval needs to be more then 5 minutes.');
 $.lang.register('noticehandler.notice-inteval-success', 'Notice interval set!');
 $.lang.register('noticehandler.notice-req-success', 'Notice req message set!');
 $.lang.register('noticehandler.notice-req-usage', 'Usage: !notice req (req messages)');

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -73,14 +73,23 @@
             CommandEvent = Packages.tv.phantombot.event.command.CommandEvent,
             notice = $.inidb.get('notices', 'message_' + RandomNotice);
 
-        if (notice == null) {
-            return;
-        }
-
         RandomNotice++;
 
         if (RandomNotice >= numberOfNotices) {
             RandomNotice = 0;
+        }
+
+        if (notice == null) {
+            return;
+        }
+
+        if (notice.match(/\(gameonly=.*\)/g)) {
+            var game = notice.match(/\(gameonly=(.*)\)/)[1];
+
+            if (!$.getGame($.channelName).equalsIgnoreCase(game)) {
+                return sendNotice();
+            }
+            notice = $.replace(notice, notice.match(/(\(gameonly=.*\))/)[1], "");
         }
 
         if (notice.startsWith('command:')) {

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -71,25 +71,29 @@
     function sendNotice() {
         var EventBus = Packages.tv.phantombot.event.EventBus,
             CommandEvent = Packages.tv.phantombot.event.command.CommandEvent,
-            notice = $.inidb.get('notices', 'message_' + RandomNotice);
+            start = RandomNotice,
+            
+        do {
+            var notice = $.inidb.get('notices', 'message_' + RandomNotice);
 
-        RandomNotice++;
+            RandomNotice++;
 
-        if (RandomNotice >= numberOfNotices) {
-            RandomNotice = 0;
-        }
+            if (RandomNotice >= numberOfNotices) {
+                RandomNotice = 0;
+            }
+            
+            if (notice && notice.match(/\(gameonly=.*\)/g)) {
+                var game = notice.match(/\(gameonly=(.*)\)/)[1];
+                if ($.getGame($.channelName).equalsIgnoreCase(game)) {
+                    notice = $.replace(notice, notice.match(/(\(gameonly=.*\))/)[1], "");
+                } else {
+                    notice === null;
+                }
+            }
+        } while(!notice || start !== RandomNotice);
 
         if (notice == null) {
             return;
-        }
-
-        if (notice.match(/\(gameonly=.*\)/g)) {
-            var game = notice.match(/\(gameonly=(.*)\)/)[1];
-
-            if (!$.getGame($.channelName).equalsIgnoreCase(game)) {
-                return sendNotice();
-            }
-            notice = $.replace(notice, notice.match(/(\(gameonly=.*\))/)[1], "");
         }
 
         if (notice.startsWith('command:')) {

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -72,9 +72,10 @@
         var EventBus = Packages.tv.phantombot.event.EventBus,
             CommandEvent = Packages.tv.phantombot.event.command.CommandEvent,
             start = RandomNotice,
+            notice = null;
             
         do {
-            var notice = $.inidb.get('notices', 'message_' + RandomNotice);
+            notice = $.inidb.get('notices', 'message_' + RandomNotice);
 
             RandomNotice++;
 

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -73,7 +73,7 @@
             CommandEvent = Packages.tv.phantombot.event.command.CommandEvent,
             start = RandomNotice,
             notice = null;
-            
+                        
         do {
             notice = $.inidb.get('notices', 'message_' + RandomNotice);
 
@@ -88,10 +88,10 @@
                 if ($.getGame($.channelName).equalsIgnoreCase(game)) {
                     notice = $.replace(notice, notice.match(/(\(gameonly=.*\))/)[1], "");
                 } else {
-                    notice === null;
+                    notice = null;
                 }
             }
-        } while(!notice || start !== RandomNotice);
+        } while(!notice && start !== RandomNotice);
 
         if (notice == null) {
             return;


### PR DESCRIPTION
Adds in `(gameonly=)` variable to timers.  
If a notice with `(gameonly=)` is selected it will call `sendNotice()` again for the next notice the interval isn't wasted.  

![image](https://user-images.githubusercontent.com/3268576/80415357-4a7eae00-8887-11ea-8c32-d6806612cd89.png)
