### PR TITLE
Add case matching option to keyword system

### DIFF
--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -877,9 +877,9 @@
         $.inidb.set('updates', 'installedv3.0.1', 'true');
     }
 
-    /* version 3.2 updates */
-    if (!$.inidb.exists('updates', 'installedv3.2') || $.inidb.get('updates', 'installedv3.2') != 'true') {
-        $.consoleLn('Starting PhantomBot update 3.2 updates...');
+    /* version 3.3.0 updates */
+    if (!$.inidb.exists('updates', 'installedv3.3.0') || $.inidb.get('updates', 'installedv3.3.0') != 'true') {
+        $.consoleLn('Starting PhantomBot update 3.3.0 updates...');
 
         $.consoleLn('Updating keywords...');
         var keys = $.inidb.GetKeyList('keywords', ''),
@@ -917,8 +917,8 @@
             $.inidb.set('keywords', newKeywords[i].key, JSON.stringify(newKeywords[i].json));
         }
 
-        $.consoleLn('PhantomBot update 3.2 completed!');
-        $.inidb.set('updates', 'installedv3.2', 'true');
+        $.consoleLn('PhantomBot update 3.3.0 completed!');
+        $.inidb.set('updates', 'installedv3.3.0', 'true');
     }
 
     /**

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -877,9 +877,9 @@
         $.inidb.set('updates', 'installedv3.0.1', 'true');
     }
 
-    /* version 3.1.3 updates */
-    if (!$.inidb.exists('updates', 'installedv3.1.3') || $.inidb.get('updates', 'installedv3.1.3') != 'true') {
-        $.consoleLn('Starting PhantomBot update 3.1.3 updates...');
+    /* version 3.2 updates */
+    if (!$.inidb.exists('updates', 'installedv3.2') || $.inidb.get('updates', 'installedv3.2') != 'true') {
+        $.consoleLn('Starting PhantomBot update 3.2 updates...');
 
         $.consoleLn('Updating keywords...');
         var keys = $.inidb.GetKeyList('keywords', ''),
@@ -917,8 +917,8 @@
             $.inidb.set('keywords', newKeywords[i].key, JSON.stringify(newKeywords[i].json));
         }
 
-        $.consoleLn('PhantomBot update 3.1.3 completed!');
-        $.inidb.set('updates', 'installedv3.1.3', 'true');
+        $.consoleLn('PhantomBot update 3.2 completed!');
+        $.inidb.set('updates', 'installedv3.2', 'true');
     }
 
     /**

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -877,6 +877,50 @@
         $.inidb.set('updates', 'installedv3.0.1', 'true');
     }
 
+    /* version 3.1.3 updates */
+    if (!$.inidb.exists('updates', 'installedv3.1.3') || $.inidb.get('updates', 'installedv3.1.3') != 'true') {
+        $.consoleLn('Starting PhantomBot update 3.1.3 updates...');
+
+        $.consoleLn('Updating keywords...');
+        var keys = $.inidb.GetKeyList('keywords', ''),
+            newKeywords = [],
+            key,
+            json,
+            i,
+            strippedKeys = {};
+
+        for (i = 0; i < keys.length; i++) {
+            key = keys[i];
+            json = JSON.parse($.inidb.get('keywords', key));
+            if (json.isRegex) {
+                json.isCaseSensitive = true;
+                key = key.replace('regex:', '');
+                json.keyword = json.keyword.replace('regex:', '');
+            } else {
+                json.isCaseSensitive = false;
+            }
+            if (strippedKeys.hasOwnProperty(key)) {
+                throw 'Could not update keywords list. The keyword "' +  key +
+                      '" exists both as regex and as plain keyword. ' +
+                      "Please resolve the conflict and restart phantombot.";
+            }
+            strippedKeys[key] = true;
+            newKeywords.push({
+                key: key,
+                json: json
+            });
+        }
+
+        $.inidb.RemoveFile('keywords');
+
+        for (i = 0; i < newKeywords.length; i++) {
+            $.inidb.set('keywords', newKeywords[i].key, JSON.stringify(newKeywords[i].json));
+        }
+
+        $.consoleLn('PhantomBot update 3.1.3 completed!');
+        $.inidb.set('updates', 'installedv3.1.3', 'true');
+    }
+
     /**
      * @function getTableContents
      * @param {string} tableName

--- a/javascript-source/handlers/keywordHandler.js
+++ b/javascript-source/handlers/keywordHandler.js
@@ -32,7 +32,7 @@
 
             if (json.isRegex) {
                 try {
-                    json.regexKey = new RegExp(json.keyword.replace('regex:', ''));
+                    json.regexKey = new RegExp(json.keyword, json.isCaseSensitive ? '' : 'i');
                 } catch (ex) {
                     $.log.error('Bad regex detected in keyword [' + keys[i] + ']: ' + ex.message);
                     continue;
@@ -47,10 +47,27 @@
      * @event ircChannelMessage
      */
     $.bind('ircChannelMessage', function(event) {
+        function executeKeyword(json, event) {
+            // Make sure the keyword isn't on cooldown.
+            if ($.coolDownKeywords.get(json.keyword, sender) > 0) {
+                return;
+            }
+            // If the keyword is a command, we need to send that command.
+            else if (json.response.startsWith('command:')) {
+                $.command.run(sender, json.response.substring(8), '', event.getTags());
+            }
+            // Keyword just has a normal response.
+            else {
+                json.response = $.replace(json.response, '.*\(keywordcount\s(.*)\).*', '');
+                json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + json.keyword + ')');
+                $.say($.tags(event, json.response, false));
+            }
+        }
+
         var message = event.getMessage(),
             sender = event.getSender(),
-            messageParts = message.toLowerCase().split(' '),
-            str = '',
+            messagePartsLower = message.toLowerCase().split(' '),
+            messageParts = message.split(' '),
             json;
 
         // Don't say the keyword if someone tries to remove it.
@@ -63,42 +80,22 @@
 
             if (json.isRegex) {
                 if (json.regexKey.test(message)) {
-                    // Make sure the keyword isn't on cooldown.
-                    if ($.coolDownKeywords.get(json.keyword, sender) > 0) {
-                        return;
-                    }
-                    // If the keyword is a command, we need to send that command.
-                    else if (json.response.startsWith('command:')) {
-                        $.command.run(sender, json.response.substring(8), '', event.getTags());
-                    }
-                    // Keyword just has a normal response.
-                    else {
-                        json.response = $.replace(json.response, '.*\(keywordcount\s(.*)\).*', '');
-                        json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + json.keyword + ')');
-                        $.say($.tags(event, json.response, false));
-                    }
+                    executeKeyword(json, event);
                     break;
                 }
             } else {
-                for (var idx = 0; idx < messageParts.length; idx++) {
+                var str = '',
+                  caseAdjustedMessageParts = messageParts;
+                if (!json.isCaseSensitive) {
+                    json.keyword = json.keyword.toLowerCase();
+                    caseAdjustedMessageParts = messagePartsLower;
+                }
+                for (var idx = 0; idx < caseAdjustedMessageParts.length; idx++) {
                     // Create a string to match on the keyword.
-                    str += (messageParts[idx] + ' ');
+                    str += (caseAdjustedMessageParts[idx] + ' ');
                     // Either match on the exact word or phrase if it contains it.
-                    if ((json.keyword.includes(' ') && str.includes(json.keyword)) || messageParts[idx].equalsIgnoreCase(json.keyword)) {
-                        // Make sure the keyword isn't on cooldown.
-                        if ($.coolDownKeywords.get(json.keyword, sender) > 0) {
-                            return;
-                        }
-                        // If the keyword is a command, we need to send that command.
-                        else if (json.response.startsWith('command:')) {
-                            $.command.run(sender, json.response.substring(8), '', event.getTags());
-                        }
-                        // Keyword just has a normal response.
-                        else {
-                            json.response = $.replace(json.response, '.*\(keywordcount\s(.*)\).*', '');
-                            json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + json.keyword + ')');
-                            $.say($.tags(event, json.response, false));
-                        }
+                    if ((json.keyword.includes(' ') && str.includes(json.keyword)) || (caseAdjustedMessageParts[idx] + '') === (json.keyword + '')) {
+                        executeKeyword(json, event);
                         break;
                     }
                 }
@@ -131,22 +128,40 @@
              * @commandpath keyword add [keyword] [response] - Adds a keyword and a response, use regex: at the start of the response to use regex.
              */
             if (action.equalsIgnoreCase('add')) {
-                if (actionArgs === undefined) {
+                var isRegex = false,
+                    isCaseSensitive = false,
+                    keyword = null,
+                    response = null;
+
+                for (var i = 1; i < args.length; i++) {
+                    if (keyword == null) {
+                        if (args[i].equalsIgnoreCase('--regex')) {
+                            isRegex = true;
+                        } else if (args[i].equalsIgnoreCase('--case-sensitive')) {
+                            isCaseSensitive = true;
+                        } else {
+                            keyword = args[i] + '';
+                        }
+                    } else {
+                        response = args.splice(i).join(' ');
+                        break;
+                    }
+                }
+
+                if (response == null) {
                     $.say($.whisperPrefix(sender) + $.lang.get('keywordhandler.add.usage'));
                     return;
                 }
 
-                var response = args.splice(2).join(' ');
-                subAction = subAction.toLowerCase();
-
                 var json = JSON.stringify({
-                    keyword: (args[1] + ''),
+                    keyword: keyword,
                     response: response,
-                    isRegex: subAction.startsWith('regex:')
+                    isRegex: isRegex,
+                    isCaseSensitive: isCaseSensitive
                 });
 
-                $.setIniDbString('keywords', subAction, json);
-                $.say($.whisperPrefix(sender) + $.lang.get('keywordhandler.keyword.added', (args[1] + '')));
+                $.setIniDbString('keywords', keyword, json);
+                $.say($.whisperPrefix(sender) + $.lang.get('keywordhandler.keyword.added', keyword));
                 loadKeywords();
             }
 

--- a/javascript-source/lang/english/handlers/handlers-keywordHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-keywordHandler.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$.lang.register('keywordhandler.add.usage', 'Usage: !keyword add [keyword / regex:keyword] [response]');
+$.lang.register('keywordhandler.add.usage', 'Usage: !keyword add [flags] [keyword] [response]. Flags can by empty or any combination of "--regex", "--case-sensitive".');
 $.lang.register('keywordhandler.keyword.404', 'That keyword does not exist.');
 $.lang.register('keywordhandler.keyword.added', 'keyword "$1" added!');
 $.lang.register('keywordhandler.keyword.removed', 'keyword "$1" has been removed!');

--- a/resources/web/panel/js/pages/keywords/keywords.js
+++ b/resources/web/panel/js/pages/keywords/keywords.js
@@ -32,7 +32,7 @@ $(run = function() {
                 let json = JSON.parse(results[i].value);
 
                 tableData.push([
-                    json.keyword.replace('regex:', ''),
+                    json.keyword,
                     json.response,
                     $('<div/>', {
                         'class': 'btn-group'
@@ -117,9 +117,12 @@ $(run = function() {
                     })
                     // Append a text box for keyword
                     .append(helpers.getTextAreaGroup('keyword-keyword', 'text', 'Keyword', '',
-                        e.keywords.keyword.replace('regex:', ''), 'Keyword that can trigger a response.', true)
+                        e.keywords.keyword, 'Keyword that can trigger a response.', true)
                         // Append checkbox for if the keyword is regex.
-                        .append(helpers.getCheckBox('keyword-regex', e.keywords.isRegex, 'Regex', 'If the keyword is using regex.')))
+                        .append(helpers.getCheckBox('keyword-regex', e.keywords.isRegex, 'Regex', 'If the keyword is using regex.'))
+                        // Append checkbox for it the keyword should be matched case-sensitive
+                        .append(helpers.getCheckBox('keyword-case-sensitive', e.keywords.isCaseSensitive, 'Case-Sensitive', 'If the keyword/regex should only match if the capitalization matches.'))
+                    )
                     // Append a text box for the keyword response.
                     .append(helpers.getTextAreaGroup('keyword-response', 'text', 'Response', '', e.keywords.response, 'Response of the keyword.'))
                     // Add an advance section that can be opened with a button toggle.
@@ -139,6 +142,7 @@ $(run = function() {
                         let keywordKey = $('#keyword-keyword'),
                             keywordResponse = $('#keyword-response'),
                             isRegex = $('#keyword-regex').is(':checked'),
+                            isCaseSensitive = $('#keyword-case-sensitive').is(':checked'),
                             keywordCooldown = $('#cooldown-count'),
                             keywordCount = $('#keyword-count');
 
@@ -156,11 +160,12 @@ $(run = function() {
                                     // Update the values.
                                     socket.updateDBValues('edit_keyword', {
                                         tables: ['keywords', 'coolkey'],
-                                        keys: [(isRegex ? 'regex:' : '') + keywordKey.val(), (isRegex ? 'regex:' : '') + keywordKey.val()],
+                                        keys: [keywordKey.val(), keywordKey.val()],
                                         values: [JSON.stringify({
-                                            keyword: (isRegex ? 'regex:' : '') + keywordKey.val(),
+                                            keyword: keywordKey.val(),
                                             response: keywordResponse.val(),
                                             isRegex: isRegex,
+                                            isCaseSensitive: isCaseSensitive,
                                             count: keywordCount.val()
                                         }), keywordCooldown.val()]
                                     }, function() {
@@ -170,6 +175,8 @@ $(run = function() {
                                             t.parents('tr').find('td:eq(0)').text(keywordKey.val());
                                             // Update the table.
                                             t.parents('tr').find('td:eq(1)').text(keywordResponse.val());
+                                            // Update the edit and delete buttons
+                                            t.parents('tr').find('td:eq(2) button.btn').data('keyword', keywordKey.val());
                                             // Close the modal.
                                             $('#edit-keyword').modal('hide');
                                             // Alert the user.
@@ -203,7 +210,10 @@ $(function() {
         // Append a text box for keyword
         .append(helpers.getTextAreaGroup('keyword-keyword', 'text', 'Keyword', 'PhantomBot', '', 'Keyword that can trigger a response.', true)
             // Append checkbox for if the keyword is regex.
-            .append(helpers.getCheckBox('keyword-regex', false, 'Regex', 'If the keyword is using regex.')))
+            .append(helpers.getCheckBox('keyword-regex', false, 'Regex', 'If the keyword is using regex.'))
+            // Append checkbox for it the keyword should be matched case-sensitive
+            .append(helpers.getCheckBox('keyword-case-sensitive', false, 'Case-Sensitive', 'If the keyword/regex should only match if the capitalization matches.'))
+        )
         // Append a text box for the keyword response.
         .append(helpers.getTextAreaGroup('keyword-response', 'text', 'Response',
             'Checkout PhantomBot, it\'s a great free and open source bot!', '', 'Response of the keyword.'))
@@ -224,6 +234,7 @@ $(function() {
             let keywordKey = $('#keyword-keyword'),
                 keywordResponse = $('#keyword-response'),
                 isRegex = $('#keyword-regex').is(':checked'),
+                isCaseSensitive = $('#keyword-case-sensitive').is(':checked'),
                 keywordCooldown = $('#cooldown-count'),
                 keywordCount = $('#keyword-count');
 
@@ -239,11 +250,12 @@ $(function() {
                     // Update the values.
                     socket.updateDBValues('add_keyword', {
                         tables: ['keywords', 'coolkey'],
-                        keys: [(isRegex ? 'regex:' : '') + keywordKey.val(), (isRegex ? 'regex:' : '') + keywordKey.val()],
+                        keys: [keywordKey.val(), keywordKey.val()],
                         values: [JSON.stringify({
-                            keyword: (isRegex ? 'regex:' : '') + keywordKey.val(),
+                            keyword: keywordKey.val(),
                             response: keywordResponse.val(),
                             isRegex: isRegex,
+                            isCaseSensitive: isCaseSensitive,
                             count: keywordCount.val()
                         }), keywordCooldown.val()]
                     }, function() {


### PR DESCRIPTION
This PR solves two minor bugs and adds one feature (all closely related, that's why it's one PR):
 - the temporal variable `str` in `keywordHandler.js` was never cleared. So `str.includes(…` would get slower, the more keywords there were.
 - `resources/web/panel/js/pages/keywords/keywords.js` would throw an error if you changed the keyword (i.e. key) of an existing keyword and tried to edit it again without reloading
 - It gives the user the option to choose, both for regex and regular keywords, if the should be match case sensitive or insensitive.

Problems/things to discuss:
 - This is not backwards compatible. It will break existing regex keywords because:
   - I removed the `regex:` prefix from the key of regex keywords as it was redundant and I couldn't come up with a way to extend that design idea to incorporate the case sensitivity flag.
   - Regex keywords were case sensitive by default. To make it more consistent I choose to make them insensitive by default.
 - I'm not sure if I like the `--regex` and `--case-sensitive` flags the way they are. Using bash like arguments feels out of line with the rest of the bot's modules. But again, I couldn't come up with a better way of implementing this functionality in the chat interface.

Note, that all problems/discussion points only stem from the third point of things this PR solves. So even if you decide to reject the PR, please consider working in the other two minor fixes.

I've tested the matching and the chat interface in my twitch chat and it worked flawlessly. The panel controls also worked as they are supposed to.