### PR TITLE
[TicketRaffle] Improve Ticket Raffle

### DIFF
--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -32,8 +32,8 @@ $.lang.register('ticketrafflesystem.entered.bonus', '$1 (+ $2 bonus) entries add
 $.lang.register('ticketrafflesystem.usage', 'Usage: !traffle open [max entries] [regulars ticket multiplier (default = 1)] [subscribers ticket multiplier (default = 1)] [cost] [-followers]');
 $.lang.register('ticketrafflesystem.msg.enabled', 'Ticket raffle message\'s have been enabled.');
 $.lang.register('ticketrafflesystem.msg.disabled', 'Ticket raffle message\'s have been disabled.');
-$.lang.register('ticketrafflesystem.ticket.usage', 'Usage: !tickets (amount) - And you currently have $1 tickets.');
-$.lang.register('ticketrafflesystem.ticket.usage.bonus', 'Usage: !tickets (amount) - And you currently have $1 (+ $2 bonus) tickets.');
+$.lang.register('ticketrafflesystem.ticket.usage', 'Usage: !tickets (amount / max) - And you currently have $1 tickets.');
+$.lang.register('ticketrafflesystem.ticket.usage.bonus', 'Usage: !tickets (amount / max) - And you currently have $1 (+ $2 bonus) tickets.');
 $.lang.register('ticketrafflesystem.auto.msginterval.set', 'Message interval set to $1 minutes.');
 $.lang.register('ticketrafflesystem.auto.msg.set', 'Message set to $1.');
 $.lang.register('ticketrafflesystem.auto.msg.usage', 'Usage: !traffle autoannouncemessage [amount in minutes]');

--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -22,7 +22,10 @@ $.lang.register('ticketrafflesystem.raffle.opened', 'Ticket raffle is now open! 
 $.lang.register('ticketrafflesystem.err.raffle.not.opened', 'There is no ticket raffle opened.');
 $.lang.register('ticketrafflesystem.raffle.closed', 'The ticket raffle is now closed. Use "!traffle draw" to draw a winner.');
 $.lang.register('ticketrafflesystem.raffle.close.err', 'The ticket raffle ended. No one entered.');
-$.lang.register('ticketrafflesystem.winner', 'The winner of this ticket raffle is: $1! $2');
+$.lang.register('ticketrafflesystem.winner.single', 'The winner of this ticket raffle is: $1! $2');
+$.lang.register('ticketrafflesystem.winner.multiple', 'The winners of this ticket raffle are: $1!');
+$.lang.register('ticketrafflesystem.winner.single.award', 'The winner has been awarded: $1!');
+$.lang.register('ticketrafflesystem.winner.multiple.award', 'The winners have been awarded: $1 each!');
 $.lang.register('ticketrafflesystem.only.buy.amount', 'You can only buy $1 ticket(s)');
 $.lang.register('ticketrafflesystem.limit.hit', 'You\'re only allowed to buy $1 ticket(s)');
 $.lang.register('ticketrafflesystem.err.not.following', 'You need to be following to enter.');

--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -17,7 +17,7 @@
 
 $.lang.register('ticketrafflesystem.err.raffle.opened', 'A ticket raffle is already opened.');
 $.lang.register('ticketrafflesystem.err.missing.syntax', 'Usage: !traffle open [max entries] [regulars ticket multiplier (default = 1)] [subscribers ticket multiplier (default = 1)] [cost] [-followers]');
-$.lang.register('ticketrafflesystem.msg.need.to.be.follwing', 'You need to be following to enter.');
+$.lang.register('ticketrafflesystem.msg.need.to.be.following', 'You need to be following to enter.');
 $.lang.register('ticketrafflesystem.raffle.opened', 'Ticket raffle is now open! Buy up to $1 tickets with !tickets - you can purchase multiple times. Tickets cost $2. $3');
 $.lang.register('ticketrafflesystem.err.raffle.not.opened', 'There is no ticket raffle opened.');
 $.lang.register('ticketrafflesystem.raffle.closed', 'The ticket raffle is now closed. Use "!traffle draw" to draw a winner.');

--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -20,6 +20,7 @@ $.lang.register('ticketrafflesystem.err.missing.syntax', 'Usage: !traffle open [
 $.lang.register('ticketrafflesystem.msg.need.to.be.following', 'You need to be following to enter.');
 $.lang.register('ticketrafflesystem.raffle.opened', 'Ticket raffle is now open! Buy up to $1 tickets with !tickets - you can purchase multiple times. Tickets cost $2. $3');
 $.lang.register('ticketrafflesystem.err.raffle.not.opened', 'There is no ticket raffle opened.');
+$.lang.register('ticketrafflesystem.err.already.drawn', 'Winners were already drawn.');
 $.lang.register('ticketrafflesystem.raffle.closed', 'The ticket raffle is now closed. Use "!traffle draw" to draw a winner.');
 $.lang.register('ticketrafflesystem.raffle.closed.and.draw', 'The ticket raffle is now closed.');
 $.lang.register('ticketrafflesystem.raffle.close.err', 'The ticket raffle ended. No one entered.');

--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -21,15 +21,17 @@ $.lang.register('ticketrafflesystem.msg.need.to.be.following', 'You need to be f
 $.lang.register('ticketrafflesystem.raffle.opened', 'Ticket raffle is now open! Buy up to $1 tickets with !tickets - you can purchase multiple times. Tickets cost $2. $3');
 $.lang.register('ticketrafflesystem.err.raffle.not.opened', 'There is no ticket raffle opened.');
 $.lang.register('ticketrafflesystem.raffle.closed', 'The ticket raffle is now closed. Use "!traffle draw" to draw a winner.');
+$.lang.register('ticketrafflesystem.raffle.closed.and.draw', 'The ticket raffle is now closed.');
 $.lang.register('ticketrafflesystem.raffle.close.err', 'The ticket raffle ended. No one entered.');
 $.lang.register('ticketrafflesystem.winner.single', 'The winner of this ticket raffle is: $1! $2');
 $.lang.register('ticketrafflesystem.winner.multiple', 'The winners of this ticket raffle are: $1!');
 $.lang.register('ticketrafflesystem.winner.single.award', 'The winner has been awarded: $1!');
 $.lang.register('ticketrafflesystem.winner.multiple.award', 'The winners have been awarded: $1 each!');
 $.lang.register('ticketrafflesystem.only.buy.amount', 'You can only buy $1 ticket(s)');
-$.lang.register('ticketrafflesystem.limit.hit', 'You\'re only allowed to buy $1 ticket(s)');
+$.lang.register('ticketrafflesystem.limit.hit', 'You\'re only allowed to buy a maximum of $1 ticket(s). You currently have $2 tickets.');
 $.lang.register('ticketrafflesystem.err.not.following', 'You need to be following to enter.');
 $.lang.register('ticketrafflesystem.err.points', 'You don\'t have enough $1 to enter.');
+$.lang.register('ticketrafflesystem.err.not.enoughUsers', 'Not enough users have entered to draw $1 winners.');
 $.lang.register('ticketrafflesystem.entered', '$1 entries added to the ticket raffle! ($2 tickets in total)');
 $.lang.register('ticketrafflesystem.entered.bonus', '$1 (+ $2 bonus) entries added to the ticket raffle! ($3 (+ $4 bonus) tickets in total)');
 $.lang.register('ticketrafflesystem.usage', 'Usage: !traffle open [max entries] [regulars ticket multiplier (default = 1)] [subscribers ticket multiplier (default = 1)] [cost] [-followers]');

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -345,7 +345,7 @@
     function awardWinners(prize) {
 
         for (var i = 0; i < lastWinners.length; i++) {
-            $.inidb.incr('points', lastWinners, prize);
+            $.inidb.incr('points', lastWinners[i], prize);
         }
 
         if (lastWinners.length > 1) {
@@ -426,9 +426,8 @@
 
                 winner(amount);
 
-                if(args[2] !== undefined && !isNaN(parseInt(args[1])) && parseInt(args[1] !== 0)) {
-
-                    awardWinners(parseInt(args[1]));
+                if(args[2] !== undefined && !isNaN(parseInt(args[2])) && parseInt(args[2]) !== 0) {
+                    awardWinners(parseInt(args[2]));
                 }
 
                 return;

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -393,7 +393,7 @@
             }
 
             /**
-             * @commandpath traffle draw [amount] [points] - Picks winner(s) for the ticket raffle and optionally awards them with points 
+             * @commandpath traffle draw [amount (default = 1)] [prize points] - Picks winner(s) for the ticket raffle and optionally awards them with points 
              */
             if (action.equalsIgnoreCase('draw')) {
 
@@ -413,7 +413,7 @@
 
                 winner(amount);
 
-                if(args[2] !== undefined && !isNaN(parseInt(args[1]))) {
+                if(args[2] !== undefined && !isNaN(parseInt(args[1])) && parseInt(args[1] !== 0)) {
 
                     awardWinners(parseInt(args[1]));
                 }

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -196,11 +196,24 @@
         $.log.event('Winner of the ticket raffle was ' + Winner);
     }
 
-    function enterRaffle(user, event, times) {
+    function enterRaffle(user, event, arg) {
         if (!raffleStatus) {
             if (msgToggle) {
                 $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.err.raffle.not.opened'));
             }
+            return;
+        }
+
+        var times;
+
+        if (isNaN(parseInt(arg)) && ($.equalsIgnoreCase(arg, "max") || $.equalsIgnoreCase(arg, "all"))) {
+            let possibleBuys = Math.floor($.getUserPoints(user)/cost);
+            times = maxEntries-getTickets(user); //Maximum possible entries that can be bought up to the maxEntries limit
+            times = (times > possibleBuys ? possibleBuys : times);
+        } else if (!isNaN(parseInt(arg))) {
+            times = parseInt(arg);
+        } else {
+            $.say($.whisperPrefix(sender) + $.lang.get('ticketrafflesystem.ticket.usage', getTickets(sender)));
             return;
         }
 
@@ -390,7 +403,7 @@
         }
 
         /**
-         * @commandpath tickets [amount] - Buy tickets to enter the ticket raffle.
+         * @commandpath tickets [amount / max] - Buy tickets to enter the ticket raffle.
          */
         if (command.equalsIgnoreCase('tickets') || command.equalsIgnoreCase('ticket')) {
             if (!action) {
@@ -404,7 +417,8 @@
                 }
                 return;
             }
-            enterRaffle(sender, event, parseInt(action));
+
+            enterRaffle(sender, event, action);
         }
     });
 

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -93,9 +93,9 @@ $(function () {
     // Open/close raffle button.
     $('#ticket-open-or-close-raffle').on('click', function () {
         if ($(this)[0].innerText.trim() === 'Open') {
-            const cost = $('#ticket-raffle-cost'),
+            const   cost = $('#ticket-raffle-cost'),
                     maxTicket = $('#ticket-raffle-max'),
-                    elegibility = $('#ticket-raffle-perm').val(),
+                    eligibility = $('#ticket-raffle-perm').val(),
                     regLuck = $('#ticket-raffle-reg'),
                     subLuck = $('#ticket-raffle-sub');
 
@@ -107,7 +107,7 @@ $(function () {
                 case helpers.handleInputNumber(subLuck, 1, 10):
                     break;
                 default:
-                    socket.sendCommand('open_traffle_cmd', 'traffle open ' + maxTicket.val() + ' ' + regLuck.val() + ' ' + subLuck.val() + ' ' + cost.val() + ' ' + elegibility, function () {
+                    socket.sendCommand('open_traffle_cmd', 'traffle open ' + maxTicket.val() + ' ' + regLuck.val() + ' ' + subLuck.val() + ' ' + cost.val() + ' ' + eligibility, function () {
                         // Alert the user.
                         toastr.success('Successfully opened the ticket raffle!');
                         // Update the button.
@@ -132,12 +132,22 @@ $(function () {
 
     // Draw raffle button.
     $('#ticket-draw-raffle').on('click', function () {
-        socket.sendCommandSync('draw_rraffle_cmd', 'traffle draw', function () {
-            // Alert the user.
-            toastr.success('Successfully drew a winner!');
-            // Reload to remove the winner.
-            helpers.temp.loadRaffleList();
-        });
+        const   drawAmount = $('#ticket-raffle-draw'),
+                prize = $('#ticket-raffle-prize');
+   
+        switch (false) {
+            case helpers.handleInputNumber(drawAmount, 1):
+            case helpers.handleInputNumber(prize, 0):
+                break;
+            default:
+                socket.sendCommandSync('draw_raffle_cmd', 'traffle draw ' + drawAmount.val() + ' ' + prize.val() , function () {
+                    console.log("Drawing winner with draw command:  " + 'traffle draw ' + drawAmount.val() + ' ' + prize.val());
+                    // Alert the user.
+                    toastr.success('Successfully drew a winner!');
+                    // Reload to remove the winner.
+                    helpers.temp.loadRaffleList();
+                });
+        }
     });
 
     // Reset raffle button.
@@ -147,6 +157,8 @@ $(function () {
         $('#ticket-raffle-cost').val('1');
         $('#ticket-raffle-reg, #ticket-raffle-sub').val('1');
         $('#ticket-raffle-table').find('tr:gt(0)').remove();
+        $('#ticket-raffle-draw').val('1');
+        $('#ticket-raffle-prize').val('0');
 
         $('#ticket-open-or-close-raffle').html($('<i/>', {
             'class': 'fa fa-unlock-alt'

--- a/resources/web/panel/pages/giveaways/ticketRaffle.html
+++ b/resources/web/panel/pages/giveaways/ticketRaffle.html
@@ -118,7 +118,25 @@
                             <div class="form-group">
                                 <label for="ticket-raffle-sub">Subscribers Ticket Multiplier</label>
                                 <input type="number" min="1" max="10" class="form-control" id="ticket-raffle-sub" value="1"
-                                    data-toggle="tooltip" title="Ticket multiplier for susbcribers. Multiplies the number of tickets the users buys with this number."/>
+                                    data-toggle="tooltip" title="Ticket multiplier for subscribers. Multiplies the number of tickets the users buys with this number."/>
+                            </div>
+
+                            <div class="box-header with-border">
+                                <h3 class="box-title">Draw Options</h3>
+                            </div>
+
+                            <!-- Draw amount -->
+                            <div class="form-group">
+                                <label for="ticket-raffle-draw">Draw amount</label>
+                                <input type="number" min="1" class="form-control" id="ticket-raffle-draw" value="1"
+                                    data-toggle="tooltip" title="The amount of winners to be drawn."/>
+                            </div>
+
+                            <!-- Prize -->
+                            <div class="form-group">
+                                <label for="ticket-raffle-prize">Prize</label>
+                                <input type="number" min="0" class="form-control" id="ticket-raffle-prize" value="0"
+                                    data-toggle="tooltip" title="The amount of point each winner is awarded."/>
                             </div>
                         </div>
 

--- a/resources/web/panel/pages/giveaways/ticketRaffle.html
+++ b/resources/web/panel/pages/giveaways/ticketRaffle.html
@@ -43,7 +43,7 @@
             <div class="col-md-3" id="ticketRaffleTable">
                 <div class="box box-solid">
                     <div class="box-header with-border">
-                        <h3 class="box-title">Ticket Raffle List</h3>
+                        <h3 class="box-title" id="traffle-list-title">Ticket Raffle List</h3>
                     </div>
 
                     <form role="form" id="ticketRaffleListModule">


### PR DESCRIPTION
**Original PR message:**
_This PR aims to get in line with other bots as mentioned on discord.

This PR enables the user to buy the maximum amount of tickets permitted via the use of `!tickets max` while keeping the amount of tickets the user already bought and is able to buy with their points in mind._

**Edit:**
Additionally, to the original PRs purpose, this PR also aims to incorporate the requested ticket raffle changes from [this issue](https://github.com/PhantomBot/PhantomBot/issues/2627). Mainly:

1. The ability to draw multiple winners at the same time with
2. The ability to distribute the bots' loyalty points to winners

To achieve 1. and 2. the `!draw` command was expanded to accept the following syntax `!draw [amount] [prize]`. Where amount is the amount of winners to be drawn and defaults to 1 if not set, prize is the amount of points each winner will be awarded with and defaults to 0 if not set.
Examples:

- `!draw 10` - Draws 10 winners if enough unique players have entered
- `!draw` - Draws a single winner
- `!draw 2` 1000 - Draws 2 winners and awards 1000 loyalty points to each winner

![image](https://user-images.githubusercontent.com/572591/162589694-97cb7625-936a-4634-a212-dc44fb6d1c85.png)

In order to allow for large amounts of winners to be drawn, a faster 'pick random users' method is used which also checks if the drawn user from the entries has not yet been drawn. The winners are announced in chat, due to the message limit of 500 characters a check is in place to splice the message in two separate messages allowing for greater winner amounts.


Before this change redrawing was possible allowing to draw multiple winners, though this was prone to selecting the same player multiple times. In all fairness, with the ability to draw multiple winners at once, I don't see the need to redraw winners and have thus blocked the command if winners were already drawn. Though, I'm open for a discussion or suggestions on this matter and will happily implement a !redraw command or just expand on !draw. Considerations here would be to deduct the loyalty points awarded before.

These changes are reflected in the panel as well:

- The Draw button will now be disabled if winners were already drawn
- Draw Options were added to account for the new parameters accepted by the expanded `!draw` command
![image](https://user-images.githubusercontent.com/572591/162589144-3151e9bb-3dce-40be-a74d-dc863937a4b7.png)

- The winners will now be shown in the table/list once the ticket raffle has ended and winners were drawn to allow the user/streamer to read the winners from the panel and not having to look at the chat which scrolls the winners away
![image](https://user-images.githubusercontent.com/572591/162589708-6b0ba944-e926-4d91-9140-ef092b0b2063.png)

