### PR TITLE
Escape keyword when auto expanding keywordcount

### DIFF
--- a/javascript-source/core/commandTags.js
+++ b/javascript-source/core/commandTags.js
@@ -28,8 +28,9 @@
 
     /*
      * @function unescapeTags
-     *
+     * @export $
      * @param {string} args
+     * @returns {string}
      */
     function escapeTags(args) {
         return args.replace(/([\\()])/g, '\\$1');
@@ -1605,9 +1606,12 @@
 
     /*
      * @function tags
-     *
+     * @export $
      * @param {string} event
      * @param {string} message
+     * @param {bool} atEnabled
+     * @param {object} localTransformers
+     * @param {bool} disableGlobalTransformers
      * @return {string}
      */
     function tags(event, message, atEnabled, localTransformers, disableGlobalTransformers) {
@@ -1693,6 +1697,12 @@
         return message;
     }
 
+    /*
+     * @function addTagTransformer
+     * @export $
+     * @param {string} tag
+     * @param {function} transformer
+     */
     function addTagTransformer(tag, transformer) {
         transformers[tag.toLowerCase()] = transformer;
     }

--- a/javascript-source/core/commandTags.js
+++ b/javascript-source/core/commandTags.js
@@ -1698,5 +1698,6 @@
     }
     
     $.tags = tags;
+    $.escapeTags = escapeTags;
     $.addTagTransformer = addTagTransformer;
 })();

--- a/javascript-source/handlers/keywordHandler.js
+++ b/javascript-source/handlers/keywordHandler.js
@@ -58,7 +58,7 @@
             }
             // Keyword just has a normal response.
             else {
-                json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + json.keyword + ')');
+                json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + $.escapeTags(json.keyword) + ')');
                 $.say($.tags(event, json.response, false));
             }
         }


### PR DESCRIPTION
When keywords contain parentheses (quite common for regex keywords), putting `(keywordcount)` into the response will be expanded such that the keyword is expanded like a tag again. In the worst case, the users causes unexpected side effects. If not that, the bot will complain that the keyword is unknown.