### PR TITLE
DelTomix_Add_Log_indications_of_blocked_file_operations

### DIFF
--- a/javascript-source/core/fileSystem.js
+++ b/javascript-source/core/fileSystem.js
@@ -44,7 +44,12 @@
     function readFile(path) {
         var lines = [];
 
-        if (!fileExists(path) || invalidLocation(path)) {
+        if (!fileExists(path)) {
+            return lines;
+        }
+
+        if (invalidLocation(path)) {
+            $.consoleLn('Blocked readFile() target outside of validPaths:' + path);
             return lines;
         }
 
@@ -69,6 +74,7 @@
      */
     function mkDir(path) {
         if (invalidLocation(path)){
+            $.consoleLn('Blocked mkDir() target outside of validPaths:' + path);
             return false;
         }
 
@@ -87,6 +93,7 @@
             pathO = new JFile(path);
 
         if (invalidLocation(file) || invalidLocation(path)) {
+            $.consoleLn('Blocked moveFile() source or target outside of validPaths:' + file + ' to ' + path);
             return;
         }
 
@@ -108,6 +115,7 @@
      */
     function saveArray(array, path, append) {
         if (invalidLocation(path)) {
+            $.consoleLn('Blocked saveArray() target outside of validPaths:' + path);
             return;
         }
 
@@ -153,6 +161,7 @@
             ps;
 
         if (invalidLocation(path)){
+            $.consoleLn('Blocked writeToFile() target outside of validPaths:' + path);
             return;
         }
 
@@ -186,6 +195,7 @@
      */
     function touchFile(path) {
         if (invalidLocation(path)) {
+            $.consoleLn('Blocked touchFile() target outside of validPaths:' + path);
             return;
         }
 
@@ -205,6 +215,7 @@
      */
     function deleteFile(path, now) {
         if (invalidLocation(path)) {
+            $.consoleLn('Blocked deleteFile() target outside of validPaths:' + path);
             return;
         }
 
@@ -228,6 +239,7 @@
      */
     function fileExists(path) {
         if (invalidLocation(path)) {
+            $.consoleLn('Blocked fileExists() target outside of validPaths:' + path);
             return false;
         }
 
@@ -248,6 +260,7 @@
      */
     function findFiles(directory, pattern) {
         if (invalidLocation(directory)) {
+            $.consoleLn('Blocked findFiles() target outside of validPaths:' + directory);
             return [];
         }
 
@@ -277,6 +290,7 @@
      */
     function isDirectory(path) {
         if (invalidLocation(path)) {
+            $.consoleLn('Blocked isDirectory() target outside of validPaths:' + path);
             return false;
         }
 
@@ -296,6 +310,7 @@
      */
     function findSize(file) {
         if (invalidLocation(file)) {
+            $.consoleLn('Blocked findSize() target outside of validPaths:' + file);
             return 0;
         }
 


### PR DESCRIPTION
This PR proposes to implement log indications of blocked file operations due to the new filesystem "jail".  

In the current implementation these fail silently with no indication that the operation has been blocked. 

By indicating blocked file access attempts in the log - it can assist in revealing mistakes in file paths, as well as alerting the administrator to potentially malicious attempts at file I/O to forbidden locations. In either case, such indications seem important.

The log entries indicate the file operation that was blocked as well as the intended path which is very convenient for quickly diagnosing behavior. In my initial testing it immediately revealed a path mistake in other PhantomBot code ( see my [PR#2395](https://github.com/PhantomBot/PhantomBot/pull/2395) )

Since this code is only called under anomalous circumstances, it would have no impact on performance or resources for normal operation. 

To test the changes a code block was temporarily added to one of my own core modules to call each file operation on a path outside of validPaths[], to ensure invocation of invalidLocation(), where each proposed log entry would be generated.  The attached file shows the code that invoked the log entries, and the resulting log output is as intended with no unexpected behavior. 

I am happy to discuss/accommodate changes if desired. 

Test code and log result;
[testAddFileBlockEntries.log](https://github.com/PhantomBot/PhantomBot/files/5350331/testAddFileBlockEntries.log)
