### PR TITLE
Show StreamElements tips rounded to 2 decimals

### DIFF
--- a/javascript-source/discord/handlers/streamElementsHandler.js
+++ b/javascript-source/discord/handlers/streamElementsHandler.js
@@ -58,7 +58,7 @@
             donationUsername = paramObj.getJSONObject('user').getString('username'),
             donationCurrency = paramObj.getString('currency'),
             donationMessage = (paramObj.has('message') ? paramObj.getString('message') : ''),
-            donationAmount = paramObj.getInt('amount'),
+            donationAmount = paramObj.getFloat('amount'),
             s = message;
 
         if ($.inidb.exists('discordDonations', 'streamelements' + donationID)) {
@@ -76,11 +76,11 @@
         }
 
         if (s.match(/\(amount\)/)) {
-            s = $.replace(s, '(amount)', String(parseInt(donationAmount.toFixed(2))));
+            s = $.replace(s, '(amount)', String(donationAmount.toFixed(2)));
         }
 
         if (s.match(/\(amount\.toFixed\(0\)\)/)) {
-            s = $.replace(s, '(amount.toFixed(0))', String(parseInt(donationAmount.toFixed(0))));
+            s = $.replace(s, '(amount.toFixed(0))', String(donationAmount.toFixed(0)));
         }
 
         if (s.match(/\(message\)/)) {

--- a/javascript-source/handlers/streamElementsHandler.js
+++ b/javascript-source/handlers/streamElementsHandler.js
@@ -66,7 +66,7 @@
             donationUsername = paramObj.getJSONObject('user').getString('username'),
             donationCurrency = paramObj.getString('currency'),
             donationMessage = (paramObj.has('message') ? paramObj.getString('message') : ''),
-            donationAmount = paramObj.getInt('amount'),
+            donationAmount = paramObj.getFloat('amount'),
             s = message;
 
         if ($.inidb.exists('donations', donationID)) {
@@ -93,11 +93,11 @@
             }
 
             if (s.match(/\(amount\)/)) {
-                s = $.replace(s, '(amount)', String(parseInt(donationAmount.toFixed(2))));
+                s = $.replace(s, '(amount)', String(donationAmount.toFixed(2)));
             }
 
             if (s.match(/\(amount\.toFixed\(0\)\)/)) {
-                s = $.replace(s, '(amount.toFixed(0))', String(parseInt(donationAmount.toFixed(0))));
+                s = $.replace(s, '(amount.toFixed(0))', String(donationAmount.toFixed(0)));
             }
 
             if (s.match(/\(message\)/)) {


### PR DESCRIPTION
Currently all tips are rounded to integers at one point or another.
With this patch `(amount)` will be rounded to 2 decimals.
`(amount.toFixed(0))` can still be used for an integer-rounded amount (I removed the superfluous `parseInt` from that line too).