### PR TITLE
Ignore the bot account when checking Welcome Alert

### DIFF
--- a/javascript-source/systems/welcomeSystem.js
+++ b/javascript-source/systems/welcomeSystem.js
@@ -41,6 +41,9 @@
         if ($.equalsIgnoreCase(sender, $.channelName)) {
             return;
         }
+        if ($.equalsIgnoreCase(sender, $.botName)) {
+            return;
+        }
         if ($.isOnline($.channelName) && welcomeEnabled && (welcomeMessage || welcomeMessageFirst)) {
             var lastUserMessage = $.getIniDbNumber('welcomeLastUserMessage', sender),
                 firstTimeChatter = lastUserMessage === undefined,


### PR DESCRIPTION
Currently, the bot ignores the channel account when sending welcome alerts, but happily welcomes itself to chat, this adds the missing check so this no longer occurs
```[12-03-2020 @ 22:37:47.703 GMT] aevumbot: Welcome back, aevumbot!```
