### PR TITLE
Fix lang variable for succesful Discord account link

### DIFF
--- a/javascript-source/discord/core/accountLink.js
+++ b/javascript-source/discord/core/accountLink.js
@@ -121,7 +121,7 @@
                     if (accounts[keys[i]].code == code && (accounts[keys[i]].time + 6e5) > $.systemTime()) {
                         $.inidb.set('discordToTwitch', keys[i], sender.toLowerCase());
 
-                        $.discordAPI.sendPrivateMessage(accounts[keys[i]].userObj, $.lang.get('discord.accountlink.link.success', $.channelName));
+                        $.discordAPI.sendPrivateMessage(accounts[keys[i]].userObj, $.lang.get('discord.accountlink.link.success', sender.toLowerCase()));
                         delete accounts[keys[i]];
                         return;
                     }


### PR DESCRIPTION
The variable `$1` in `discord.accountlink.link.success` in the language should contain the Twitch channel it was linked to. Instead, it contains the channel name of the bot's owner.