### PR TITLE
Feature: add caddy as reverse proxy and https certificate manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ lib/
 
 # Allow java-runtime files
 !resources/java-runtime*/*
+
+
+# docker compose config
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,14 +37,14 @@ services:
     environment:
       # ------ Override any botlogin.txt variable here, with the PHANTOMBOT_ prefix
       # Twitch bot user (Required)
-      - PHANTOMBOT_USER=
+      PHANTOMBOT_USER:
       # Twitch bot user OAuth token (https://twitchapps.com/tmi/) (Required)
-      - PHANTOMBOT_OAUTH=
+      PHANTOMBOT_OAUTH:
       # Twitch caster channel OAuth token (https://phantombot.tv/oauth/)
-      # - PHANTOMBOT_APIOAUTH=
+      PHANTOMBOT_APIOAUTH:
       # Twitch caster channel (Required)
-      - PHANTOMBOT_CHANNEL=
+      PHANTOMBOT_CHANNEL:
       # Webinterface username
-      #- PHANTOMBOT_PANELUSER=
+      PHANTOMBOT_PANELUSER:
       # Webinterface password
-      #- PHANTOMBOT_PANELPASSWORD=
+      PHANTOMBOT_PANELPASSWORD:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,27 @@
 
 version: '3'
 services:
+
+  caddy:
+    container_name: caddy
+    image: caddy:latest
+    ports:
+      - 443:443
+    restart: always
+    depends_on:
+      - phantombot
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    command: [
+      "caddy",
+      "reverse-proxy",
+      "--from",
+      "${DOMAIN:-localhost}",
+      "--to",
+      "phantombot-nightly:25000"
+    ]
+
   phantombot:
     # build: 
     #   context: .
@@ -48,3 +69,7 @@ services:
       PHANTOMBOT_PANELUSER:
       # Webinterface password
       PHANTOMBOT_PANELPASSWORD:
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,6 @@ services:
     #   dockerfile: Dockerfile
     container_name: phantombot-nightly
     image: gmt2001/phantombot-nightly:latest
-    ports:
-      - "25000:25000"
     restart: always
     volumes:
       - /opt/PhantomBot/addons

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
     # build: 
     #   context: .
     #   dockerfile: Dockerfile
+    #   args:
+    #     PROJECT_VERSION: $PROJECT_VERSION
+    #     TARGETPLATFORM: ${TARGETPLATFORM:-linux/amd64}
     container_name: phantombot-nightly
     image: gmt2001/phantombot-nightly:latest
     restart: always


### PR DESCRIPTION
Caddy server is an open source reverse proxy / http server that comes with the convenient feature of taking care of certificates.
This change adds caddy to docker-compose.yml and configures it as reverse proxy that creates self-signed certificates for the domain set in `.env` file.

I also changed the environment section of the phantombot service to allow overrides from `.env` instead of setting those values directly in `docker-compose.yml`.


**How To Use**

* create a new file `.env` in the root of your local PhantomBot repository clone:
  ```
  PHANTOMBOT_CHANNEL=test
  PHANTOMBOT_USER=test
  PHANTOMBOT_OAUTH=oauth:testTestTest
  PHANTOMBOT_APIOAUTH=oauth:testTestTestTestTest
  PHANTOMBOT_PANELUSER=myuser
  PHANTOMBOT_PANELPASSWORD=mypassword
  PHANTOMBOT_DISCORD_TOKEN=testTestTestTestTest.testTestTestTestTest
  DOMAIN=phantombot.local
  ```
  and change its content to the real values for your own bot (how you get them is explained in `docker-compose.yml` for example)
* make sure the value you set for `DOMAIN=` is really working - either by adding it to `/etc/hosts` for IP `127.0.0.1` or you simply use `DOMAIN=localhost` or even getting yourself a real domain with a real server
* run `docker-compose up -d`
* access your phantombot at `https://$DOMAIN/` - you just need to accept the self-signed certificate


**Build dockerimage locally**

* add following entries to the end of `.env`
  ```
  TARGETPLATFORM=linux/amd64
  PROJECT_VERSION=3.2.1
  ```
* un-comment the build section of phantombot service in the `docker-compose.yml` (do not break indentation)
* run `docker-compose build --no-cache --pull && docker-compose up -d`
