### PR TITLE
Add web panel display and edit option for disabling default commands

### DIFF
--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -358,4 +358,22 @@
     $.registerChatAlias = registerChatAlias;
     $.tempUnRegisterChatCommand = tempUnRegisterChatCommand;
     $.getSubCommandFromArguments = getSubCommandFromArguments;
+
+    $.bind('webPanelSocketUpdate', function (event) {
+        if (event.getScript().equalsIgnoreCase('./core/commandRegister.js')) {
+            var args = event.getArgs(),
+                eventName = args[0] + '',
+                command = args[1] + '',
+                commandLower = command.toLowerCase() + '';
+            if (eventName === 'enable') {
+                if ($.inidb.exists('tempDisabledCommandScript', commandLower)) {
+                    $.registerChatCommand($.inidb.get('tempDisabledCommandScript', commandLower), commandLower);
+                }
+            } else if (eventName === 'disable') {
+                if (commandExists(commandLower)) {
+                    tempUnRegisterChatCommand(commandLower);
+                }
+            }
+        }
+    });
 })();

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -17,167 +17,208 @@
 
 // Function that querys all of the data we need.
 $(function() {
+    const getDisabledIconAttr = function(disabled) {
+        return {
+            class: 'fa disabled-status-icon ' + (disabled ? 'fa-ban text-muted' : 'fa-check'),
+            title: disabled ? 'disabled' : 'enabled'
+        };
+    };
+
+    const updateCommandDisabled = function(name, disabled, callback) {
+        const wsUpdate = function () {
+            socket.wsEvent('command_disabled_update_ws', './core/commandRegister.js', null,
+              [disabled ? 'disable' : 'enable', name], callback);
+        };
+
+        if (disabled) {
+            socket.updateDBValue('command_disabled_update', 'disabledCommands', name, true, wsUpdate);
+        } else {
+            socket.removeDBValue('command_disabled_remove', 'disabledCommands', name, wsUpdate);
+        }
+    };
+
     // Query all commands.
     socket.getDBTableValues('commands_get_all', 'permcom', function(results) {
         socket.getDBTableValues('custom_commands_get_all', 'command', function(customCommands) {
-            let tableData = [],
-                cmds = [];
+            socket.getDBTableValues('disabled_commands_get_all', 'disabledCommands', function(disabledCommands) {
+                let tableData = [],
+                    cmds = {},
+                    disabled = {};
 
-            for (let i = 0; i < customCommands.length; i++) {
-                cmds.push(customCommands[i].key);
-            }
-
-            for (let i = 0; i < results.length; i++) {
-                if (cmds.indexOf(results[i].key) !== -1) {
-                    continue;
+                for (let i = 0; i < customCommands.length; i++) {
+                    cmds[customCommands[i].key] = true;
                 }
 
-                tableData.push([
-                    '!' + results[i].key,
-                    helpers.getGroupNameById(results[i].value),
-                    $('<div/>', {
-                        'class': 'btn-group'
-                    }).append($('<button/>', {
-                        'type': 'button',
-                        'class': 'btn btn-xs btn-danger',
-                        'style': 'float: right',
-                        'data-toggle': 'tooltip',
-                        'title': 'Deletes the command permission and resets it to default on startup. This does not remove the command unless it doesn\'t exist anymore.',
-                        'data-command': results[i].key,
-                        'html': $('<i/>', {
-                            'class': 'fa fa-refresh'
-                        })
-                    })).append($('<button/>', {
-                        'type': 'button',
-                        'class': 'btn btn-xs btn-warning',
-                        'style': 'float: right',
-                        'data-command': results[i].key,
-                        'html': $('<i/>', {
-                            'class': 'fa fa-edit'
-                        })
-                    })).html()
-                ]);
-            }
+                for (let i = 0; i < disabledCommands.length; i++) {
+                    disabled[disabledCommands[i].key] = true;
+                }
 
-            // if the table exists, destroy it.
-            if ($.fn.DataTable.isDataTable('#defaultCommandsTable')) {
-                $('#defaultCommandsTable').DataTable().destroy();
-                // Remove all of the old events.
-                $('#defaultCommandsTable').off();
-            }
+                for (let i = 0; i < results.length; i++) {
+                    if (cmds.hasOwnProperty(results[i].key)) {
+                        continue;
+                    }
 
-            // Create table.
-            let table = $('#defaultCommandsTable').DataTable({
-                'searching': true,
-                'autoWidth': false,
-                'data': tableData,
-                'columnDefs': [
-                    { 'className': 'default-table-large', 'orderable': false, 'targets': 2 },
-                    { 'width': '45%', 'targets': 0 }
-                ],
-                'columns': [
-                    { 'title': 'Command' },
-                    { 'title': 'User Level' },
-                    { 'title': 'Actions' }
-                ]
-            });
+                    tableData.push([
+                        '!' + results[i].key,
+                        helpers.getGroupNameById(results[i].value),
+                        $('<div/>')
+                          .append($('<i/>',
+                              getDisabledIconAttr(disabled.hasOwnProperty(results[i].key))
+                          ))
+                          .html(),
+                        $('<div/>', {
+                            'class': 'btn-group'
+                        }).append($('<button/>', {
+                            'type': 'button',
+                            'class': 'btn btn-xs btn-danger',
+                            'style': 'float: right',
+                            'data-toggle': 'tooltip',
+                            'title': 'Deletes the command permission and resets it to default on startup. This does not remove the command unless it doesn\'t exist anymore.',
+                            'data-command': results[i].key,
+                            'html': $('<i/>', {
+                                'class': 'fa fa-refresh'
+                            })
+                        })).append($('<button/>', {
+                            'type': 'button',
+                            'class': 'btn btn-xs btn-warning',
+                            'style': 'float: right',
+                            'data-command': results[i].key,
+                            'html': $('<i/>', {
+                                'class': 'fa fa-edit'
+                            })
+                        })).html()
+                    ]);
+                }
 
-            // On delete button.
-            table.on('click', '.btn-danger', function() {
-                let command = $(this).data('command'),
-                    row = $(this).parents('tr'),
-                    t = $(this);
+                // if the table exists, destroy it.
+                if ($.fn.DataTable.isDataTable('#defaultCommandsTable')) {
+                    $('#defaultCommandsTable').DataTable().destroy();
+                    // Remove all of the old events.
+                    $('#defaultCommandsTable').off();
+                }
 
-                // Ask the user if he want to reset the command.
-                helpers.getConfirmDeleteModal('default_command_modal_remove', 'Are you sure you want to reset the command\'s permission?', false,
-                        'The command\'s permission has been reset!', function() {
-                    socket.removeDBValue('permcom_temp_del', 'permcom', command, function(e) {
-                        // Hide tooltip.
-                        t.tooltip('hide');
-                        // Remove the table row.
-                        table.row(row).remove().draw(false);
+                // Create table.
+                let table = $('#defaultCommandsTable').DataTable({
+                    'searching': true,
+                    'autoWidth': false,
+                    'data': tableData,
+                    'columnDefs': [
+                        { 'className': 'default-table-large', 'orderable': false, 'targets': [2, 3] },
+                        { 'width': '45%', 'targets': 0 }
+                    ],
+                    'columns': [
+                        { 'title': 'Command' },
+                        { 'title': 'User Level' },
+                        { 'title': 'Status' },
+                        { 'title': 'Actions' }
+                    ]
+                });
+
+                // On delete button.
+                table.on('click', '.btn-danger', function() {
+                    let command = $(this).data('command'),
+                        row = $(this).parents('tr'),
+                        t = $(this);
+
+                    // Ask the user if he want to reset the command.
+                    helpers.getConfirmDeleteModal('default_command_modal_remove', 'Are you sure you want to reset the command\'s permission?', false,
+                            'The command\'s permission has been reset!', function() {
+                        socket.removeDBValue('permcom_temp_del', 'permcom', command, function(e) {
+                            // Hide tooltip.
+                            t.tooltip('hide');
+                            // Remove the table row.
+                            table.row(row).remove().draw(false);
+                        });
                     });
                 });
-            });
 
-            // On edit button.
-            table.on('click', '.btn-warning', function() {
-                let command = $(this).data('command'),
-                    t = $(this);
+                // On edit button.
+                table.on('click', '.btn-warning', function() {
+                    let command = $(this).data('command'),
+                        t = $(this);
 
-                // Get all the info about the command.
-                socket.getDBValues('default_command_edit', {
-                    tables: ['permcom', 'cooldown', 'pricecom', 'paycom'],
-                    keys: [command, command, command, command]
-                }, function(e) {
-                    let cooldownJson = (e.cooldown === null ? { isGlobal: 'true', seconds: 0 } : JSON.parse(e.cooldown));
+                    // Get all the info about the command.
+                    socket.getDBValues('default_command_edit', {
+                        tables: ['permcom', 'cooldown', 'pricecom', 'paycom', 'disabledCommands'],
+                        keys: [command, command, command, command, command]
+                    }, function(e) {
+                        let cooldownJson = (e.cooldown === null ? { isGlobal: 'true', seconds: 0 } : JSON.parse(e.cooldown));
 
-                    // Get advance modal from our util functions in /utils/helpers.js
-                    helpers.getAdvanceModal('edit-command', 'Edit Command', 'Save', $('<form/>', {
-                        'role': 'form'
-                    })
-                    // Append input box for the command name. This one is disabled.
-                    .append(helpers.getInputGroup('command-name', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
-                    // Append a select option for the command permission.
-                    .append(helpers.getDropdownGroup('command-permission', 'User Level', helpers.getGroupNameById(e.permcom),
-                        ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
-                    // Add an advance section that can be opened with a button toggle.
-                    .append($('<div/>', {
-                        'class': 'collapse',
-                        'id': 'advance-collapse',
-                        'html': $('<form/>', {
-                                'role': 'form'
-                            })
-                            // Append input box for the command cost.
-                            .append(helpers.getInputGroup('command-cost', 'number', 'Cost', '0', helpers.getDefaultIfNullOrUndefined(e.pricecom, '0'),
-                                'Cost in points that will be taken from the user when running the command.'))
-                            // Append input box for the command reward.
-                            .append(helpers.getInputGroup('command-reward', 'number', 'Reward', '0', helpers.getDefaultIfNullOrUndefined(e.paycom, '0'),
-                                'Reward in points the user will be given when running the command.'))
-                            // Append input box for the command cooldown.
-                            .append(helpers.getInputGroup('command-cooldown', 'number', 'Cooldown (Seconds)', '5', cooldownJson.seconds,
-                                'Cooldown of the command in seconds.')
-                                // Append checkbox for if the cooldown is global or per-user.
-                                .append(helpers.getCheckBox('command-cooldown-global', cooldownJson.isGlobal === 'true', 'Global',
-                                    'If checked the cooldown will be applied to everyone in the channel. When not checked, the cooldown is applied per-user.')))
-                            // Callback function to be called once we hit the save button on the modal.
-                    })), function() {
-                        let commandPermission = $('#command-permission'),
-                            commandCost = $('#command-cost'),
-                            commandReward = $('#command-reward'),
-                            commandCooldown = $('#command-cooldown'),
-                            commandCooldownGlobal = $('#command-cooldown-global').is(':checked');
+                        // Get advance modal from our util functions in /utils/helpers.js
+                        helpers.getAdvanceModal('edit-command', 'Edit Command', 'Save', $('<form/>', {
+                            'role': 'form'
+                        })
+                        // Append input box for the command name. This one is disabled.
+                        .append(helpers.getInputGroup('command-name', 'text', 'Command', '', '!' + command, 'Name of the command. This cannot be edited.', true))
+                        // Append a select option for the command permission.
+                        .append(helpers.getDropdownGroup('command-permission', 'User Level', helpers.getGroupNameById(e.permcom),
+                            ['Caster', 'Administrators', 'Moderators', 'Subscribers', 'Donators', 'VIPs', 'Regulars', 'Viewers']))
+                        // Add an advance section that can be opened with a button toggle.
+                        .append($('<div/>', {
+                            'class': 'collapse',
+                            'id': 'advance-collapse',
+                            'html': $('<form/>', {
+                                    'role': 'form'
+                                })
+                                // Append input box for the command cost.
+                                .append(helpers.getInputGroup('command-cost', 'number', 'Cost', '0', helpers.getDefaultIfNullOrUndefined(e.pricecom, '0'),
+                                    'Cost in points that will be taken from the user when running the command.'))
+                                // Append input box for the command reward.
+                                .append(helpers.getInputGroup('command-reward', 'number', 'Reward', '0', helpers.getDefaultIfNullOrUndefined(e.paycom, '0'),
+                                    'Reward in points the user will be given when running the command.'))
+                                // Append input box for the command cooldown.
+                                .append(helpers.getInputGroup('command-cooldown', 'number', 'Cooldown (Seconds)', '5', cooldownJson.seconds,
+                                    'Cooldown of the command in seconds.')
+                                    // Append checkbox for if the cooldown is global or per-user.
+                                    .append(helpers.getCheckBox('command-cooldown-global', cooldownJson.isGlobal === 'true', 'Global',
+                                        'If checked the cooldown will be applied to everyone in the channel. When not checked, the cooldown is applied per-user.')))
+                                .append(helpers.getCheckBox('command-disabled', e.disabledCommands != null, 'Disabled',
+                                    'If checked, the command cannot be used in chat.'))
+                                // Callback function to be called once we hit the save button on the modal.
+                        })), function() {
+                            let commandPermission = $('#command-permission'),
+                                commandCost = $('#command-cost'),
+                                commandReward = $('#command-reward'),
+                                commandCooldown = $('#command-cooldown'),
+                                commandCooldownGlobal = $('#command-cooldown-global').is(':checked'),
+                                commandDisabled = $('#command-disabled').is(':checked');
 
-                        // Handle each input to make sure they have a value.
-                        switch (false) {
-                            case helpers.handleInputNumber(commandCost):
-                            case helpers.handleInputNumber(commandReward):
-                            case helpers.handleInputNumber(commandCooldown):
-                                break;
-                            default:
-                                // Save command information here and close the modal.
-                                socket.updateDBValues('custom_command_edit', {
-                                    tables: ['pricecom', 'paycom'],
-                                    keys: [command, command],
-                                    values: [commandCost.val(), commandReward.val()]
-                                }, function() {
-                                    // Add the cooldown to the cache.
-                                    socket.wsEvent('default_command_edit_cooldown_ws', './core/commandCoolDown.js', null,
-                                        ['add', command, commandCooldown.val(), String(commandCooldownGlobal)], function() {
-                                        // Edit the command permission.
-                                        socket.sendCommand('default_command_permisison_update', 'permcomsilent ' + command + ' ' +
-                                            helpers.getGroupIdByName(commandPermission.find(':selected').text(), true), function() {
-                                            // Update user level value.
-                                            t.parents('tr').find('td:eq(1)').text(commandPermission.find(':selected').text());
-                                            // Close the modal.
-                                            $('#edit-command').modal('hide');
-                                            // Tell the user the command was edited.
-                                            toastr.success('Successfully edited command !' + command);
+                            // Handle each input to make sure they have a value.
+                            switch (false) {
+                                case helpers.handleInputNumber(commandCost):
+                                case helpers.handleInputNumber(commandReward):
+                                case helpers.handleInputNumber(commandCooldown):
+                                    break;
+                                default:
+                                    // Save command information here and close the modal.
+                                    socket.updateDBValues('custom_command_edit', {
+                                        tables: ['pricecom', 'paycom'],
+                                        keys: [command, command],
+                                        values: [commandCost.val(), commandReward.val()]
+                                    }, function() {
+                                        updateCommandDisabled(command, commandDisabled, function () {
+                                            // Add the cooldown to the cache.
+                                            socket.wsEvent('default_command_edit_cooldown_ws', './core/commandCoolDown.js', null,
+                                                ['add', command, commandCooldown.val(), String(commandCooldownGlobal)], function() {
+                                                // Edit the command permission.
+                                                socket.sendCommand('default_command_permisison_update', 'permcomsilent ' + command + ' ' +
+                                                    helpers.getGroupIdByName(commandPermission.find(':selected').text(), true), function() {
+                                                    const $tr = t.parents('tr');
+                                                    // Update user level value.
+                                                    $tr.find('td:eq(1)').text(commandPermission.find(':selected').text());
+                                                    // Update status icons
+                                                    $tr.find('.disabled-status-icon').attr(getDisabledIconAttr(commandDisabled));
+                                                    // Close the modal.
+                                                    $('#edit-command').modal('hide');
+                                                    // Tell the user the command was edited.
+                                                    toastr.success('Successfully edited command !' + command);
+                                                });
+                                            });
                                         });
                                     });
-                                });
-                        }
-                    }).modal('toggle');
+                            }
+                        }).modal('toggle');
+                    });
                 });
             });
         });


### PR DESCRIPTION
Currently you can disable default commands (e.g. `!mods`) via chat: `!disablecom mods`. The webpanel will neither reflect that status nor provide an option to change it. I've updated the web panel to do both.

Screenshots:
![image](https://user-images.githubusercontent.com/4061254/98353719-fd427c80-201f-11eb-8570-df0e50e4395b.png)
![image](https://user-images.githubusercontent.com/4061254/98353771-13503d00-2020-11eb-9eec-6db3c5c6d49a.png)
![image](https://user-images.githubusercontent.com/4061254/98353806-1fd49580-2020-11eb-94fd-2c73af5c8daa.png)
