### PR TITLE
Add toggle to disable checking names for quotes in the database

### DIFF
--- a/javascript-source/lang/english/systems/systems-quoteSystem.js
+++ b/javascript-source/lang/english/systems/systems-quoteSystem.js
@@ -34,3 +34,5 @@ $.lang.register('quotesystem.quotemessage.success', 'Changed the message used fo
 $.lang.register('quotesystem.searchquote.usage', 'Usage: !searchquote [text] (Must provide at least 5 characters)');
 $.lang.register('quotesystem.searchquote.404', 'No matching quotes found.');
 $.lang.register('quotesystem.searchquote.found', 'Quote IDs with matches: $1');
+$.lang.register('quotesystem.twitchnames-disabled', 'Usernames for quotes won\'t be validated');
+$.lang.register('quotesystem.twitchnames-enabled', 'Usernames for quotes will validated against users who have been in chat.');

--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -309,6 +309,22 @@
 
             $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.searchquote.found', matchingKeys.join(', ')));
         }
+
+        /**
+         * @commandpath quotetwitchnamestoggle - Toggles on and off if quote names need to have been seen in chat before
+         */
+        if (command.equalsIgnoreCase('quotetwitchnamestoggle')) {
+            var useTwitchNames = $.inidb.get('settings', 'quoteTwitchNamesToggle') == "true";
+            if (useTwitchNames) {
+                useTwitchNames = false;
+                $.inidb.set('settings', 'quoteTwitchNamesToggle', 'false');
+                $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.twitchnames-disabled'));
+            } else {
+                useTwitchNames = true;
+                $.inidb.set('settings', 'quoteTwitchNamesToggle', 'true');
+                $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.twitchnames-enabled'));
+            }
+        }
     });
 
     /**
@@ -324,5 +340,6 @@
         $.registerChatCommand('./systems/quoteSystem.js', 'editquote', 2);
         $.registerChatCommand('./systems/quoteSystem.js', 'quote');
         $.registerChatCommand('./systems/quoteSystem.js', 'quotemessage', 1);
+        $.registerChatCommand('./systems/quoteSystem.js', 'quotetwitchnamestoggle', 1);
     });
 })();

--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -192,13 +192,15 @@
                     $.say($.whisperPrefix(sender) + $.lang.get('quotesystem.add.usage2'));
                     return;
                 }
-                var target = args[0].toLowerCase();
-                if (!$.user.isKnown(target)) {
+                var useTwitchNames = ($.inidb.exists('settings', 'quoteTwitchNamesToggle')) ? $.inidb.get('settings', 'quoteTwitchNamesToggle') == "true" : true;
+                var target = useTwitchNames ? args[0].toLowerCase() : args[0].substring(0, 1).toUpperCase() + args[0].substring(1).toLowerCase();
+                if (useTwitchNames && !$.user.isKnown(target)) {
                     $.say($.whisperPrefix(sender) + $.lang.get('common.user.404', target));
                     return;
                 }
                 quote = args.splice(1).join(' ');
-                $.say($.lang.get('quotesystem.add.success', $.username.resolve(target), saveQuote(String($.username.resolve(target)), quote)));
+                var username = useTwitchNames ? $.username.resolve(target) : target;
+                $.say($.lang.get('quotesystem.add.success', username, saveQuote(String(username), quote)));
                 $.log.event(sender + ' added a quote "' + quote + '".');
                 return;
             }

--- a/resources/web/panel/js/pages/quotes/quotes.js
+++ b/resources/web/panel/js/pages/quotes/quotes.js
@@ -203,13 +203,21 @@ $(function() {
 
     // Quotes settings button.
     $('#quote-settings-button').on('click', function() {
-        socket.getDBValue('get_quote_settings', 'settings', 'quoteMessage', function(e) {
+        socket.getDBValues('get_quote_settings', {
+            tables: ['settings', 'settings'],
+            keys: ['quoteMessage', 'quoteTwitchNamesToggle']
+        }, true, function(e) {
             helpers.getModal('quote-settings', 'Quote Settings', 'Save', $('<form/>', {
                 'role': 'form'
             })
             // Quote input.
-            .append(helpers.getInputGroup('quote-msg', 'text', 'Quote Response', '', helpers.getDefaultIfNullOrUndefined(e.settings, '[(id)] "(quote)", by (user) ((date))'), 'Message said in chat when someone uses the quote command. Tags: (id), (quote), (user), (game) and (date)')), function() {// Callback once we click the save button.
-                let quoteMsg = $('#quote-msg');
+            .append(helpers.getInputGroup('quote-msg', 'text', 'Quote Response', '', helpers.getDefaultIfNullOrUndefined(e.settings, '[(id)] "(quote)", by (user) ((date))'),
+                'Message said in chat when someone uses the quote command. Tags: (id), (quote), (user), (game) and (date)'))
+            .append(helpers.getDropdownGroup('quote-twitch-names-toggle', 'Force Twitch Names', (e['quoteTwitchNamesToggle'] !== 'false' ? 'Yes' : 'No'), ['Yes', 'No'],
+                'If names for quotes should be validated against Twitch usernames. If not, names can be anything.')),
+            function() {// Callback once we click the save button.
+                let quoteMsg = $('#quote-msg'),
+                    quoteTwitchNamesToggle = $('#quote-twitch-names-toggle').find(':selected').text() === 'Yes';
 
                 // Handle each input to make sure they have a value.
                 switch (false) {
@@ -217,7 +225,11 @@ $(function() {
                         break;
                     default:
                         // Add quote.
-                        socket.updateDBValue('get_quote_settings_update', 'settings', 'quoteMessage', quoteMsg.val(), function() {
+                        socket.updateDBValues('get_quote_settings_update', {
+                            tables: ['settings', 'settings'],
+                            keys: ['quoteMessage', "quoteTwitchNamesToggle"],
+                            values: [quoteMsg.val(), quoteTwitchNamesToggle]
+                        }, function() {
                             // Close the modal.
                             $('#quote-settings').modal('hide');
                             // Alert the user.


### PR DESCRIPTION
Adds dropdown in the quote settings to disable strict checking of usernames. 
When disabled allows for any name to be used.  
Defaults to true 
![image](https://user-images.githubusercontent.com/3268576/80429881-f3d29d80-88a1-11ea-93b8-a011e5f806bf.png)
![image](https://user-images.githubusercontent.com/3268576/80429791-c128a500-88a1-11ea-9528-66c49abbb76f.png)
