### PR TITLE
Add all-in and half as betting and gambling options

### DIFF
--- a/javascript-source/discord/games/gambling.js
+++ b/javascript-source/discord/games/gambling.js
@@ -87,16 +87,25 @@
          * @discordcommandpath gamble [amount] - Gamble your points.
          */
         if (command.equalsIgnoreCase('gamble')) {
-            if (isNaN(parseInt(action))) {
-                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.gambling.usage'));
-            } else {
-                var twitchName = $.discord.resolveTwitchName(event.getSenderId());
-                if (twitchName !== null) {
-                    gamble(channel, twitchName, mention, sender, parseInt(action));
-                } else {
-                    $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.accountlink.usage.nolink'));
-                }
+            var twitchName = $.discord.resolveTwitchName(event.getSenderId());
+            if (twitchName == null) {
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.accountlink.usage.nolink'));
             }
+
+            var points;
+            if ($.equalsIgnoreCase(action, "all") || $.equalsIgnoreCase(action, "allin") || $.equalsIgnoreCase(action, "all-in")){
+                points = $.getUserPoints(sender);
+            } else if ($.equalsIgnoreCase(action, "half")){
+                points = Math.floor($.getUserPoints(sender)/2);
+            } else if (isNaN(parseInt(action))) {
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.gambling.usage'));
+                return;
+            } else {
+                points = parseInt(action);
+            }
+            
+            gamble(channel, twitchName, mention, sender, points);
+
         }
 
         if (command.equalsIgnoreCase('gambling')) {

--- a/javascript-source/discord/games/gambling.js
+++ b/javascript-source/discord/games/gambling.js
@@ -88,7 +88,7 @@
          */
         if (command.equalsIgnoreCase('gamble')) {
             var twitchName = $.discord.resolveTwitchName(event.getSenderId());
-            if (twitchName == null) {
+            if (twitchName === null) {
                 $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.accountlink.usage.nolink'));
                 return;
             }

--- a/javascript-source/discord/games/gambling.js
+++ b/javascript-source/discord/games/gambling.js
@@ -90,6 +90,7 @@
             var twitchName = $.discord.resolveTwitchName(event.getSenderId());
             if (twitchName == null) {
                 $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.accountlink.usage.nolink'));
+                return;
             }
 
             var points;
@@ -105,7 +106,7 @@
             }
             
             gamble(channel, twitchName, mention, sender, points);
-
+            return;
         }
 
         if (command.equalsIgnoreCase('gambling')) {

--- a/javascript-source/games/gambling.js
+++ b/javascript-source/games/gambling.js
@@ -89,7 +89,7 @@
                 $.say($.whisperPrefix(sender) + $.lang.get('gambling.usage'));
                 return;
             } else {
-                points = parseInt(action)
+                points = parseInt(action);
             }
 
             gamble(sender, points);

--- a/javascript-source/games/gambling.js
+++ b/javascript-source/games/gambling.js
@@ -93,7 +93,7 @@
             }
 
             gamble(sender, points);
-
+            return;
         }
 
         /**

--- a/javascript-source/games/gambling.js
+++ b/javascript-source/games/gambling.js
@@ -80,12 +80,20 @@
          * @commandpath gamble [amount] - Gamble your points.
          */
         if (command.equalsIgnoreCase('gamble')) {
-            if (!parseInt(action)) {
+            var points;
+            if ($.equalsIgnoreCase(action, "all") || $.equalsIgnoreCase(action, "allin") || $.equalsIgnoreCase(action, "all-in")){
+                points = $.getUserPoints(sender);
+            } else if ($.equalsIgnoreCase(action, "half")){
+                points = Math.floor($.getUserPoints(sender)/2);
+            } else if (isNan(parseInt(action))) {
                 $.say($.whisperPrefix(sender) + $.lang.get('gambling.usage'));
                 return;
+            } else {
+                points = parseInt(action)
             }
 
-            gamble(sender, parseInt(action));
+            gamble(sender, points);
+
         }
 
         /**

--- a/javascript-source/lang/english/discord/games/games-gambling.js
+++ b/javascript-source/lang/english/discord/games/games-gambling.js
@@ -20,7 +20,7 @@ $.lang.register('discord.gambling.error.max', 'You\'re only allowed to gamble a 
 $.lang.register('discord.gambling.error.min', 'You\'re only allowed to gamble a minimum of $1.');
 $.lang.register('discord.gambling.lost', '$1 rolled $2 and lost $3. $5'); // Use $4 for the points the user has remaining
 $.lang.register('discord.gambling.won', '$1 rolled $2 and won $3! $5'); // Use $4 for the points the user has remaining
-$.lang.register('discord.gambling.usage', 'Usage: !gamble [amount]');
+$.lang.register('discord.gambling.usage', 'Usage: !gamble [amount / all / half]');
 $.lang.register('discord.gambling.set.max.usage', 'Usage: !gambling setmax [amount]');
 $.lang.register('discord.gambling.set.max', 'Set max gambling to $1!');
 $.lang.register('discord.gambling.set.min.usage', 'Usage: !gambling setmin [amount]');

--- a/javascript-source/lang/english/games/games-gambling.js
+++ b/javascript-source/lang/english/games/games-gambling.js
@@ -20,7 +20,7 @@ $.lang.register('gambling.error.max', 'You\'re only allowed to gamble a maximum 
 $.lang.register('gambling.error.min', 'You\'re only allowed to gamble a minimum amount of $1.');
 $.lang.register('gambling.lost', '$1 rolled $2 and lost $3. $5'); // Use $4 for the points the user has renaming
 $.lang.register('gambling.won', '$1 rolled $2 and won $3! $5'); // Use $4 for the points the user has renaming
-$.lang.register('gambling.usage', 'Usage: !gamble [amount]');
+$.lang.register('gambling.usage', 'Usage: !gamble [amount / all / half]');
 $.lang.register('gambling.set.max.usage', 'Usage: !gamblesetmax [amount]');
 $.lang.register('gambling.set.max', 'Set the maximum gambling amount to $1!');
 $.lang.register('gambling.set.min.usage', 'Usage: !gamblesetmin [amount]');

--- a/javascript-source/lang/english/systems/systems-bettingSystem.js
+++ b/javascript-source/lang/english/systems/systems-bettingSystem.js
@@ -27,7 +27,7 @@ $.lang.register('bettingsystem.close.success.winners', 'A total of $1 players wo
 $.lang.register('bettingsystem.save.format', 'Title: "$1", Options: "$2", Total Points: $3, Total Entries: $4, Points Won: $5.');
 $.lang.register('bettingsystem.results', 'Current bet: Title: "$1", Options: "$2", Total Points: $3, Total Entries: $4');
 $.lang.register('bettingsystem.global.usage', 'Usage: !bet [open / close / save / saveformat / lookup / results / togglemessages / gain]');
-$.lang.register('bettingsystem.bet.usage', 'Usage: !bet [amount] [option]');
+$.lang.register('bettingsystem.bet.usage', 'Usage: !bet [amount / all / half] [option]');
 $.lang.register('bettingsystem.bet.error.neg', 'You cannot bet negative $1!');
 $.lang.register('bettingsystem.bet.error.min', 'The minimum bet you can place is $1.');
 $.lang.register('bettingsystem.bet.error.max', 'The maximum bet you can place is $1.');

--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -316,9 +316,6 @@
         if (bet.status === false || bet.opened === false) {
             // $.say($.whisperPrefix(sender) + 'There\'s no bet opened.');
             return;
-        } else if (isNaN(parseInt(amount)) || option.length === 0) {
-            message(sender, $.lang.get('bettingsystem.bet.usage'));
-            return;
         } else if (amount < 1) {
             message(sender, $.lang.get('bettingsystem.bet.error.neg', $.pointNameMultiple));
             return;
@@ -462,7 +459,26 @@
                  * @commandpath bet [amount] [option] - Bets on that option.
                  */
             } else {
-                vote(sender, args[0], args.splice(1).join(' ').toLowerCase().trim());
+                var option = args.splice(1).join(' ').toLowerCase().trim()
+                if(option.length === 0) {
+                    message(sender, $.lang.get('bettingsystem.bet.usage'));
+                    return; 
+                }
+
+                var points;
+                if ($.equalsIgnoreCase(action, "all") || $.equalsIgnoreCase(action, "allin") || $.equalsIgnoreCase(action, "all-in")){
+                    points = $.getUserPoints(sender);
+                } else if ($.equalsIgnoreCase(action, "half")){
+                    points = Math.floor($.getUserPoints(sender)/2);
+                } else if (isNaN(parseInt(action))) {
+                    message(sender, $.lang.get('bettingsystem.bet.usage'));
+                    return; 
+                } else {
+                    points = action
+                }
+
+                vote(sender, points, option);
+
             }
         }
     });

