### PR TITLE
DelTomix_Fix_paths_to_addons_missing_leading_pwd_ref_'./'

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -813,7 +813,7 @@
                         $.inidb.set('group', spl[i], '2');
                     }
                 }
-                $.saveArray(modListUsers, 'addons/mods.txt', false);
+                $.saveArray(modListUsers, './addons/mods.txt', false);
             } else if (message.indexOf(vipMessageStart) > -1) {
                 spl = message.replace(vipMessageStart, '').split(', ');
                 vipUsers = [];
@@ -830,14 +830,14 @@
                         $.inidb.set('group', spl[i], '5');
                     }
                 }
-                $.saveArray(vipUsers, 'addons/vips.txt', false);
+                $.saveArray(vipUsers, './addons/vips.txt', false);
             } else if (message.indexOf(novipMessageStart) > -1) {
                 for (i in keys) {
                     if ($.inidb.get('group', keys[i]).equalsIgnoreCase('5')) {
                         $.inidb.del('group', keys[i]);
                     }
                 }
-                $.deleteFile('addons/vips.txt', true);
+                $.deleteFile('./addons/vips.txt', true);
             } else if (message.indexOf('specialuser') > -1) {
                 spl = message.split(' ');
                 if (spl[2].equalsIgnoreCase('subscriber')) {
@@ -848,7 +848,7 @@
                         for (var i = 0; i < subUsers.size(); i++) {
                             subsTxtList.push(subUsers.get(i));
                         }
-                        $.saveArray(subsTxtList, 'addons/subs.txt', false);
+                        $.saveArray(subsTxtList, './addons/subs.txt', false);
                     }
                 }
             }


### PR DESCRIPTION
Some saveArray targets referencing the addons directory omitted the leading present-working-directory reference './' causing the target to NOT match any validPaths[] thus blocked as invalidLocation().

These changes are trivial and I have tested them in my own running phantombot instance without issue. I'm not sure that test results are needed - but if needed let me know what I can provide.
