### PR TITLE
Fix tags in keyword response

### DIFF
--- a/javascript-source/handlers/keywordHandler.js
+++ b/javascript-source/handlers/keywordHandler.js
@@ -58,8 +58,10 @@
             }
             // Keyword just has a normal response.
             else {
+                var CommandEvent = Packages.tv.phantombot.event.command.CommandEvent;
+                var cmdEvent = new CommandEvent(sender, "keyword_" + json.keyword, event.getMessage(), event.getTags());
                 json.response = $.replace(json.response, '(keywordcount)', '(keywordcount ' + $.escapeTags(json.keyword) + ')');
-                $.say($.tags(event, json.response, false));
+                $.say($.tags(cmdEvent, json.response, false));
             }
         }
 


### PR DESCRIPTION
Some tags that relied on command event data (e.g., sender) would not be expanded
correctly in a keyword response.

I noticed the problem when I tried to use `(echo)` in a keyword response.
Tested and working on my local bot deployment for several months now.
