### PR TITLE
Do not welcome bots

### DIFF
--- a/javascript-source/systems/welcomeSystem.js
+++ b/javascript-source/systems/welcomeSystem.js
@@ -44,6 +44,9 @@
         if ($.equalsIgnoreCase(sender, $.botName)) {
             return;
         }
+        if ($.isTwitchBot(sender.toLowerCase())) {
+			return;
+		}
         if ($.isOnline($.channelName) && welcomeEnabled && (welcomeMessage || welcomeMessageFirst)) {
             var lastUserMessage = $.getIniDbNumber('welcomeLastUserMessage', sender),
                 firstTimeChatter = lastUserMessage === undefined,


### PR DESCRIPTION
Currently, bots get welcomed by Phantombot if they send a message in chat. Due to the constant abundance of spammy bots being around, it's best to also ignore the bots from `ignorebots.txt`. This way either that bot gets only welcomed until it's added to `ignorebots.txt` list or never if the `ignorebots.txt` list is synchronized with a twitch bot list and the bot is present in that list (for example [this list](https://github.com/arrowgent/Twitchtv-Bots-List/blob/main/list.txt))
