### PR TITLE
Bug-Fix: Correcting relative links in /obs/poll-chart/index.html

### DIFF
--- a/resources/web/obs/poll-chart/index.html
+++ b/resources/web/obs/poll-chart/index.html
@@ -22,7 +22,7 @@
     <!-- Load CSS for Chart.js -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.css" />
     <!-- Load our styles -->
-    <link rel="stylesheet" href="poll-chart/css/styles.css"/>
+    <link rel="stylesheet" href="css/styles.css"/>
 </head>
 
 <!-- Main body -->
@@ -44,6 +44,6 @@
     <!-- Load Bot config file -->
     <script src="/common/js/wsConfig.js"></script>
     <!-- Load our script -->
-    <script src="poll-chart/js/index.js"></script>
+    <script src="js/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit adjusts two references two incorrect references to relative resources in resources/web/obs/poll-chart/index.html
I kept the links relative rather than absolute to maintain portability of the code if it is ever relocated in the future.

Before these changes, the OBS poll-chart preview did does not work as the link to the script than handles websockets and renders the chart is broken.

I have tested this change locally and also on the main instance of my bot and found that this fixes poll-charts being displayed in OBS.
It also displays console output from websockets rather than 404'ing in chrome inspector.