### PR TITLE
Allow 3.4.7 to 3.5.0 Upgrade to succeed

### DIFF
--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -219,7 +219,8 @@
         i;
 
         for (i = 0; i < keys.length; i++) {
-            if ($.javaString(keys[i]).startsWith('org.mozilla.javascript')) {
+            var key = $.javaString(keys[i]);
+            if (key && key.startsWith('org.mozilla.javascript')) {
                 $.inidb.RemoveKey('time', '', keys[i]);
             }
         }


### PR DESCRIPTION
While upgrading from PhantomBot 3.4.7 to 3.5.0 nightly, a fatal exception can be thrown if a null value is found.

"TypeError: cannot call method "startsWith" of null (core/updates.js:222)"

This was handled by ensuring the value is well established before checking the string for content.