### PR TITLE
Fix (user) lookup for quotes

### DIFF
--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -278,7 +278,7 @@
                 quoteStr = quoteStr.replace('(id)', (quote.length === 5 ? quote[4].toString() : quote[3].toString())).
                 replace('(quote)', quote[1]).
                 replace('(userrank)', $.resolveRank(quote[0])).
-                replace('(user)', $.username.resolve(username)).
+                replace('(user)', $.username.resolve(quote[0])).
                 replace('(game)', (quote.length === 5 ? quote[3] : "Some Game")).
                 replace('(date)', $.getLocalTimeString($.getSetIniDbString('settings', 'quoteDateFormat', 'dd-MM-yyyy'), parseInt(quote[2])));
                 $.say(quoteStr);


### PR DESCRIPTION
Fixes erroneous username variable in new quotes system
pre-fix
```
[20:45] ~%+AevumDecessus: !quote 5
[20:45] @aevumbot: [5] "Stop, Stop, Stop a bunch of fat guys stuck in the hole - Parker" - Undefined (2020-05-16)
[20:45] ~%+AevumDecessus: !editquote 5 user parkervcp
[20:45] @aevumbot: @AevumDecessus, Updated user on quote 5 to parkervcp.
[20:45] ~%+AevumDecessus: !quote 5
[20:45] @aevumbot: [5] "Stop, Stop, Stop a bunch of fat guys stuck in the hole - Parker" - Undefined (2020-05-16)
```

post-fix
```
[20:53] ~%+AevumDecessus: !quote 5
[20:53] @aevumbot: [5] "Stop, Stop, Stop a bunch of fat guys stuck in the hole - Parker", by parkervcp (2020-05-16)
```