### PR TITLE
Added alert support to manual host handler

### DIFF
--- a/javascript-source/handlers/hostHandler.js
+++ b/javascript-source/handlers/hostHandler.js
@@ -195,7 +195,29 @@
         }
 
         if (hostToggle === true && viewers >= hostMinCount) {
-            $.say(s);
+            if (s.match(/\(alert [,.\w\W]+\)/g)) {
+                var filename = s.match(/\(alert ([,.\w\W]+)\)/)[1];
+                $.panelsocketserver.alertImage(filename);
+                s = (s + '').replace(/\(alert [,.\w\W]+\)/, '');
+                if (s == '') {
+                    return null;
+                }
+            }
+
+            if (s.match(/\(playsound\s([a-zA-Z1-9_]+)\)/g)) {
+                if (!$.audioHookExists(s.match(/\(playsound\s([a-zA-Z1-9_]+)\)/)[1])) {
+                    $.log.error('Could not play audio hook: Audio hook does not exist.');
+                    return null;
+                }
+                $.panelsocketserver.triggerAudioPanel(s.match(/\(playsound\s([a-zA-Z1-9_]+)\)/)[1]);
+                s = $.replace(s, s.match(/\(playsound\s([a-zA-Z1-9_]+)\)/)[0], '');
+                if (s == '') {
+                    return null;
+                }
+            }
+            if (s != '') {
+                $.say(s);
+            }
         }
 
         $.writeToFile(hoster + ' ', './addons/hostHandler/latestHost.txt', false);


### PR DESCRIPTION
Adds (alert) support to the host handler for manual hosts. Support was added in b675b84 for auto hosts, but not for manual hosts.

Also makes sure that if the text field is empty, the bot doesn't announce anything in chat

Before change
```
phantombot_fragforce | [09-09-2020 @ 02:25:10.071 GMT] [CHAT] Dragux just hosted with 0 viewers! (alert hello_there.gif)
phantombot_fragforce | [09-09-2020 @ 02:25:10.312 GMT] [DISCORD] [#fragforce-twitch] [EMBED] Dragux just hosted for 0 viewers!
phantombot_fragforce | [09-09-2020 @ 02:25:13.402 GMT] [CHAT] parkervcp just hosted with 0 viewers! (alert hello_there.gif)
phantombot_fragforce | [09-09-2020 @ 02:25:13.616 GMT] [DISCORD] [#fragforce-twitch] [EMBED] parkervcp just hosted for 0 viewers!
```


After Change
```
phantombot_fragforce | [09-09-2020 @ 02:28:45.401 GMT] [CHAT] LuthienAzaelia just hosted with 0 viewers!
phantombot_fragforce | [09-09-2020 @ 02:28:45.736 GMT] [DISCORD] [#fragforce-twitch] [EMBED] LuthienAzaelia just hosted for 0 viewers!
phantombot_fragforce | [09-09-2020 @ 02:28:52.453 GMT] [CHAT] AevumDecessus just hosted with 0 viewers!
phantombot_fragforce | [09-09-2020 @ 02:28:52.694 GMT] [DISCORD] [#fragforce-twitch] [EMBED] AevumDecessus just hosted for 0 viewers!
```