### PR TITLE
Fixed notice interval command accepting no minutes argument

### DIFF
--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -272,17 +272,17 @@
              * @commandpath notice interval [minutes] - Sets the notice interval in minutes
              */
             if (action.equalsIgnoreCase('interval')) {
-                if (args.length == 0) {
+                if (args.length < 2) {
                     $.say($.whisperPrefix(sender) + $.lang.get('noticehandler.notice-interval-usage'));
                     return;
-                } else if (parseInt(args[1]) < 5) {
+                } else if (isNaN(args[1]) || parseInt(args[1]) < 5) {
                     $.say($.whisperPrefix(sender) + $.lang.get('noticehandler.notice-interval-404'));
                     return;
                 } else {
-                    $.inidb.set('noticeSettings', 'interval', args[1]);
+                    $.inidb.set('noticeSettings', 'interval', parseInt(args[1]));
                     noticeInterval = parseInt(args[1]);
                     $.say($.whisperPrefix(sender) + $.lang.get('noticehandler.notice-inteval-success'));
-                    reloadNoticeSettings()
+                    reloadNoticeSettings();
                     return;
                 }
             }


### PR DESCRIPTION
Fixed notice interval command accepting a minutes argument that is not-a-number
closes PhantomBot/PhantomBot#2352