--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -474,7 +474,7 @@
                     message(sender, $.lang.get('bettingsystem.bet.usage'));
                     return; 
                 } else {
-                    points = parseInt(action)
+                    points = parseInt(action);
                 }
 
                 vote(sender, points, option);

--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -459,7 +459,7 @@
                  * @commandpath bet [amount] [option] - Bets on that option.
                  */
             } else {
-                var option = args.splice(1).join(' ').toLowerCase().trim()
+                var option = args.splice(1).join(' ').toLowerCase().trim();
                 if(option.length === 0) {
                     message(sender, $.lang.get('bettingsystem.bet.usage'));
                     return; 
@@ -474,7 +474,7 @@
                     message(sender, $.lang.get('bettingsystem.bet.usage'));
                     return; 
                 } else {
-                    points = action
+                    points = parseInt(action)
                 }
 
                 vote(sender, points, option);

--- a/javascript-source/systems/bettingSystem.js
+++ b/javascript-source/systems/bettingSystem.js
@@ -478,7 +478,7 @@
                 }
 
                 vote(sender, points, option);
-
+                return;
             }
         }
     });


### PR DESCRIPTION
Adds the option to bet all or half the user's point in betting and gambling. This change is applied to Twitchs' gambling and betting, as well as discords' betting.

Furthermore, gambling on discord will now first check if the users' account is linked and then proceed.