### PR TITLE
Remove getModuleIndex()

### DIFF
--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -1111,7 +1111,6 @@
         loadScriptRecursive: loadScriptRecursive,
         isModuleEnabled: isModuleEnabled,
         isModuleLoaded: isModuleLoaded,
-        getModuleIndex: getModuleIndex,
         getHookIndex: getHookIndex,
         loadScript: loadScript,
         getModule: getModule,

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -185,15 +185,6 @@
         }
     }
 
-    /*
-     * @function getModuleIndex
-     *
-     * @param  {String} scriptName
-     * @return {Number}
-     */
-    function getModuleIndex(scriptName) {
-        return modules.indexOf(scriptName);
-    }
 
     /*
      * @function isModuleEnabled


### PR DESCRIPTION
**javascript-source/init.js**
As modules are added as properties of the array object the array has no length, nor can indexOf find any elements and thus will always return -1.

* Removed the getModuleIndex() function
 