### PR TITLE
Allow negative arguments to randomInt

### DIFF
--- a/javascript-source/core/commandTags.js
+++ b/javascript-source/core/commandTags.js
@@ -68,7 +68,7 @@
                     result: String($.randRange(1, 100)),
                     cache: false
                 };
-            } else if ((match = args.match(/^\s(\d+),\s?(\d+)$/))) {
+            } else if ((match = args.match(/^\s(-?\d+),\s?(-?\d+)$/))) {
                 return {
                     result: String($.randRange(parseInt(match[1]), parseInt(match[2]))),
                     cache: false


### PR DESCRIPTION
Changed the Regex for randomInt to allow optional negative input, which should still be correctly parsed and accounted for by parseInt and rangeRange.

Tried my best to get test results, but following DEV-SETUP with IntelliJ was not sufficient for me and I also couldn't figure out how to write/run test cases... If a more experienced dev would like to re-implement this in a separate PR, or just build on top of this one w/ test results, that would be great. Apologies for the issues, I spent quite awhile wrangling with it and poring over the contribution docs but couldn't get anything working.