### PR TITLE
$.discord.addRole -> $.discord.setRole

### DIFF
--- a/javascript-source/discord/commands/customCommands.js
+++ b/javascript-source/discord/commands/customCommands.js
@@ -157,7 +157,7 @@
         }
 
         if (s.match(/\(setrole ([\w\W\s]+), ([\w\W\s]+)/)) {
-            $.discord.addRole(s.match(/\(setrole ([\w\W\s]+), ([\w\W\s]+)\)/)[2], s.match(/\(setrole ([\w\W\s]+), ([\w\W\s]+)\)/)[1]);
+            $.discord.setRole(s.match(/\(setrole ([\w\W\s]+), ([\w\W\s]+)\)/)[2], s.match(/\(setrole ([\w\W\s]+), ([\w\W\s]+)\)/)[1]);
 
             s = $.replace(s, s.match(/\(setrole ([\w\W\s]+), ([\w\W\s]+)\)/)[0], '');
             if (s.length === 0) {


### PR DESCRIPTION
As written here: https://community.phantom.bot/t/role-management-does-not-work/8710
`$.discord.addRole` does not exists and causes an error.