### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -359,7 +359,7 @@
                 }
 
                 function parseHashMap() {
-                    var hash = window.location.hash.substr(1);
+                    var hash = window.location.hash.slice(1);
                     var kvs = hash.split('&');
                     var spl;
 

--- a/docs/oauth/index.html
+++ b/docs/oauth/index.html
@@ -252,7 +252,7 @@
                 }
 
                 var queryString = window.location.hash, // Query string that starts with ?
-                        queryParts = queryString.substr(1).split(/#|&/), // Split at each &, which is a new query.
+                        queryParts = queryString.slice(1).split(/#|&/), // Split at each &, which is a new query.
                         queryMap = new Map(), // Create a new map for save our keys and values.
                         baseAPIUri = 'https://id.twitch.tv/oauth2/authorize',
                         clientID = '26zr06lmku74srltt7qprwbotaxm91',
@@ -260,8 +260,8 @@
                         state;
 
                 for (var i = 0; i < queryParts.length; i++) {
-                    var key = queryParts[i].substr(0, queryParts[i].indexOf('=')),
-                            value = queryParts[i].substr(queryParts[i].indexOf('=') + 1, queryParts[i].length);
+                    var key = queryParts[i].substring(0, queryParts[i].indexOf('=')),
+                            value = queryParts[i].slice(queryParts[i].indexOf('=') + 1);
 
                     if (key.length > 0 && value.length > 0) {
                         queryMap.set(key.toLowerCase(), value);

--- a/docs/panel-stable/js/pages/dashboard/dashboard.js
+++ b/docs/panel-stable/js/pages/dashboard/dashboard.js
@@ -367,7 +367,7 @@ $(function () {
 
     // Handle custom command run.
     $('#custom-command-run').on('select2:select', function (e) {
-        socket.sendCommand('send_command', e.params.data.text.substr(1), function () {
+        socket.sendCommand('send_command', e.params.data.text.slice(1), function () {
             // Alert user.
             toastr.success('Successfully ran command ' + e.params.data.text);
             // Clear input.

--- a/docs/panel-stable/js/pages/extra/queue.js
+++ b/docs/panel-stable/js/pages/extra/queue.js
@@ -57,7 +57,7 @@ $(run = function () {
 
                 const trim = function (username) {
                     if (username.length > 15) {
-                        return username.substr(0, 15) + '...';
+                        return username.slice(0, 15) + '...';
                     } else {
                         return username;
                     }

--- a/docs/panel-stable/js/utils/helpers.js
+++ b/docs/panel-stable/js/utils/helpers.js
@@ -1168,8 +1168,8 @@ $(function () {
 
                 let html = '';
                 if (version.startsWith("nightly-")) {
-                    html = 'Nightly build ' + version.substr(8) + ' of PhantomBot is now availabel to download! <br>' +
-                            'You can grab your own copy of nightly build ' + version.substr(8) + ' of PhantomBot ' +
+                    html = 'Nightly build ' + version.slice(8) + ' of PhantomBot is now availabel to download! <br>' +
+                            'You can grab your own copy of nightly build ' + version.slice(8) + ' of PhantomBot ' +
                             $('<a/>', {'target': '_blank', 'rel': 'noopener noreferrer'}).prop('href', downloadLink).append('here.')[0].outerHTML + ' <br>' +
                             '<b>Please check ' +
                             $('<a/>', {'target': '_blank', 'rel': 'noopener noreferrer'}).prop('href', 'https://phantombot.github.io/PhantomBot/guides/#guide=content/setupbot/updatebot').append('this guide')[0].outerHTML +
@@ -1270,7 +1270,7 @@ $(function () {
     };
 
     helpers.parseHashmap = function () {
-        var hash = window.location.hash.substr(1);
+        var hash = window.location.hash.slice(1);
         var kvs = hash.split('&');
         var hashmap = [];
         var spl;

--- a/docs/panel-stable/login/index.html
+++ b/docs/panel-stable/login/index.html
@@ -250,7 +250,7 @@
                                 }
 
                                 $(function () {
-                                    var hash = window.location.hash.substr(1);
+                                    var hash = window.location.hash.slice(1);
                                     var kvs = hash.split('&');
                                     var hashmap = [];
                                     var spl;

--- a/docs/panel/js/pages/dashboard/dashboard.js
+++ b/docs/panel/js/pages/dashboard/dashboard.js
@@ -367,7 +367,7 @@ $(function () {
 
     // Handle custom command run.
     $('#custom-command-run').on('select2:select', function (e) {
-        socket.sendCommand('send_command', e.params.data.text.substr(1), function () {
+        socket.sendCommand('send_command', e.params.data.text.slice(1), function () {
             // Alert user.
             toastr.success('Successfully ran command ' + e.params.data.text);
             // Clear input.

--- a/docs/panel/js/pages/extra/queue.js
+++ b/docs/panel/js/pages/extra/queue.js
@@ -57,7 +57,7 @@ $(run = function () {
 
                 const trim = function (username) {
                     if (username.length > 15) {
-                        return username.substr(0, 15) + '...';
+                        return username.slice(0, 15) + '...';
                     } else {
                         return username;
                     }

--- a/docs/panel/js/utils/helpers.js
+++ b/docs/panel/js/utils/helpers.js
@@ -1168,8 +1168,8 @@ $(function () {
 
                 let html = '';
                 if (version.startsWith("nightly-")) {
-                    html = 'Nightly build ' + version.substr(8) + ' of PhantomBot is now availabel to download! <br>' +
-                            'You can grab your own copy of nightly build ' + version.substr(8) + ' of PhantomBot ' +
+                    html = 'Nightly build ' + version.slice(8) + ' of PhantomBot is now availabel to download! <br>' +
+                            'You can grab your own copy of nightly build ' + version.slice(8) + ' of PhantomBot ' +
                             $('<a/>', {'target': '_blank', 'rel': 'noopener noreferrer'}).prop('href', downloadLink).append('here.')[0].outerHTML + ' <br>' +
                             '<b>Please check ' +
                             $('<a/>', {'target': '_blank', 'rel': 'noopener noreferrer'}).prop('href', 'https://phantombot.github.io/PhantomBot/guides/#guide=content/setupbot/updatebot').append('this guide')[0].outerHTML +
@@ -1270,7 +1270,7 @@ $(function () {
     };
 
     helpers.parseHashmap = function () {
-        var hash = window.location.hash.substr(1);
+        var hash = window.location.hash.slice(1);
         var kvs = hash.split('&');
         var hashmap = [];
         var spl;

--- a/docs/panel/login/index.html
+++ b/docs/panel/login/index.html
@@ -250,7 +250,7 @@
                                 }
 
                                 $(function () {
-                                    var hash = window.location.hash.substr(1);
+                                    var hash = window.location.hash.slice(1);
                                     var kvs = hash.split('&');
                                     var hashmap = [];
                                     var spl;

--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -329,7 +329,7 @@
             var silent = false;
             if (action.startsWith('silent@')) {
                 silent = true;
-                action = action.substr(7);
+                action = action.slice(7);
             }
 
             if (!$.commandExists(action)) {

--- a/javascript-source/core/timeSystem.js
+++ b/javascript-source/core/timeSystem.js
@@ -196,7 +196,7 @@
 
             // Replace last comma with ", and".
             if (timeString.indexOf(',') !== -1) {
-                timeString = (timeString.substr(0, timeString.lastIndexOf(',')) + $.lang.get('common.time.and') + timeString.substr(timeString.lastIndexOf(',') + 2));
+                timeString = (timeString.slice(0, timeString.lastIndexOf(',')) + $.lang.get('common.time.and') + timeString.slice(timeString.lastIndexOf(',') + 2));
             }
             return timeString;
         }
@@ -259,7 +259,7 @@
 
         // Replace last comma with ", and".
         if (timeString.indexOf(',') !== -1) {
-            timeString = (timeString.substr(0, timeString.lastIndexOf(',')) + $.lang.get('common.time.and') + timeString.substr(timeString.lastIndexOf(',') + 2));
+            timeString = (timeString.slice(0, timeString.lastIndexOf(',')) + $.lang.get('common.time.and') + timeString.slice(timeString.lastIndexOf(',') + 2));
         }
         return timeString;
     }

--- a/javascript-source/discord/core/misc.js
+++ b/javascript-source/discord/core/misc.js
@@ -155,16 +155,16 @@
     function sanitizeChannelName(channel) {
         channel = channel.trim();
 
-        if (channel.substr(0, 1) === '<') {
-            channel = channel.substr(1);
+        if (channel.startsWith('<')) {
+            channel = channel.slice(1);
         }
 
-        if (channel.substr(0, 1) === '#') {
-            channel = channel.substr(1);
+        if (channel.startsWith('#')) {
+            channel = channel.slice(1);
         }
 
-        if (channel.substr(channel.length - 1, 1) === '>') {
-            channel = channel.substr(0, channel.length - 1);
+        if (channel.endsWith('>')) {
+            channel = channel.slice(0, channel.length - 1);
         }
 
         return channel;

--- a/javascript-source/discord/handlers/streamHandler.js
+++ b/javascript-source/discord/handlers/streamHandler.js
@@ -59,7 +59,7 @@
     function getTrimmedGameName() {
         var game = $.jsString($.twitchcache.getGameTitle());
 
-        return (game.length > 15 ? game.substr(0, 15) + '...' : game);
+        return (game.length > 15 ? game.slice(0, 15) + '...' : game);
     }
 
     function sanitizeTitle(s) {

--- a/javascript-source/systems/youtubePlayer.js
+++ b/javascript-source/systems/youtubePlayer.js
@@ -2067,7 +2067,7 @@
                     if (currentPlaylist.getRequestAtIndex(minRange) == null) {
                         break;
                     }
-                    displayString += "[(#" + showRange + ") " + currentPlaylist.getRequestAtIndex(minRange).getVideoTitle().substr(0, 20) + "] ";
+                    displayString += "[(#" + showRange + ") " + currentPlaylist.getRequestAtIndex(minRange).getVideoTitle().slice(0, 20) + "] ";
                     minRange++;
                 }
                 if (displayString.equals('')) {

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -42,12 +42,12 @@ $(function () {
      */
     function getQueryMap() {
         let queryString = window.location.search, // Query string that starts with ?
-                queryParts = queryString.substr(1).split('&'), // Split at each &, which is a new query.
+                queryParts = queryString.slice(1).split('&'), // Split at each &, which is a new query.
                 queryMap = new Map(); // Create a new map for save our keys and values.
 
         for (let i = 0; i < queryParts.length; i++) {
-            let key = queryParts[i].substr(0, queryParts[i].indexOf('=')),
-                    value = queryParts[i].substr(queryParts[i].indexOf('=') + 1, queryParts[i].length);
+            let key = queryParts[i].substring(0, queryParts[i].indexOf('=')),
+                    value = queryParts[i].slice(queryParts[i].indexOf('=') + 1);
 
             if (key.length > 0 && value.length > 0) {
                 queryMap.set(key, value);
@@ -356,7 +356,7 @@ $(function () {
                 });
             }
 
-            let audioPath = getAudioFile(gifFile.substr(0, gifFile.indexOf('.')), defaultPath);
+            let audioPath = getAudioFile(gifFile.slice(0, gifFile.indexOf('.')), defaultPath);
 
             if (audioPath.length > 0 && gifFile.substring(gifFile.lastIndexOf('.') + 1) !== audioPath.substring(audioPath.lastIndexOf('.') + 1)) {
                 hasAudio = true;

--- a/resources/web/oauth/index.html
+++ b/resources/web/oauth/index.html
@@ -345,7 +345,7 @@
                         }
 
                         var queryString = window.location.search, // Query string that starts with ?
-                                queryParts = queryString.substr(1).split(/#|&/), // Split at each &, which is a new query.
+                                queryParts = queryString.slice(1).split(/#|&/), // Split at each &, which is a new query.
                                 queryMap = new Map(), // Create a new map for save our keys and values.
                                 baseAPIUri = 'https://id.twitch.tv/oauth2/authorize',
                                 redirectURI = (window.location.origin + window.location.pathname),
@@ -359,8 +359,8 @@
                         }
 
                         for (var i = 0; i < queryParts.length; i++) {
-                            var key = queryParts[i].substr(0, queryParts[i].indexOf('=')),
-                                    value = queryParts[i].substr(queryParts[i].indexOf('=') + 1, queryParts[i].length);
+                            var key = queryParts[i].substring(0, queryParts[i].indexOf('=')),
+                                    value = queryParts[i].slice(queryParts[i].indexOf('=') + 1);
 
                             if (key.length > 0 && value.length > 0) {
                                 queryMap.set(key.toLowerCase(), value);

--- a/resources/web/obs/poll-chart/js/index.js
+++ b/resources/web/obs/poll-chart/js/index.js
@@ -26,12 +26,12 @@ $(function() {
      */
     function getQueryMap() {
         let queryString = window.location.search, // Query string that starts with ?
-            queryParts = queryString.substr(1).split('&'), // Split at each &, which is a new query.
+            queryParts = queryString.slice(1).split('&'), // Split at each &, which is a new query.
             queryMap = new Map(); // Create a new map for save our keys and values.
 
         for (let i = 0; i < queryParts.length; i++) {
-            let key = queryParts[i].substr(0, queryParts[i].indexOf('=')),
-                value = queryParts[i].substr(queryParts[i].indexOf('=') + 1, queryParts[i].length);
+            let key = queryParts[i].substring(0, queryParts[i].indexOf('=')),
+                value = queryParts[i].slice(queryParts[i].indexOf('=') + 1);
 
             if (key.length > 0 && value.length > 0) {
                 queryMap.set(key.toLowerCase(), value);

--- a/resources/web/panel/js/pages/dashboard/dashboard.js
+++ b/resources/web/panel/js/pages/dashboard/dashboard.js
@@ -367,7 +367,7 @@ $(function () {
 
     // Handle custom command run.
     $('#custom-command-run').on('select2:select', function (e) {
-        socket.sendCommand('send_command', e.params.data.text.substr(1), function () {
+        socket.sendCommand('send_command', e.params.data.text.slice(1), function () {
             // Alert user.
             toastr.success('Successfully ran command ' + e.params.data.text);
             // Clear input.

--- a/resources/web/panel/js/pages/extra/queue.js
+++ b/resources/web/panel/js/pages/extra/queue.js
@@ -57,7 +57,7 @@ $(run = function () {
 
                 const trim = function (username) {
                     if (username.length > 15) {
-                        return username.substr(0, 15) + '...';
+                        return username.slice(0, 15) + '...';
                     } else {
                         return username;
                     }

--- a/resources/web/panel/js/utils/helpers.js
+++ b/resources/web/panel/js/utils/helpers.js
@@ -1168,8 +1168,8 @@ $(function () {
 
                 let html = '';
                 if (version.startsWith("nightly-")) {
-                    html = 'Nightly build ' + version.substr(8) + ' of PhantomBot is now availabel to download! <br>' +
-                            'You can grab your own copy of nightly build ' + version.substr(8) + ' of PhantomBot ' +
+                    html = 'Nightly build ' + version.slice(8) + ' of PhantomBot is now availabel to download! <br>' +
+                            'You can grab your own copy of nightly build ' + version.slice(8) + ' of PhantomBot ' +
                             $('<a/>', {'target': '_blank', 'rel': 'noopener noreferrer'}).prop('href', downloadLink).append('here.')[0].outerHTML + ' <br>' +
                             '<b>Please check ' +
                             $('<a/>', {'target': '_blank', 'rel': 'noopener noreferrer'}).prop('href', 'https://phantombot.github.io/PhantomBot/guides/#guide=content/setupbot/updatebot').append('this guide')[0].outerHTML +
@@ -1270,7 +1270,7 @@ $(function () {
     };
 
     helpers.parseHashmap = function () {
-        var hash = window.location.hash.substr(1);
+        var hash = window.location.hash.slice(1);
         var kvs = hash.split('&');
         var hashmap = [];
         var spl;

--- a/resources/web/panel/login/index.html
+++ b/resources/web/panel/login/index.html
@@ -250,7 +250,7 @@
                                 }
 
                                 $(function () {
-                                    var hash = window.location.hash.substr(1);
+                                    var hash = window.location.hash.slice(1);
                                     var kvs = hash.split('&');
                                     var hashmap = [];
                                     var spl;

--- a/resources/web/ytplayer/js/index.js
+++ b/resources/web/ytplayer/js/index.js
@@ -63,7 +63,7 @@ $(function() {
 
                     for (let i = 0; i < results.length; i++) {
                         if (results[i].indexOf('ytPlaylist_') !== -1) {
-                            playlists.push(results[i].substr(results[i].indexOf('_') + 1, results[i].length));
+                            playlists.push(results[i].slice(results[i].indexOf('_') + 1));
                         }
                     }
 
@@ -530,7 +530,7 @@ $(function() {
 
             for (let i = 0; i < results.length; i++) {
                 if (results[i].indexOf('ytPlaylist_') !== -1) {
-                    playlists.push(results[i].substr(results[i].indexOf('_') + 1, results[i].length));
+                    playlists.push(results[i].slice(results[i].indexOf('_') + 1));
                 }
             }
 

--- a/resources/web/ytplayer/js/util/helpers.js
+++ b/resources/web/ytplayer/js/util/helpers.js
@@ -242,7 +242,7 @@ $(function() {
     helpers.getPlayerSize = () => {
         let size = localStorage.getItem('phantombot_ytplayer_size');
 
-        return (size === null ? 'Default' : size[0].toUpperCase() + size.substr(1));
+        return (size === null ? 'Default' : size[0].toUpperCase() + size.slice(1));
     };
 
     /*


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it either with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or with [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.