### PR TITLE
Separate global and per-user command cooldown

### DIFF
--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -130,7 +130,6 @@
         if (isSpecial(command)) {
             if (command.equalsIgnoreCase('adventure') && defaultCooldowns[command] !== undefined && defaultCooldowns[command] > $.systemTime()) {
                 maxCoolDown = getTimeDif(defaultCooldowns[command]);
-                return [maxCoolDown, isGlobal];
             }
             return [maxCoolDown, isGlobal];
         }

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -144,7 +144,7 @@
                 isGlobal = true;
                 if (cooldown.globalTime > $.systemTime()) {
                     maxCoolDown = getTimeDif(cooldown.globalTime);
-                } else {
+                } else if(cooldown.userTimes[username] === undefined || (cooldown.userTimes[username] !== undefined && cooldown.userTimes[username] < $.systemTime())){ //Only set a cooldown timer if the user can actually use the command
                     set(command, useDefault, cooldown.globalSec, undefined);
                 } 
             }
@@ -261,11 +261,12 @@
     /*
      * @function handleCoolCom
      *
+     * @param {String}  sender
      * @param {String}  command
      * @param {String}  first
      * @param {String}  second
      */
-    function handleCoolCom(command, first, second) {
+    function handleCoolCom(sender, command, first, second) {
         var action1 = first.split("="),
             type1   = action1[0],
             secsG   = Operation.UnChanged,
@@ -330,7 +331,7 @@
                 $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
                 return;
             }
-            handleCoolCom(action, subAction, actionArgs);
+            handleCoolCom(sender, action, subAction, actionArgs);
             return;
         }
 

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -187,7 +187,7 @@
     }
 
     /**
-     * @function say
+     * @function sayWithTimeout
      * @export $
      * @param {string} message
      * @param {boolean} run

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -295,4 +295,40 @@
         $.consoleLn('PhantomBot update 3.5.0 completed!');
         $.inidb.set('updates', 'installedv3.5.0', 'true');
     }
+
+    /* version 3.6.0 updates */
+    if (!$.inidb.GetBoolean('updates', '', 'installedv3.6.0')) {
+        $.consoleLn('Starting PhantomBot update 3.6.0 updates...');
+
+        // Convert cooldowns to separate global and user cooldowns
+        var cooldowns = $.inidb.GetKeyList('cooldown', ''),
+                json;
+
+
+        for (i in cooldowns) {
+            json = JSON.parse($.inidb.get('cooldown', cooldowns[i]));
+
+            var globalSec,
+                userSec,
+                curSec = parseInt(json.seconds);
+
+            if (json.isGlobal.toString().equals('true')) {
+                globalSec = curSec;
+                userSec = -1;
+            } else {
+                globalSec = -1;
+                userSec = curSec;
+            }
+
+            $.inidb.set('cooldown', cooldowns[i], JSON.stringify({
+                command: String(json.command),
+                globalSec: globalSec,
+                userSec: userSec
+            }));
+        }
+
+        $.consoleLn('PhantomBot update 3.6.0 completed!');
+        $.inidb.SetBoolean('updates', '', 'installedv3.6.0', 'true');
+    }
+
 })();

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -301,7 +301,8 @@
 
         // Convert cooldowns to separate global and user cooldowns
         var cooldowns = $.inidb.GetKeyList('cooldown', ''),
-                json;
+                json,
+                i;
 
 
         for (i in cooldowns) {
@@ -327,7 +328,7 @@
         }
 
         $.consoleLn('PhantomBot update 3.6.0 completed!');
-        $.inidb.SetBoolean('updates', '', 'installedv3.6.0', 'true');
+        $.inidb.SetBoolean('updates', '', 'installedv3.6.0', true);
     }
 
 })();

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -542,12 +542,12 @@
 
             [cooldownDuration, isGlobalCooldown] = $.coolDown.get(cooldownCommand, sender, isMod);
 
