### PR TITLE
Improve discord moderation cleanup error handling

### DIFF
--- a/javascript-source/discord/core/moderation.js
+++ b/javascript-source/discord/core/moderation.js
@@ -635,22 +635,24 @@
              * @discordcommandpath moderation cleanup [channel] [amount] - Will delete that amount of messages for that channel.
              */
             if (action.equalsIgnoreCase('cleanup')) {
+                var resolvedChannel = null;
                 if (subAction === undefined || (actionArgs == undefined || isNaN(parseInt(actionArgs)))) {
                     $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('moderation.cleanup.usage'));
                     return;
-                } else if (parseInt(actionArgs) > 10000 || parseInt(actionArgs) < 1) {
-                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('moderation.cleanup.err'));
+                } else if (parseInt(actionArgs) > 10000 || parseInt(actionArgs) < 2) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('moderation.cleanup.err.amount'));
                     return;
                 }
 
                 if (subAction.match(/<#\d+>/)) {
-                    subAction = $.discordAPI.getChannelByID(subAction.match(/<#(\d+)>/)[1]);
-                    if (subAction == null) {
-                        return;
-                    }
+                    resolvedChannel = $.discordAPI.getChannelByID(subAction.match(/<#(\d+)>/)[1]);
+                }
+                if (resolvedChannel == null) {
+                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('moderation.cleanup.err.unknownchannel', subAction));
+                    return;
                 }
 
-                $.discordAPI.bulkDelete(subAction, parseInt(actionArgs));
+                $.discordAPI.bulkDelete(resolvedChannel, parseInt(actionArgs));
 
                 $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('moderation.cleanup.done', actionArgs));
             }

--- a/javascript-source/lang/english/discord/core/core-moderation.js
+++ b/javascript-source/lang/english/discord/core/core-moderation.js
@@ -51,7 +51,8 @@ $.lang.register('moderation.whitelist.remove.success', 'Phrase or username remov
 $.lang.register('moderation.whitelist.list.404', 'The whitelist is empty.');
 $.lang.register('moderation.whitelist.list', 'Whitelist: ```$1```');
 $.lang.register('moderation.cleanup.usage', 'Usage: !moderation cleanup [channel] [amount]');
-$.lang.register('moderation.cleanup.err', 'You can only delete 1 to 10000 messages.');
+$.lang.register('moderation.cleanup.err.amount', 'You can only delete 2 to 10000 messages.');
+$.lang.register('moderation.cleanup.err.unknownchannel', 'Unknown channel: $1. Try discord\'s auto-completion.');
 $.lang.register('moderation.cleanup.failed', 'Failed to perform bulk message deletion: Currently deleting messages.');
 $.lang.register('moderation.cleanup.failed.err', 'Failed to perform bulk message deletion.');
 $.lang.register('moderation.cleanup.done', 'Deleted $1 messages!');


### PR DESCRIPTION
Fixes:
 * bot would silently fail if channel is given but unknown (or in wrong format)
 * `discordAPI.bulkDelete` expects 2 or more messages (not 1 or more)

WIP: couldn't fully test yet because `discordAPI.bulkDelete` seems not to work https://community.phantom.bot/t/discord-moderation-cleanup-is-not-working