### PR TITLE
Fix Issue #2717, !shoutout not triggering corecommands.shoutout.no.game message.

### DIFF
--- a/javascript-source/core/coreCommands.js
+++ b/javascript-source/core/coreCommands.js
@@ -39,7 +39,7 @@
                     streamerGame = $.getGame(streamer),
                     streamerURL = 'https://twitch.tv/' + streamer;
 
-            if (streamerGame == null || streamerGame.length === 0) {
+            if (streamerGame == null || streamerGame.length === 0 || streamerGame == "") {
                 $.say($.lang.get('corecommands.shoutout.no.game', streamerDisplay, streamerURL));
                 return;
             }


### PR DESCRIPTION
#2717 

When using !shoutout against a "streamer" (aka. Twitch User) that has not streamed the "corecommands.shoutout.offline" response is being triggered and sent in chat. The logic on the original line 42 did not trigger due to whatever value was captured in variable "streamerGame". I added an additional comparison. With the added comparison (streamerGame == ""), it is now using the appropriate "corecommands.shoutout.no.game" response when shouting out a streamer/Twitch User that has not streamed.

PhantomBot/Javascript-Source/Core/coreCommands.js
Line 42 originally reads as:
if (streamerGame == null || streamerGame.length === 0) {

The proposed new line 42 reads as:
if (streamerGame == null || streamerGame.length === 0 || streamerGame == "") {


since I forgot to add the a log output showing the post-change results that I tested in the original issue (2717), please see the log entries from my journalctl output below - which shows a chat message with the appropriate output for a user that has not streamed.
Mar 27 23:18:36 PhantomBotVM0 launch-service.sh [28612]: [03-28-2022] hippysec !shoutout Zeldobot
Mar 27 23:18:37 PhantomBotVM0 launch-service.sh [28612]: [03-28-2022] [CHAT] Shout out to ZeldoBot! They have not played anything recently, but consider following @ https://twitch.tv/zeldobot. :)