### PR TITLE
Import sys in healthcheck.py

### DIFF
--- a/resources/config/healthcheck/healthcheck.py
+++ b/resources/config/healthcheck/healthcheck.py
@@ -46,6 +46,7 @@ import json
 import os
 from pathlib import Path
 import requests
+import sys
 import time
 
 parser = argparse.ArgumentParser(description="Test PhantomBot to ensure it is running and connected")


### PR DESCRIPTION
Fixes this error:

```
$ python3 ./healthcheck.py
Restarting phantombot due to failure lastalive...
Traceback (most recent call last):
  File "./healthcheck.py", line 127, in <module>
    dofailure("lastalive", "Last alive timestamp has expired")
  File "./healthcheck.py", line 41, in dofailure
    print("Health Check Failed (" + type + "):" + message, file=sys.stderr)
NameError: name 'sys' is not defined
```