### PR TITLE
Fix OAuth's URL being incorrect on the /oath page

### DIFF
--- a/resources/web/oauth/index.html
+++ b/resources/web/oauth/index.html
@@ -336,8 +336,8 @@
                                 queryParts = queryString.substr(1).split(/#|&/), // Split at each &, which is a new query.
                                 queryMap = new Map(), // Create a new map for save our keys and values.
                                 baseAPIUri = 'https://id.twitch.tv/oauth2/authorize',
-                                redirectURI = window.location.origin + window.location.pathname,
-                                redirectURIBroadcaster = (redirectURI + "/broadcaster").replaceAll('//', '/'),
+                                redirectURI = (window.location.origin + window.location.pathname).replace(/\/$/, ''),
+                                redirectURIBroadcaster = redirectURI + "/broadcaster",
                                 broadcaster = "",
                                 clientID,
                                 state;


### PR DESCRIPTION
 since the slashes from https:// and http:// were trimmed to one. This could lead to confusion for users