### PR TITLE
Adjust external commands table spacing

### DIFF
--- a/resources/web/panel/js/pages/commands/external.js
+++ b/resources/web/panel/js/pages/commands/external.js
@@ -57,7 +57,6 @@ $(function() {
                     {
                         'className': 'default-table',
                         'orderable': false,
-                        'width': '15%',
                         'targets': 1
                     },
                 ],


### PR DESCRIPTION
Branden noticed that the external commands table didn't look like the other commands table. So I adjusted it from this
![image](https://user-images.githubusercontent.com/4061254/99280261-71a3c980-2831-11eb-9bc1-e437c9376b12.png)

to this
![image](https://user-images.githubusercontent.com/4061254/99280320-7d8f8b80-2831-11eb-9c8f-20fbcaac2f9f.png)
