### PR TITLE
Fix js string vs java string bug in link whitelist

### DIFF
--- a/javascript-source/core/chatModerator.js
+++ b/javascript-source/core/chatModerator.js
@@ -334,7 +334,7 @@
             whiteList = [];
 
         for (i = 0; i < keys.length; i++) {
-            whiteList.push(keys[i]);
+            whiteList.push(keys[i] + '');
         }
     }
 
@@ -1024,7 +1024,7 @@
                     $.say($.whisperPrefix(sender) + $.lang.get('chatmoderator.whitelist.add.usage'));
                     return;
                 }
-                var link = argString.split(' ').slice(1).join(' ').toLowerCase();
+                var link = argString.split(' ').slice(1).join(' ').toLowerCase() + '';
                 $.inidb.set('whiteList', link, 'true');
                 whiteList.push(link);
                 $.say($.whisperPrefix(sender) + $.lang.get('chatmoderator.whitelist.link.added'));


### PR DESCRIPTION
With #2221 I broke the whitelist system. Sorry. It's the old js string vs java string thing. I solved the problem by making sure only js stings are in the whitelist array now.