### PR TITLE
Fix adventure cooldown

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -928,11 +928,6 @@
      * @event webPanelSocketUpdate
      */
     $.bind('webPanelSocketUpdate', function (event) {
-        var handleExtraCooldown = function (commandLower, extra) {
-            if (extra.cooldown != null) {
-                $.coolDown.add(commandLower, parseInt(extra.cooldown.seconds), extra.cooldown.seconds.cooldown);
-            }
-        };
         var handleExtraDisabled = function (commandLower, extra) {
             if (extra.disabled != null) {
                 if (extra.disabled) {
@@ -958,10 +953,8 @@
             } else if (eventName === 'add') {
                 customCommands[commandLower] = args[2];
                 $.registerChatCommand('./commands/customCommands.js', commandLower);
-                handleExtraCooldown(commandLower, extra);
             } else if (eventName === 'edit') {
                 customCommands[commandLower] = args[2];
-                handleExtraCooldown(commandLower, extra);
                 handleExtraDisabled(commandLower, extra);
             } else if (eventName === 'removeAlias') {
                 $.unregisterChatCommand(commandLower);
@@ -969,11 +962,9 @@
             } else if (eventName === 'addAlias') {
                 $.registerChatCommand('./commands/customCommands.js', commandLower);
                 $.registerChatAlias(commandLower);
-                handleExtraCooldown(commandLower, extra);
             } else if (eventName === 'editAlias') {
                 $.registerChatCommand('./commands/customCommands.js', commandLower);
                 $.registerChatAlias(commandLower);
-                handleExtraCooldown(commandLower, extra);
                 handleExtraDisabled(commandLower, extra);
             }
         }

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -131,6 +131,7 @@
         if (isSpecial(command)) {
             if (command.equalsIgnoreCase('adventure') && defaultCooldowns[command] !== undefined && defaultCooldowns[command] > $.systemTime()) {
                 maxCoolDown = getTimeDif(defaultCooldowns[command]);
+                isGlobal = true;
             }
             return [maxCoolDown, isGlobal];
         }

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -367,7 +367,7 @@
 
         clearCurrentAdventure();
         temp = "";
-        $.coolDown.set('adventure', false, coolDown, false);
+        $.coolDown.set('adventure', true, coolDown, undefined);
         if (coolDownAnnounce) {
             setTimeout(function() {
                 $.say($.lang.get('adventuresystem.reset', $.pointNameMultiple));

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -391,7 +391,7 @@ $(function () {
                             updateCommandVisibility(commandName.val(), commandDisabled, commandHidden, function () {
                                 // Register the custom command with the cache.
                                 socket.wsEvent('custom_command_add_ws', './commands/customCommands.js', null,
-                                    ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val()], function () {
+                                    ['add', commandName.val(), commandResponse.val(), JSON.stringify({disabled: commandDisabled})], function () {
                                     // Add the cooldown to the cache.
                                     socket.wsEvent('custom_command_cooldown_ws', './core/commandCoolDown.js', null,
                                         ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val()], function () {


### PR DESCRIPTION
This PR fixes an issue pointed out on discord. The issue was that the adventure command didn't go on global cooldown after an adventure ended.

Additionally, this PR removes stray code:

- Aliases cannot have separate cooldowns, though the events addAlias and editAlias allowed for it. Neither of those WS-events provided the needed information anyway
- Adding or editing a custom command also allowed to set the cooldown in the same WS-event even though this is done via a separate WS-event. These separate WS-events are in [add](https://github.com/PhantomBot/PhantomBot/blob/89e851ff9587f9d2c8598e057d09444891cc08d0/resources/web/panel/js/pages/commands/custom.js#L396) and [edit](https://github.com/PhantomBot/PhantomBot/blob/89e851ff9587f9d2c8598e057d09444891cc08d0/resources/web/panel/js/pages/commands/custom.js#L272) respectively

This let the question of why the cooldown was provided as the 2nd WS-event argument, although the command response is expected as a secondary argument. This PR fixes this as well ... oddly enough, it didn't break adding custom commands through the panel