### PR TITLE
Fix CustomCommands.transformers.buildArgs returning raw:true when usi…

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -126,7 +126,7 @@
                     }
                     return {
                         result: ($.equalsIgnoreCase(match[1], '=') ? '(' : '') + escapeTags(match[2]) + ($.equalsIgnoreCase(match[1], '=') ? ')' : ''),
-                        raw: true
+                        raw: $.equalsIgnoreCase(match[1], '=')
                     };
                 }
             }


### PR DESCRIPTION
…ng (1|def) tag, which could cause unintended tag parsing if there is () in the default value
