### PR TITLE
Fix #2583

### DIFF
--- a/source/tv/phantombot/twitch/pubsub/TwitchPubSub.java
+++ b/source/tv/phantombot/twitch/pubsub/TwitchPubSub.java
@@ -363,7 +363,6 @@ public class TwitchPubSub {
                         switch (messageObj.getString("type")) {
                             case "stream-up":
                                 if (chanid == this.channelId) {
-                                    EventBus.instance().postAsync(new TwitchOnlineEvent());
                                     TwitchCache.instance(PhantomBot.instance().getChannelName()).goOnline();
                                 }
                                 EventBus.instance().postAsync(new PubSubStreamUpEvent(chanid, srvtime, messageObj.getInt("play_delay")));


### PR DESCRIPTION
Fixes [#2583](https://github.com/PhantomBot/PhantomBot/issues/2583)

The issue is that EventSub sends an Online Event which triggers twitter to post a tweat while at the same time retrieving the game from TwitchCache. But The cache still hold the old game. Later on, the cache gets updated and the game changes.
Though this is not the best solution imo but it fixes the issue by forcing the update first and then triggers the "online"-Event. Thus, at the time the twitter script polls the cache for the game it's already updated.

P.s Sorry for the preliminary Pull req before I added this message ... my bad I miss clicked

Edit: Sadly there is no game information provided by PubSub [only this](https://ibb.co/pdW0whz) which is why I use the updateCache function