### PR TITLE
utf8mb4 charset for MySQL

### DIFF
--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -128,7 +128,7 @@ public class MySQLStore extends DataStore {
         fName = validateFname(fName);
 
         try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("CREATE TABLE IF NOT EXISTS phantombot_" + fName + " (section LONGTEXT, variable varchar(255) NOT NULL, value LONGTEXT, PRIMARY KEY (section(30), variable(150)));");
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS phantombot_" + fName + " (section LONGTEXT, variable varchar(255) NOT NULL, value LONGTEXT, PRIMARY KEY (section(30), variable(150))) DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;");
         } catch (SQLException ex) {
             com.gmt2001.Console.err.printStackTrace(ex);
         }


### PR DESCRIPTION
Hi,

When using MySQL datastore, if I use emojis in a command, the command isn't saved because the default charset can't handle it.

See 
![image](https://user-images.githubusercontent.com/7402764/88112030-555b8d00-cbaf-11ea-85d0-cabf96dc7d56.png)

But it's working with utf8mb4 

![image](https://user-images.githubusercontent.com/7402764/88112124-7f14b400-cbaf-11ea-8392-8c43926bd244.png)

And it's correctly reflected in phantombot interface

![image](https://user-images.githubusercontent.com/7402764/88112456-33163f00-cbb0-11ea-816e-eb05dd4fb054.png)


Also, if the database has already been created, it must be updated

```
ALTER DATABASE phantombot CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
```

```
ALTER TABLE phantombot_<table> CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
```

If the database does not exists yet, it must be created with

```
CREATE DATABASE phantombot COLLATE 'utf8mb4_unicode_ci';
```


_(please don't judge my obnoxious usage of emojis)_