### PR TITLE
WIP: Robsdedude fix custom command random variable

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -128,7 +128,9 @@
                 var path = RegExp.$2;
                 var path2 = RegExp.$1;
                 var results = $.arrayShuffle($.readFile('./addons/' + path.trim().replace(/\.\./g, '')));
-                message = $.replace(message, '(' + path2.trim(), $.randElement(results));
+                message = $.replaceFunc(message, '(' + path2.trim(), function() {
+                    return $.randElement(results);
+                });
             }
         }
 
@@ -271,7 +273,9 @@
 
         if (message.match(/\(random\)/g)) {
             try {
-                message = $.replace(message, '(random)', $.username.resolve($.randElement($.users)));
+                message = $.replaceFunc(message, '(random)', function () {
+                    return $.username.resolve($.randElement($.users));
+                });
             } catch (ex) {
                 message = $.replace(message, '(random)', $.username.resolve($.botName));
             }
@@ -279,7 +283,9 @@
 
         if (message.match(/\(randomrank\)/g)) {
             try {
-                message = $.replace(message, '(randomrank)', $.resolveRank($.randElement($.users)));
+                message = $.replaceFunc(message, '(randomrank)', function () {
+                    return $.resolveRank($.randElement($.users));
+                });
             } catch (ex) {
                 message = $.replace(message, '(randomrank)', $.resolveRank($.botName));
             }
@@ -301,13 +307,19 @@
             message = $.replace(message, '(pay)', String($.inidb.exists('paycom', event.getCommand()) ? $.getPointsString($.inidb.get('paycom', event.getCommand())) : $.getPointsString(0)));
         }
 
-        if (message.match(/\(#\)/g)) {
-            message = $.replace(message, '(#)', String($.randRange(1, 100)));
+        if (message.match(/\(#\)/)) {
+            message = $.replaceFunc(s, '(#)', function () {
+                return String($.randRange(1, 100));
+            });
         }
 
-        if (message.match(/\(# (\d+),(\d+)\)/g)) {
-            var mat = message.match(/\(# (\d+),(\d+)\)/);
-            message = $.replace(message, mat[0], String($.randRange(parseInt(mat[1]), parseInt(mat[2]))));
+        if (message.match(/\(# (\d+),(\d+)\)/)) {
+            var mat = message.match(/\(# (\d+),(\d+)\)/),
+                min = parseInt(mat[1]),
+                max = parseInt(mat[2]);
+            message = $.replaceFunc(message, mat[0], function () {
+                return String($.randRange(min, max));
+            });
         }
 
         if (message.match(/\(viewers\)/g)) {

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -695,12 +695,32 @@
      *
      * @function replace
      * @export $
-     * @param {string}
+     * @param {string} str: the string in which to replace all matches
+     * @param {string} from: the matches to look for in str
+     * @param {string} to: what to replace the matches with
      */
     function replace(str, from, to) {
         var idx, parts = [], l = from.length, prev = 0;
         for (; ~(idx = str.indexOf(from, prev)); ) {
             parts.push(str.slice(prev, idx), to);
+            prev = idx + l;
+        }
+        parts.push(str.slice(prev));
+        return parts.join('');
+    }
+
+
+    /**
+     * @function replaceFunc
+     * @export $
+     * @param {string} str: the string in which to replace the first matche
+     * @param {string} from: the matches to look for in str
+     * @param {function} toFunc: function to return what to replace the matches with (gets called for each match).
+     */
+    function replaceFunc(str, from, toFunc) {
+        var idx, parts = [], l = from.length, prev = 0;
+        for (; ~(idx = str.indexOf(from, prev)); ) {
+            parts.push(str.slice(prev, idx), toFunc());
             prev = idx + l;
         }
         parts.push(str.slice(prev));
@@ -754,6 +774,7 @@
     $.trueRandElement = trueRandElement;
     $.trueRandRange = trueRandRange;
     $.paginateArray = paginateArray;
+    $.replaceFunc = replaceFunc;
     $.replace = replace;
     $.userPrefix = userPrefix;
     $.reloadMisc = reloadMisc;

--- a/javascript-source/discord/commands/customCommands.js
+++ b/javascript-source/discord/commands/customCommands.js
@@ -81,16 +81,22 @@
         }
 
         if (s.match(/\(random\)/)) {
-            s = $.replace(s, '(random)', $.discord.username.random());
+            s = $.replaceFunc(s, '(random)', $.discord.username.random);
         }
 
         if (s.match(/\(#\)/)) {
-            s = $.replace(s, '(#)', $.randRange(1, 100).toString());
+            s = $.replaceFunc(s, '(#)', function () {
+                return $.randRange(1, 100).toString();
+            });
         }
 
         if (s.match(/\(# (\d+),(\d+)\)/g)) {
-            var mat = s.match(/\(# (\d+),(\d+)\)/);
-            s = $.replace(s, mat[0], $.randRange(parseInt(mat[1]), parseInt(mat[2])).toString());
+            var mat = s.match(/\(# (\d+),(\d+)\)/),
+                min = parseInt(mat[1]),
+                max = parseInt(mat[2]);
+            s = $.replaceFunc(s, mat[0], function () {
+                return $.randRange(min, max).toString();
+            });
         }
 
         if (s.match(/\(status\)/)) {
@@ -126,7 +132,9 @@
         if (s.match(/\(readfilerand/)) {
             if (s.search(/\((readfilerand ([^)]+)\))/g) >= 0) {
                 var results = $.readFile('./addons/' + RegExp.$2);
-                s = $.replace(s, '(' + RegExp.$1, $.randElement(results));
+                s = $.replaceFunc(s, '(' + RegExp.$1, function () {
+                    return $.randElement(results);
+                });
             }
         }
 


### PR DESCRIPTION
Currently, if you have multiple random variables in you custom commands (e.g. `(#)` or `(# 1,2)`) phantom bot only draws one random number per same random variable string. 

Example: Custom command `(# 1,6) | (# 1,6) | (# 1,7)` will result in `a | a | b` where `a` is one random number from 1 to 6 and `b` another random number from 1 to 7.