### PR TITLE
Separate global and user cooldowns on discord

### DIFF
--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -42,6 +42,7 @@
 
     /*
      * @class Cooldown
+     *
      * @param {String}  command
      * @param {Number}  globalSec
      * @param {Number}  userSec
@@ -55,9 +56,9 @@
     }
 
     /*
-     * @function Stringify
+     * @function toJSONString
+     *
      * @param {String}  command
-     * 
      * @return {JSON String}
      */ 
     function toJSONString(command) {
@@ -211,8 +212,8 @@
      *
      * @export $.coolDown
      * @param {String}  command
-     * @param {Number}  seconds
-     * @param {Boolean} isGlobal
+     * @param {Number}  globalSec
+     * @param {Number}  userSec
      */
     function add(command, globalSec, userSec) {
         if (cooldowns[command] === undefined) {
@@ -326,7 +327,7 @@
          * @commandpath coolcom [command] [user=seconds] [global=seconds] - Sets a cooldown for a command, default is global if no type and no secondary type is given. Using -1 for the seconds removes the cooldown.
          */
         if (command.equalsIgnoreCase('coolcom')) {
-            if(action === undefined || subAction === undefined) {
+            if(action === undefined || isNaN(parseInt(undefined))) {
                 $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
                 return;
             }

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -327,7 +327,7 @@
          * @commandpath coolcom [command] [user=seconds] [global=seconds] - Sets a cooldown for a command, default is global if no type and no secondary type is given. Using -1 for the seconds removes the cooldown.
          */
         if (command.equalsIgnoreCase('coolcom')) {
-            if(action === undefined || isNaN(parseInt(undefined))) {
+            if(action === undefined || isNaN(parseInt(subAction))) {
                 $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
                 return;
             }

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -335,4 +335,43 @@
         $.inidb.SetBoolean('updates', '', 'installedv3.6.0', true);
     }
 
+    /* version 3.6.0 updates */
+    if (!$.inidb.GetBoolean('updates', '', 'installedv3.7.0')) {
+        $.consoleLn('Starting PhantomBot update 3.7.0 updates...');
+
+        // Convert cooldowns to separate global and user cooldowns
+        var cooldowns = $.inidb.GetKeyList('discordCooldown', ''),
+                json,
+                i;
+
+
+        for (i in cooldowns) {
+            json = JSON.parse($.inidb.get('discordCooldown', cooldowns[i]));
+
+            var globalSec,
+                userSec,
+                curSec = parseInt(json.seconds);
+
+            if (json.isGlobal.toString().equals('true')) {
+                globalSec = curSec;
+                userSec = -1;
+            } else {
+                globalSec = -1;
+                userSec = curSec;
+            }
+
+            $.inidb.set('discordCooldown', cooldowns[i], JSON.stringify({
+                command: String(json.command),
+                globalSec: globalSec,
+                userSec: userSec
+            }));
+        }
+
+        //Send cooldown messages in discord channel? (default=false)
+        $.inidb.SetBoolean('discordCooldownSettings', '', 'coolDownMsgEnabled', false);
+
+        $.consoleLn('PhantomBot update 3.7.0 completed!');
+        $.inidb.SetBoolean('updates', '', 'installedv3.7.0', true);
+    }
+
 })();

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -331,14 +331,6 @@
             $.inidb.set('settings', 'quoteMessage', $.inidb.get('settings', 'quoteMessage').replace('(user)', '(userrank)'));
         }
 
-        $.consoleLn('PhantomBot update 3.6.0 completed!');
-        $.inidb.SetBoolean('updates', '', 'installedv3.6.0', true);
-    }
-
-    /* version 3.6.0 updates */
-    if (!$.inidb.GetBoolean('updates', '', 'installedv3.7.0')) {
-        $.consoleLn('Starting PhantomBot update 3.7.0 updates...');
-
         // Convert cooldowns to separate global and user cooldowns
         var cooldowns = $.inidb.GetKeyList('discordCooldown', ''),
                 json,
@@ -370,8 +362,7 @@
         //Send cooldown messages in discord channel? (default=false)
         $.inidb.SetBoolean('discordCooldownSettings', '', 'coolDownMsgEnabled', false);
 
-        $.consoleLn('PhantomBot update 3.7.0 completed!');
-        $.inidb.SetBoolean('updates', '', 'installedv3.7.0', true);
+        $.consoleLn('PhantomBot update 3.6.0 completed!');
+        $.inidb.SetBoolean('updates', '', 'installedv3.6.0', true);
     }
-
 })();