-            if (cooldownDuration > 0) {
+            if (cooldownDuration > 0 && $.getIniDbBoolean('settings', 'coolDownMsgEnabled')) {
                 if (isGlobalCooldown) {
-                    $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.global', command, cooldownDuration), $.getIniDbBoolean('settings', 'coolDownMsgEnabled', false));
+                    $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.global', command, cooldownDuration), true);
                     consoleDebug('Command ! ' + command + ' was not sent due to it being on a global cooldown.');
                 } else {
-                    $.say($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.user', command, cooldownDuration), $.getIniDbBoolean('settings', 'coolDownMsgEnabled', false));
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.user', command, cooldownDuration));
                     consoleDebug('Command ! ' + command + ' was not sent due to it being on cooldown for user ' + sender + '.');
                 }
                 return;

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -484,7 +484,7 @@
             // Check if the command exists or if the module is disabled.
             if (!$.commandExists(command) || !isModuleEnabled($.getCommandScript(command))) {
                 return;
-            } else
+            }
 
             // Check if the command has an alias.
             if ($.aliasExists(command)) {
@@ -512,34 +512,44 @@
                     }
                 }
                 return;
-            } else
+            }
 
             // Check the command permission.
             if ($.permCom(sender, command, subCommand, event.getTags()) !== 0) {
                 $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('cmd.perm.404', (!$.subCommandExists(command, subCommand) ? $.getCommandGroupName(command) : $.getSubCommandGroupName(command, subCommand))), $.getIniDbBoolean('settings', 'permComMsgEnabled', false));
                 consoleDebug('Command !' + command + ' was not sent due to the user not having permission for it.');
                 return;
-            } else
+            }
 
             // Check the command cost.
             if ($.priceCom(sender, command, subCommand, isMod) === 1) {
                 $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('cmd.needpoints', $.getPointsString($.getCommandPrice(command, subCommand, ''))), $.getIniDbBoolean('settings', 'priceComMsgEnabled', false));
                 consoleDebug('Command !' + command + ' was not sent due to the user not having enough points.');
                 return;
-            } else
-                // Check the command cooldown.
-                var oncooldown = false;
-            if (args.length > 1 && $.coolDown.exists(command + ' ' + args[0] + ' ' + args[1])) {
-                oncooldown = $.coolDown.get(command + ' ' + args[0] + ' ' + args[1], sender, isMod) !== 0;
-            } else if (args.length > 0 && $.coolDown.exists(command + ' ' + args[0])) {
-                oncooldown = $.coolDown.get(command + ' ' + args[0], sender, isMod) !== 0;
-            } else {
-                oncooldown = $.coolDown.get(command, sender, isMod) !== 0;
             }
 