--- a/javascript-source/discord/core/commandCooldown.js
+++ b/javascript-source/discord/core/commandCooldown.js
@@ -278,7 +278,7 @@
             actionArgs = args[2];
 
         /*
-         * @commandpath coolcom [command] [seconds] [type (global / user)] - Sets a cooldown for a command, default is global. Using -1 for the seconds removes the cooldown.
+         * @commandpath coolcom [command] [user=seconds] [global=seconds] - Sets a cooldown for a command, default is global if no type and no secondary type is given. Using -1 for the seconds removes the cooldown.
          */
         if (command.equalsIgnoreCase('coolcom')) {
             if (action === undefined || isNaN(parseInt(subAction))) {

--- a/javascript-source/discord/core/commandCooldown.js
+++ b/javascript-source/discord/core/commandCooldown.js
@@ -24,19 +24,41 @@
         defaultCooldowns = [],
         cooldowns = [];
 
+    const   Type = {
+            User: 'user',
+            Global: 'global',
+        },
+        Operation = {
+            UnSet: -1,
+            UnChanged: 0,
+        };
+
     /*
      * @class Cooldown
+     * @param {String}  command
+     * @param {Number}  globalSec
+     * @param {Number}  userSec
+     */
+    function Cooldown(command, globalSec, userSec) {
+        this.command = command;
+        this.globalSec = globalSec;
+        this.userSec = userSec;
+        this.userTimes = [];
+        this.globalTime = 0; 
+    }
+
+    /*
+     * @function toJSONString
      *
      * @param {String}  command
-     * @param {Number}  seconds
-     * @param {Boolean} isGlobal
-     */
-    function Cooldown(command, seconds, isGlobal) {
-        this.isGlobal = isGlobal;
-        this.command = command;
-        this.seconds = seconds;
-        this.cooldowns = [];
-        this.time = 0;
+     * @return {JSON String}
+     */ 
+    function toJSONString(command) {
+        return JSON.stringify({
+            command: String(command.command),
+            globalSec: command.globalSec,
+            userSec: command.userSec
+        });
     }
 
     /*
@@ -50,42 +72,58 @@
         for (i in commands) {
             json = JSON.parse($.inidb.get('discordCooldown', commands[i]));
 
-            cooldowns[commands[i]] = new Cooldown(json.command, json.seconds, (json.isGlobal == true));
+            cooldowns[commands[i]] = new Cooldown(json.command, json.globalSec, json.userSec);
         }
     }
 
     /*
      * @function get
      *
-     * @export $.coolDown
+     * @export $.discord.coolDown
      * @param  {String}  command
      * @param  {String}  username
      * @return {Number}
      */
     function get(command, username) {
-        var cooldown = cooldowns[command];
+        var isGlobal = false,
+            maxCoolDown = 0,
+            cooldown = cooldowns[command],
+            useDefault = false;
+        
+    if (cooldown !== undefined) {
+        
+        if (cooldown.globalSec !== Operation.UnSet) {
+            isGlobal = true;
+            if (cooldown.globalTime > $.systemTime()) {
+                maxCoolDown = getTimeDif(cooldown.globalTime);
+            } else if(cooldown.userTimes[username] === undefined || (cooldown.userTimes[username] !== undefined && cooldown.userTimes[username] < $.systemTime())){ //Only set a cooldown timer if the user can actually use the command
+                set(command, useDefault, cooldown.globalSec, undefined);
+            } 
+        }
 
-        if (cooldown !== undefined) {
-            if (cooldown.isGlobal) {
-                if (cooldown.time > $.systemTime()) {
-                    return cooldown.time;
-                } else {
-                    return set(command, true, cooldown.seconds);
+        if (cooldown.userSec !== Operation.UnSet) {
+            if (cooldown.userTimes[username] !== undefined && cooldown.userTimes[username] > $.systemTime()) {
+                userCoolDown = getTimeDif(cooldown.userTimes[username]);
+                if(userCoolDown > maxCoolDown) {
+                    isGlobal = false;
+                    maxCoolDown = userCoolDown;
                 }
-            } else {
-                if (cooldown.cooldowns[username] !== undefined && cooldown.cooldowns[username] > $.systemTime()) {
-                    return cooldown.cooldowns[username];
-                } else {
-                    return set(command, true, cooldown.seconds, username);
-                }
-            }
-        } else {
-            if (defaultCooldowns[command] !== undefined && defaultCooldowns[command] > $.systemTime()) {
-                return defaultCooldowns[command];
-            } else {
-                return set(command, false, defaultCooldownTime);
+            } else if (maxCoolDown === 0){ //Global cooldown got set ... also set user cooldown or only per-user cooldown is activated
+                set(command, useDefault, cooldown.userSec, username);
             }
         }
+        return [maxCoolDown, isGlobal];
+    }
+
+
+    if (defaultCooldowns[command] !== undefined && defaultCooldowns[command] > $.systemTime()) {
+        maxCoolDown = getTimeDif(defaultCooldowns[command]);
+    } else {
+        useDefault  = true;
+        set(command, useDefault, defaultCooldownTime, undefined);
+    }
+
+    return [maxCoolDown, isGlobal];
     }
 
     /*
@@ -93,57 +131,62 @@
      *
      * @export $.coolDown
      * @param  {String}  command
-     * @param  {Boolean} hasCooldown
-     * @param  {Number}  seconds
+     * @param  {Boolean} useDefault
+     * @param  {Number}  duration
      * @param  {String}  username
-     * @return {Number}
      */
-    function set(command, hasCooldown, seconds, username) {
-        seconds = ((parseInt(seconds) * 1e3) + $.systemTime());
+    function set(command, useDefault, duration, username) {
+        finishTime = (duration > 0 ? ((parseInt(duration) * 1e3) + $.systemTime()) : 0);
 
-        if (hasCooldown) {
-            if (username === undefined) {
-                cooldowns[command].time = seconds;
-            } else {
-                cooldowns[command].cooldowns[username] = seconds;
-            }
-        } else {
-            defaultCooldowns[command] = seconds;
+        if (useDefault) {
+            defaultCooldowns[command] = finishTime;
+            return;
         }
-        return 0;
+
+        if (username === undefined) {
+            cooldowns[command].globalTime = finishTime;
+        } else {
+            cooldowns[command].userTimes[username] = finishTime;
+        }
+    }
+
+    function getTimeDif(cooldownSec) {
+        return (cooldownSec - $.systemTime() > 1000 ? Math.ceil(((cooldownSec - $.systemTime()) / 1000)) : 1);
+    }
+
+
+    function exists(command) {
+        return defaultCooldowns[command] !== undefined || cooldowns[command] !== undefined;
     }
 
     /*
      * @function add
      *
-     * @export $.coolDown
+     * @export $.discord.coolDown
      * @param {String}  command
-     * @param {Number}  seconds
-     * @param {Boolean} isGlobal
+     * @param {Number}  globalSec
+     * @param {Number}  userSec
      */
-    function add(command, seconds, isGlobal) {
+    function add(command, globalSec, userSec) {
         if (cooldowns[command] === undefined) {
-            cooldowns[command] = new Cooldown(command, seconds, isGlobal);
-            $.inidb.set('discordCooldown', command, JSON.stringify({
-                command: String(command),
-                seconds: String(seconds),
-                isGlobal: String(isGlobal)
-            }));
+            cooldowns[command] = new Cooldown(command, 
+                                             (globalSec === Operation.UnChanged ? Operation.UnSet : globalSec), 
+                                             (userSec === Operation.UnChanged ? Operation.UnSet : userSec));
         } else {
-            cooldowns[command].isGlobal = isGlobal;
-            cooldowns[command].seconds = seconds;
-            $.inidb.set('discordCooldown', command, JSON.stringify({
-                command: String(command),
-                seconds: String(seconds),
-                isGlobal: String(isGlobal)
-            }));
+            if (globalSec !== Operation.UnChanged) {
+                cooldowns[command].globalSec = globalSec;
+            }
+            if (userSec !== Operation.UnChanged) {
+                cooldowns[command].userSec = userSec;
+            }
         }
+        $.inidb.set('discordCooldown', command, toJSONString(cooldowns[command]));
     }
 
     /*
      * @function remove
      *
-     * @export $.coolDown
+     * @export $.discord.coolDown
      * @param {String}  command
      */
     function remove(command) {
@@ -156,12 +199,68 @@
     /*
      * @function clear
      *
-     * @export $.coolDown
+     * @export $.discord.coolDown
      * @param {String}  command
      */
     function clear(command) {
         if (cooldowns[command] !== undefined) {
-            cooldowns[command].time = 0;
+            cooldowns[command].globalTime = 0;
+            cooldowns[command].userTimes = [];
+        }
+    }
+
+    /*
+     * @function handleCoolCom
+     *
+     * @param {String}  sender
+     * @param {String}  channel
+     * @param {String}  command
+     * @param {String}  first
+     * @param {String}  second
+     */
+    function handleCoolCom(mention, channel, command, first, second) {
+        var action1 = first.split("="),
+            type1   = action1[0],
+            secsG   = Operation.UnChanged,
+            secsU   = Operation.UnChanged;
+
+        if(!isNaN(parseInt(type1)) && second === undefined) { //Only assume this is global if no secondary action is present
+            type1 = Type.Global;
+            secsG = ParseInt(type1);
+        } else if (!type1.equalsIgnoreCase(Type.Global) && !type1.equalsIgnoreCase(Type.User) || isNaN(parseInt(action1[1]))) {
+            $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.cooldown.coolcom.usage'));
+            return;
+        } else {
+            secsG = type1.equalsIgnoreCase(Type.Global) ? parseInt(action1[1]) : secsG;
+            secsU = type1.equalsIgnoreCase(Type.User) ? parseInt(action1[1]) : secsU;
+        }
+
+        
+        if (second !== undefined){
+            var action2 = second.split("="),
+                type2   = action2[0];
+
+            if (!type2.equalsIgnoreCase(Type.Global) && !type2.equalsIgnoreCase(Type.User) || isNaN(parseInt(action2[1])) || type2.equalsIgnoreCase(type1)) {
+                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.cooldown.coolcom.usage'));
+                return;
+            } else {
+                secsG = type2.equalsIgnoreCase(Type.Global) ? parseInt(action2[1]) : secsG;
+                secsU = type2.equalsIgnoreCase(Type.User) ? parseInt(action2[1]) : secsU;
+            }
+        }
+
+        if (secsG === Operation.UnSet && secsU === Operation.UnSet) {
+            remove(command);
+        } else {
+            add(command, secsG, secsU);
+            clear(command);
+        }     
+
+        if(action2 !== undefined) {
+            $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.cooldown.coolcom.setCombo', command, secsG, secsU));
+        } else {
+            messageType = type1.equalsIgnoreCase(Type.Global) ? "discord.cooldown.coolcom.setGlobal" : "discord.cooldown.coolcom.setUser";
+            $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get(messageType, command, (secsG === Operation.UnChanged ? secsU : secsG)));
         }
     }
 
@@ -187,18 +286,7 @@
                 return;
             }
 
-            actionArgs = (actionArgs !== undefined && actionArgs == 'user' ? false : true);
-            action = action.replace('!', '').toLowerCase();
-            subAction = parseInt(subAction);
-
-            if (subAction > -1) {
-                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.cooldown.coolcom.set', action, subAction));
-                add(action, subAction, actionArgs);
-            } else {
-                $.discord.say(channel, $.discord.userPrefix(mention) + $.lang.get('discord.cooldown.coolcom.remove', action));
-                remove(action);
-            }
-            clear(command);
+            handleCoolCom(mention, channel, action, subAction, actionArgs);
             return;
         }
 
@@ -241,7 +329,9 @@
     $.bind('webPanelSocketUpdate', function(event) {
         if (event.getScript().equalsIgnoreCase('./discord/core/commandCoolDown.js')) {
             if (event.getArgs()[0] == 'add') {
-                add(event.getArgs()[1], event.getArgs()[2], event.getArgs()[3].equals('true'));
+                add(event.getArgs()[1], event.getArgs()[2], event.getArgs()[3]);
+            } else if (event.getArgs()[0] == 'update') {
+                defaultCooldownTime = $.getIniDbNumber('discordCooldownSettings', 'defaultCooldownTime', 5);
             } else {
                 remove(event.getArgs()[1]);
             }
@@ -252,6 +342,7 @@
     $.discord.cooldown = {
         remove: remove,
         clear: clear,
+        exists: exists,
         get: get,
         set: set,
         add: add

--- a/javascript-source/discord/core/commandCooldown.js
+++ b/javascript-source/discord/core/commandCooldown.js
@@ -328,9 +328,9 @@
      */
     $.bind('webPanelSocketUpdate', function(event) {
         if (event.getScript().equalsIgnoreCase('./discord/core/commandCoolDown.js')) {
-            if (event.getArgs()[0] == 'add') {
+            if (event.getArgs()[0] === 'add') {
                 add(event.getArgs()[1], event.getArgs()[2], event.getArgs()[3]);
-            } else if (event.getArgs()[0] == 'update') {
+            } else if (event.getArgs()[0] === 'update') {
                 defaultCooldownTime = $.getIniDbNumber('discordCooldownSettings', 'defaultCooldownTime', 5);
             } else {
                 remove(event.getArgs()[1]);

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -627,11 +627,6 @@
 
             [cooldownDuration, isGlobalCooldown] = $.discord.cooldown.get(cooldownCommand, senderId);
 
-            consoleLn("Username:" + username + " userid: " + senderId + " command: " + command + " cooldown command: " + cooldownCommand);
-            consoleLn("resolved username: " + $.discord.userPrefix(username) +  " resolved userid: " + $.discord.userPrefix(senderId));
-            consoleLn("Duration:" + cooldownDuration + " global: " + isGlobalCooldown + " admin: " + isAdmin);
-            consoleLn("messages enabled: " + $.getIniDbBoolean('discordCooldownSettings', 'coolDownMsgEnabled'));
-
             if (isAdmin === false && cooldownDuration > 0) {
                 if ($.getIniDbBoolean('discordCooldownSettings', 'coolDownMsgEnabled')) {
                     consoleDebug('Discord command ! ' + command + ' was not sent due to it being on cooldown ' + (isGlobalCooldown ? 'globally' : 'for user' + username) + '.');

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -542,13 +542,15 @@
 
             [cooldownDuration, isGlobalCooldown] = $.coolDown.get(cooldownCommand, sender, isMod);
 
-            if (cooldownDuration > 0 && $.getIniDbBoolean('settings', 'coolDownMsgEnabled')) {
-                if (isGlobalCooldown) {
-                    $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.global', command, cooldownDuration), true);
-                    consoleDebug('Command ! ' + command + ' was not sent due to it being on a global cooldown.');
-                } else {
-                    $.say($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.user', command, cooldownDuration));
-                    consoleDebug('Command ! ' + command + ' was not sent due to it being on cooldown for user ' + sender + '.');
+            if (cooldownDuration > 0) {
+                consoleDebug('Command ! ' + command + ' was not sent due to it being on cooldown ' + (isGlobalCooldown ? 'globally' : 'for user' + sender) + '.');
+                if ($.getIniDbBoolean('settings', 'coolDownMsgEnabled')) {
+                    if (isGlobalCooldown) {
+                        $.sayWithTimeout($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.global', command, cooldownDuration), true);
+                        
+                    } else {
+                        $.say($.whisperPrefix(sender) + $.lang.get('init.cooldown.msg.user', command, cooldownDuration));
+                    }
                 }
                 return;
             }
@@ -611,7 +613,34 @@
                 return;
             }
 
-            if (isAdmin == false && $.discord.cooldown.get(command, senderId) !== 0) {
+            // Check the command cooldown.
+            var cooldownDuration,
+                isGlobalCooldown,
+                cooldownCommand = command;
+
+            if (args.length === 1 && $.discord.cooldown.exists(cooldownCommand + ' ' + args[0])) {
+                cooldownCommand += ' ' + args[0];
+            }
+            if (args.length > 1 && $.discord.cooldown.exists(cooldownCommand + ' ' + args[1])) {
+                cooldownCommand += ' ' + args[1];
+            } 
+
+            [cooldownDuration, isGlobalCooldown] = $.discord.cooldown.get(cooldownCommand, senderId);
+
+            consoleLn("Username:" + username + " userid: " + senderId + " command: " + command + " cooldown command: " + cooldownCommand);
+            consoleLn("resolved username: " + $.discord.userPrefix(username) +  " resolved userid: " + $.discord.userPrefix(senderId));
+            consoleLn("Duration:" + cooldownDuration + " global: " + isGlobalCooldown + " admin: " + isAdmin);
+            consoleLn("messages enabled: " + $.getIniDbBoolean('discordCooldownSettings', 'coolDownMsgEnabled'));
+
+            if (isAdmin === false && cooldownDuration > 0) {
+                if ($.getIniDbBoolean('discordCooldownSettings', 'coolDownMsgEnabled')) {
+                    consoleDebug('Discord command ! ' + command + ' was not sent due to it being on cooldown ' + (isGlobalCooldown ? 'globally' : 'for user' + username) + '.');
+                    if (isGlobalCooldown) {
+                        $.discord.say(channelId, $.discord.userPrefix(username) + $.lang.get('init.cooldown.msg.global', command, cooldownDuration));
+                    } else {
+                        $.discord.say(channelId, $.discord.userPrefix(username) + $.lang.get('init.cooldown.msg.user', command, cooldownDuration));
+                    }
+                }
                 return;
             }
 

--- a/javascript-source/lang/english/discord/core/core-commandCooldown.js
+++ b/javascript-source/lang/english/discord/core/core-commandCooldown.js
@@ -15,9 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$.lang.register('discord.cooldown.coolcom.usage', 'Usage: !coolcom [command] [seconds] [type (global / user)] - Using -1 for the seconds removes the cooldown.');
+$.lang.register('discord.cooldown.coolcom.usage', 'Usage: !coolcom [command] [seconds / global=seconds / user=seconds] [global=seconds / user=seconds] - Using -1 for the seconds removes the cooldown. Only specifying seconds assumes global only if no secondary argument is given!');
 $.lang.register('discord.cooldown.coolcom.set', 'Cooldown for command !$1 has been set to $2 seconds.');
 $.lang.register('discord.cooldown.coolcom.remove', 'Cooldown for command !$1 has been removed.');
 $.lang.register('discord.cooldown.cooldown.usage', 'Usage: !cooldown [setdefault]');
 $.lang.register('discord.cooldown.default.set', 'The default cooldown for commands without one has been set to $1 seconds.');
 $.lang.register('discord.cooldown.default.usage', 'Usage: !cooldown setdefault [seconds] - Set a cooldown for commands that don\'t have one.');
+$.lang.register('discord.cooldown.coolcom.setGlobal', 'Cooldown for command !$1 has globally been set to $2 seconds.');
+$.lang.register('discord.cooldown.coolcom.setUser', 'Cooldown for command !$1 has been set to $2 seconds individually for each user.');
+$.lang.register('discord.cooldown.coolcom.setCombo', 'Cooldown for command !$1 has globally been set to $2 seconds and to $3 seconds individually for each user.');

--- a/resources/web/panel/js/pages/discord/discordDefaultCommands.js
+++ b/resources/web/panel/js/pages/discord/discordDefaultCommands.js
@@ -172,12 +172,12 @@ $(run = function() {
                                 // Append input box for the command alias.
                                 .append(helpers.getInputGroup('command-alias', 'text', 'Alias', '!ex', helpers.getDefaultIfNullOrUndefined(e.discordAliascom, ''),
                                     'Another command name that will also trigger this command.'))
-                                // Append input box for the command cooldown.
-                                .append(helpers.getInputGroup('command-cooldown', 'number', 'Cooldown (Seconds)', '0', helpers.getDefaultIfNullOrUndefined(cooldownJson.seconds, '0'),
-                                    'Cooldown of the command in seconds.')
-                                    // Append checkbox for if the cooldown is global or per-user.
-                                    .append(helpers.getCheckBox('command-cooldown-global', cooldownJson.isGlobal === 'true', 'Global',
-                                        'If checked the cooldown will be applied to everyone in the channel. When not checked, the cooldown is applied per-user.')))
+                                // Append input box for the global command cooldown.
+                                .append(helpers.getInputGroup('command-cooldown-global', 'number', 'Global Cooldown (Seconds)', '-1', cooldownJson.globalSec,
+                                    'Global Cooldown of the command in seconds. -1 Uses the bot-wide settings.'))
+                                // Append input box for per-user cooldown.
+                                .append(helpers.getInputGroup('command-cooldown-user', 'number', 'Per-User Cooldown (Seconds)', '-1', cooldownJson.userSec,
+                                    'Per-User cooldown of the command in seconds. -1 removes per-user cooldown.'))
                                 // Callback function to be called once we hit the save button on the modal.
                         })), function() {
                             let commandName = $('#command-name'),
@@ -185,8 +185,8 @@ $(run = function() {
                                 commandCost = $('#command-cost'),
                                 commandChannel = $('#command-channel'),
                                 commandAlias = $('#command-alias'),
-                                commandCooldown = $('#command-cooldown'),
-                                commandCooldownGlobal = $('#command-cooldown-global').is(':checked');
+                                commandCooldownGlobal = $('#command-cooldown-global'),
+                                commandCooldownUser = $('#command-cooldown-user');
 
                             // Remove the ! and spaces.
                             commandName.val(commandName.val().replace(/\!/g, '').toLowerCase());
@@ -215,14 +215,15 @@ $(run = function() {
                             // Handle each input to make sure they have a value.
                             switch (false) {
                                 case helpers.handleInputString(commandName):
-                                case helpers.handleInputNumber(commandCooldown):
+                                case helpers.handleInputNumber(commandCooldownGlobal, -1):
+                                case helpers.handleInputNumber(commandCooldownUser, -1):
                                     break;
                                 default:
                                     // Save command information here and close the modal.
                                     socket.updateDBValues('custom_command_add', {
-                                        tables: ['discordPricecom', 'discordPermcom', 'discordCooldown'],
+                                        tables: ['discordPricecom', 'discordPermcom'],
                                         keys: [commandName.val(), commandName.val(), commandName.val()],
-                                        values: [commandCost.val(), JSON.stringify(permObj), JSON.stringify({command: String(commandName.val()), seconds: String(commandCooldown.val()), isGlobal: String(commandCooldownGlobal)})]
+                                        values: [commandCost.val(), JSON.stringify(permObj)]
                                     }, function() {
                                         if (commandChannel.val().length > 0) {
                                             socket.updateDBValue('discord_channel_command_cmd', 'discordChannelcom', commandName.val(), commandChannel.val(), new Function());
@@ -236,21 +237,25 @@ $(run = function() {
                                             socket.removeDBValue('discord_alias_command_cmd', 'discordAliascom', commandName.val(), new Function());
                                         }
 
-                                        // Reload the table.
-                                        run();
-                                        // Close the modal.
-                                        $('#edit-command').modal('hide');
-                                        // Tell the user the command was added.
-                                        toastr.success('Successfully edited command !' + commandName.val());
+                                        socket.wsEvent('custom_command_edit_cooldown_ws', './discord/core/commandCoolDown.js', null,
+                                            ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val()], function () {
 
-                                        // I hate doing this, but the logic is fucked anyways.
-                                        helpers.setTimeout(function() {
-                                            // Add the cooldown to the cache.
-                                            socket.wsEvent('discord', './discord/commands/customCommands.js', '',
-                                                [commandName.val(), JSON.stringify(permObj),
-                                                commandChannel.val(), commandAlias.val(), commandCost.val()], new Function());
-                                        }, 5e2);
-                                    });
+                                            // Reload the table.
+                                            run();
+                                            // Close the modal.
+                                            $('#edit-command').modal('hide');
+                                            // Tell the user the command was added.
+                                            toastr.success('Successfully edited command !' + commandName.val());
+
+                                            // I hate doing this, but the logic is fucked anyways.
+                                            helpers.setTimeout(function() {
+                                                // Add the cooldown to the cache.
+                                                socket.wsEvent('discord', './discord/commands/customCommands.js', '',
+                                                    [commandName.val(), JSON.stringify(permObj),
+                                                    commandChannel.val(), commandAlias.val(), commandCost.val()], new Function());
+                                            }, 5e2);
+                                        });
+                                });
                             }
                         }).on('shown.bs.modal', function(e) {
                             $('#command-permission').select2();

--- a/resources/web/panel/js/pages/settings/commandSettings.js
+++ b/resources/web/panel/js/pages/settings/commandSettings.js
@@ -37,7 +37,7 @@ $(run = function() {
         // Set global cooldown.
         $('#global-cooldown').val(e.defaultCooldownTime);
         // Remove discord cooldown or get data.
-        if(e.hasDiscord != 'true') {
+        if(e.hasDiscord !== 'true') {
             $('#cmd-discord-cooldown-messages').parent().parent().remove();
             $('#global-discord-cooldown').parent().remove();
         } else {
@@ -45,7 +45,7 @@ $(run = function() {
                 tables: ['discordCooldownSettings', 'discordCooldownSettings'],
                 keys: ['defaultCooldownTime', 'coolDownMsgEnabled']
                 }, true, function(e) {
-                    $('#cmd-discord-cooldown-messages').val((e.coolDownMsgEnabled === 'true' ? 'Yes' : 'No'))
+                    $('#cmd-discord-cooldown-messages').val((e.coolDownMsgEnabled === 'true' ? 'Yes' : 'No'));
                     $('#global-discord-cooldown').val(e.defaultCooldownTime);
                 });
         }

--- a/resources/web/panel/js/pages/settings/commandSettings.js
+++ b/resources/web/panel/js/pages/settings/commandSettings.js
@@ -20,9 +20,9 @@ $(run = function() {
     // Get command settings.
     socket.getDBValues('get_command_settings', {
         tables: ['settings', 'settings', 'settings', 'settings', 'cooldownSettings',
-            'cooldownSettings'],
+            'cooldownSettings', 'panelData'],
         keys: ['permComMsgEnabled', 'priceComMsgEnabled', 'coolDownMsgEnabled',
-            'pricecomMods', 'modCooldown', 'defaultCooldownTime']
+            'pricecomMods', 'modCooldown', 'defaultCooldownTime', 'hasDiscord']
     }, true, function(e) {
         // Set cost message.
         $('#cmd-cost-messages').val((e.priceComMsgEnabled === 'true' ? 'Yes' : 'No'));
@@ -36,6 +36,19 @@ $(run = function() {
         $('#cooldown-mods').val((e.modCooldown === 'true' ? 'No' : 'Yes'));
         // Set global cooldown.
         $('#global-cooldown').val(e.defaultCooldownTime);
+        // Remove discord cooldown or get data.
+        if(e.hasDiscord != 'true') {
+            $('#cmd-discord-cooldown-messages').parent().parent().remove();
+            $('#global-discord-cooldown').parent().remove();
+        } else {
+            socket.getDBValues('get_discord_command_settings', {
+                tables: ['discordCooldownSettings', 'discordCooldownSettings'],
+                keys: ['defaultCooldownTime', 'coolDownMsgEnabled']
+                }, true, function(e) {
+                    $('#cmd-discord-cooldown-messages').val((e.coolDownMsgEnabled === 'true' ? 'Yes' : 'No'))
+                    $('#global-discord-cooldown').val(e.defaultCooldownTime);
+                });
+        }
     });
 });
 
@@ -48,19 +61,37 @@ $(function() {
             cmdCooldownMessage = $('#cmd-cooldown-messages').find(':selected').text() === 'Yes',
             priceComMods = $('#pricecom-mods').find(':selected').text() !== 'Yes',
             cooldownMods = $('#cooldown-mods').find(':selected').text() !== 'Yes',
-            globalTime = $('#global-cooldown');
+            globalTime = $('#global-cooldown'),
+            discordCmdCooldownMessage = $('#cmd-discord-cooldown-messages').find(':selected').text() === 'Yes',
+            discordCooldown = $('#global-discord-cooldown');
+
+        // Check if element exists -> saves another DB-Lookup
+        if(discordCooldown !== undefined) {
+            if (!helpers.handleInputNumber(discordCooldown, 5) === null) {
+                return;
+            }
+        }
 
         switch (false) {
             case helpers.handleInputNumber(globalTime, 5):
                 break;
             default:
+                
+                if(discordCooldown !== undefined) {
+                    socket.updateDBValues('update_dc_global_CD', {
+                        tables: ['discordCooldownSettings', 'discordCooldownSettings'],
+                        keys: ['defaultCooldownTime', 'coolDownMsgEnabled'],
+                        values: [discordCooldown.val(), discordCmdCooldownMessage]
+                        }, function() {
+                        socket.wsEvent('update_dc_global_CD_ws', './discord/core/commandCoolDown.js', null, ['update'], new Function());
+                        //If the socket fails here it will fail in the next wsEvent as well and inform the user
+                    });
+                }
+
                 socket.updateDBValues('update_cmd_settings', {
-                    tables: ['settings', 'settings', 'settings', 'settings', 'cooldownSettings',
-                        'cooldownSettings'],
-                    keys: ['permComMsgEnabled', 'priceComMsgEnabled', 'coolDownMsgEnabled',
-                        'pricecomMods', 'modCooldown', 'defaultCooldownTime'],
-                    values: [cmdPermMessage, cmdCostMessage, cmdCooldownMessage,
-                        priceComMods, cooldownMods, globalTime.val()]
+                    tables: ['settings', 'settings', 'settings', 'settings', 'cooldownSettings', 'cooldownSettings'],
+                    keys: ['permComMsgEnabled', 'priceComMsgEnabled', 'coolDownMsgEnabled', 'pricecomMods', 'modCooldown', 'defaultCooldownTime'],
+                    values: [cmdPermMessage, cmdCostMessage, cmdCooldownMessage, priceComMods, cooldownMods, globalTime.val()]
                 }, function() {
                     socket.wsEvent('update_cmd_settings_ws', './core/commandCoolDown.js', null, ['update'], function() {
                         toastr.success('Successfully update command settings!');

--- a/resources/web/panel/pages/settings/commandSettings.html
+++ b/resources/web/panel/pages/settings/commandSettings.html
@@ -63,11 +63,23 @@
                     </div>
 
                     <div class="form-group">
-                        <!-- Permcom toggle. -->
-                        <label for="cmd-cooldown-messages">Enable Cooldown Messages</label>
+                        <!-- Twitch Permcom toggle. -->
+                        <label for="cmd-cooldown-messages">Enable Cooldown Messages on Twitch</label>
                         <div class="dropdown">
                             <select class="form-control" id="cmd-cooldown-messages" style="cursor: pointer;" data-toggle="tooltip"
                                 title="If a message should be said in a chat when a user tries to use a command that's still on cooldown.">
+                                <option>Yes</option>
+                                <option>No</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <!-- Discord Permcom toggle. -->
+                        <label for="cmd-dc-cooldown-messages">Enable Cooldown Messages on Discord</label>
+                        <div class="dropdown">
+                            <select class="form-control" id="cmd-discord-cooldown-messages" style="cursor: pointer;" data-toggle="tooltip"
+                                title="If a message should be said in the channel when a user tries to use a command that's still on cooldown.">
                                 <option>Yes</option>
                                 <option>No</option>
                             </select>
@@ -106,8 +118,13 @@
                 <div class="tab-pane" id="cmd_settings_cooldown">
                     <!-- Logs keep days. -->
                     <div class="form-group">
-                        <label for="global-cooldown">Global Cooldown (Seconds)</label>
+                        <label for="global-cooldown">Global Twitch Cooldown (Seconds)</label>
                         <input type="number" class="form-control" id="global-cooldown" data-toggle="tooltip"
+                            title="Cooldown given to commands that don't have a custom cooldown. Minimum is 5 seconds."/>
+                    </div>
+                    <div class="form-group">
+                        <label for="global-discord-cooldown">Global Discord Cooldown (Seconds)</label>
+                        <input type="number" class="form-control" id="global-discord-cooldown" data-toggle="tooltip"
                             title="Cooldown given to commands that don't have a custom cooldown. Minimum is 5 seconds."/>
                     </div>
                 </div>


### PR DESCRIPTION
Port [PR #2720](https://github.com/PhantomBot/PhantomBot/pull/2720) to discord.

![image](https://user-images.githubusercontent.com/572591/161607746-871f0952-2b18-4ea5-b430-ba0672136042.png)
Don't mind my broken discord -😅

Images of the panel-side
![image](https://user-images.githubusercontent.com/572591/161608106-fd23af73-b94d-478b-98d3-c471f0255559.png)
![image](https://user-images.githubusercontent.com/572591/161608187-2ec4218b-1864-4210-89af-c57c7cb7f0ed.png)
![image](https://user-images.githubusercontent.com/572591/161608231-4feb1b7a-3e07-444a-90b4-e6abf49976c6.png)

This PR also fixes the cooldown being ignored if the `coolDownMsgEnabled` was disabled, as well as printing the Debug output no matter if the coolDownMsg is enabled or not.

Edit: I assume major changes for 3.6.0 are already locked in, which is why I've created a separate update 3.7.0