-            if (oncooldown) {
-                $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg', command, $.coolDown.getSecs(sender, command, isMod)), $.getIniDbBoolean('settings', 'coolDownMsgEnabled', false));
-                consoleDebug('Command !' + command + ' was not sent due to it being on cooldown.');
+            // Check the command cooldown.
+            var cooldownDuration,
+                isGlobalCooldown,
+                cooldownCommand = command;
+
+            if (args.length === 1 && $.coolDown.exists(cooldownCommand + ' ' + args[0])) {
+                cooldownCommand += ' ' + args[0];
+            }
+            if (args.length > 1 && $.coolDown.exists(cooldownCommand + ' ' + args[1])) {
+                cooldownCommand += ' ' + args[1];
+            } 
+
+            [cooldownDuration, isGlobalCooldown] = $.coolDown.get(cooldownCommand, sender, isMod);
+
+            if (cooldownDuration > 0) {
+                if (isGlobalCooldown) {
+                    $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.global', command, cooldownDuration), $.getIniDbBoolean('settings', 'coolDownMsgEnabled', false));
+                    consoleDebug('Command ! ' + command + ' was not sent due to it being on a global cooldown.');
+                } else {
+                    $.say($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.user', command, cooldownDuration), $.getIniDbBoolean('settings', 'coolDownMsgEnabled', false));
+                    consoleDebug('Command ! ' + command + ' was not sent due to it being on cooldown for user ' + sender + '.');
+                }
                 return;
             }
 

--- a/javascript-source/lang/english/main.js
+++ b/javascript-source/lang/english/main.js
@@ -303,9 +303,11 @@ $.lang.register('console.received.slowmode.start', 'Received a start slow mode (
 $.lang.register('console.received.subscriberonly.end', 'Received an end subscribers-only mode notification from jtv');
 $.lang.register('console.received.subscriberonly.start', 'Received a start subscribers-only mode notification from jtv');
 $.lang.register('cooldown.set.togglemodcooldown', 'Command cooldowns have been $1 for moderators.');
-$.lang.register('cooldown.coolcom.usage', 'Usage: !coolcom [command] [seconds] [type (global / user)] - Using -1 for the seconds removes the cooldown.');
+$.lang.register('cooldown.coolcom.usage', 'Usage: !coolcom [command] [seconds / global=seconds / user=seconds] [global=seconds / user=seconds] - Using -1 for the seconds removes the cooldown. Only specifying seconds assumes global only if no secondary argument is given!');
 $.lang.register('cooldown.coolcom.err', 'The minimum cooldown that can be set is 5 seconds.');
-$.lang.register('cooldown.coolcom.set', 'Cooldown for command !$1 has been set to $2 seconds.');
+$.lang.register('cooldown.coolcom.setGlobal', 'Cooldown for command !$1 has globally been set to $2 seconds.');
+$.lang.register('cooldown.coolcom.setUser', 'Cooldown for command !$1 has been set to $2 seconds individually for each user.');
+$.lang.register('cooldown.coolcom.setCombo', 'Cooldown for command !$1 has globally been set to $2 seconds and to $3 seconds individually for each user.');
 $.lang.register('cooldown.coolcom.remove', 'Cooldown for command !$1 has been removed.');
 $.lang.register('cooldown.cooldown.usage', 'Usage: !cooldown [togglemoderators / setdefault]');
 $.lang.register('cooldown.default.set', 'The default cooldown for commands without one has been set to $1 seconds.');
@@ -349,7 +351,8 @@ $.lang.register('init.mod.toggle.price.msg.off', 'The price message has been dis
 $.lang.register('init.mod.toggle.price.msg.on', 'The price message has been enabled.');
 $.lang.register('init.toggle.cooldown.msg.on', 'The cooldown message has been enabled.');
 $.lang.register('init.toggle.cooldown.msg.off', 'The cooldown message has been disabled.');
-$.lang.register('init.cooldown.msg', 'command !$1 is still on cooldown. ($2 seconds)');
+$.lang.register('init.cooldown.msg.global', 'command !$1 is still on a global cooldown. ($2 seconds left)');
+$.lang.register('init.cooldown.msg.user', 'command !$1 is still on cooldown for you. ($2 seconds left)');
 $.lang.register('lang.curlang', 'The current language is $1!');
 $.lang.register('lang.lang.404', 'That language file does not exist!');
 $.lang.register('lang.lang.changed', 'Changed language to $1!');

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -142,7 +142,7 @@ $(function() {
                         tables: ['permcom', 'cooldown', 'pricecom', 'paycom', 'disabledCommands'],
                         keys: [command, command, command, command, command]
                     }, function(e) {
-                        let cooldownJson = (e.cooldown === null ? { isGlobal: 'true', seconds: 0 } : JSON.parse(e.cooldown));
+                        let cooldownJson = (e.cooldown === null ? { globalSec: -1, userSec: -1 } : JSON.parse(e.cooldown));
 
                         // Get advance modal from our util functions in /utils/helpers.js
                         helpers.getAdvanceModal('edit-command', 'Edit Command', 'Save', $('<form/>', {
@@ -166,12 +166,12 @@ $(function() {
                                 // Append input box for the command reward.
                                 .append(helpers.getInputGroup('command-reward', 'number', 'Reward', '0', helpers.getDefaultIfNullOrUndefined(e.paycom, '0'),
                                     'Reward in points the user will be given when running the command.'))
-                                // Append input box for the command cooldown.
-                                .append(helpers.getInputGroup('command-cooldown', 'number', 'Cooldown (Seconds)', '5', cooldownJson.seconds,
-                                    'Cooldown of the command in seconds.')
-                                    // Append checkbox for if the cooldown is global or per-user.
-                                    .append(helpers.getCheckBox('command-cooldown-global', cooldownJson.isGlobal === 'true', 'Global',
-                                        'If checked the cooldown will be applied to everyone in the channel. When not checked, the cooldown is applied per-user.')))
+                                // Append input box for the global command cooldown.
+                                .append(helpers.getInputGroup('command-cooldown-global', 'number', 'Global Cooldown (Seconds)', '-1', cooldownJson.globalSec,
+                                    'Global Cooldown of the command in seconds. -1 Uses the bot-wide settings.'))
+                                // Append input box for per-user cooldown.
+                                .append(helpers.getInputGroup('command-cooldown-user', 'number', 'Per-User Cooldown (Seconds)', '-1', cooldownJson.userSec,
+                                    'Per-User cooldown of the command in seconds. -1 removes per-user cooldown.'))
                                 .append(helpers.getCheckBox('command-disabled', e.disabledCommands != null, 'Disabled',
                                     'If checked, the command cannot be used in chat.'))
                                 // Callback function to be called once we hit the save button on the modal.
@@ -179,15 +179,16 @@ $(function() {
                             let commandPermission = $('#command-permission'),
                                 commandCost = $('#command-cost'),
                                 commandReward = $('#command-reward'),
-                                commandCooldown = $('#command-cooldown'),
-                                commandCooldownGlobal = $('#command-cooldown-global').is(':checked'),
+                                commandCooldownGlobal = $('#command-cooldown-global'),
+                                commandCooldownUser = $('#command-cooldown-user'),
                                 commandDisabled = $('#command-disabled').is(':checked');
 
                             // Handle each input to make sure they have a value.
                             switch (false) {
                                 case helpers.handleInputNumber(commandCost):
                                 case helpers.handleInputNumber(commandReward):
-                                case helpers.handleInputNumber(commandCooldown):
+                                case helpers.handleInputNumber(commandCooldownGlobal, -1):
+                                case helpers.handleInputNumber(commandCooldownUser, -1):
                                     break;
                                 default:
                                     // Save command information here and close the modal.
@@ -199,7 +200,7 @@ $(function() {
                                         updateCommandDisabled(command, commandDisabled, function () {
                                             // Add the cooldown to the cache.
                                             socket.wsEvent('default_command_edit_cooldown_ws', './core/commandCoolDown.js', null,
-                                                ['add', command, commandCooldown.val(), String(commandCooldownGlobal)], function() {
+                                                ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val()], function() {
                                                 // Edit the command permission.
                                                 socket.sendCommand('default_command_permisison_update', 'permcomsilent ' + command + ' ' +
                                                     helpers.getGroupIdByName(commandPermission.find(':selected').text(), true), function() {


### PR DESCRIPTION
Separates the per command cooldowns into global (cooldowns for everyone) and per-user cooldowns, as mentioned in [this issue](https://github.com/gmt2001/PhantomBot-1/issues/8).
The bot-wide global cooldown is used, if none is set for a specific command.
Thus, this PR gives the user more configurability on how cooldowns work, such as only allowing a user to use a command once an hour while others can still use it freely (as far as the global cooldown allows it).
Further, this PR improves the code flow of **commandCoolDown.js** and simplifying it as well. (for example, the `getSec()` function was only used in `init.js` and while being **95%** identical to the `get()` function.)

This PR introduces changes to the `!coolcom [command] [seconds] [type (global / user)]` command. The new syntax is as follows:
+ `!coolcom [command] [user=seconds] [global=seconds]` where user and global can be used interchangeably and also allowing a single number.
+ `!coolcom age user=130 global=30` //Sets per-user cooldown to 130 seconds and the global cooldown to 30 seconds
_is equal to_
 `!coolcom age global=30 user=130`
+ `!coolcom age global=30` //Sets only the global cooldown to 30 seconds and leaves the per-user cooldown unchanged
_is equal to_
 `!coolcom age 30` //Assumes global, if no type (user/global) is given and thus setting the global cooldown to 30 seconds
+ `!coolcom age user=130` //Sets only the user cooldown to 130 seconds and leaves the global cooldown unchanged

To allow for this separation, an update to the database is necessary, which will use the following new layout:
_Command_Name - JSON {command: Command_Name, globalSec: Global_Cooldown, userSec: User_Cooldown}_
Databases created before this change is released will be upgraded accordingly.

The Panel had to reflect this change as well to allow users to also configure per user commands for audio hooks, custom commands and default commands there. This is achieved by replacing the **Global**-checkbox with an input field of type **number**:
![image](https://user-images.githubusercontent.com/572591/160708591-62afd509-6460-4087-a234-9cd9d99fcd5e.png)

The related lang-files have been modified as well.

An example user interaction would be this:
![image](https://user-images.githubusercontent.com/572591/160711994-8d90fc1d-be02-45e4-bb39-56caa6d681a2.png)

P.s. I assumed this will be part of 3.6.0 which is why that's the version being saved in the database during the update.