### PR TITLE
Use default parameter value in alertFollow

### DIFF
--- a/javascript-source/handlers/followHandler.js
+++ b/javascript-source/handlers/followHandler.js
@@ -28,11 +28,7 @@
  *
  */
 
-function alertFollow(announceFollows, followToggle, s, follower, followReward, followQueue) {
-    alertFollow(announceFollows, followToggle, s, follower, followReward, followQueue, false)
-}
-
-function alertFollow(announceFollows, followToggle, s, follower, followReward, followQueue, replay) {
+function alertFollow(announceFollows, followToggle, s, follower, followReward, followQueue, replay = false) {
     if (announceFollows === true && followToggle === true) {
         if (s.match(/\(name\)/)) {
             s = $.replace(s, '(name)', $.username.resolve(follower));


### PR DESCRIPTION
JavaScript doesn't have function overloading; there can be only one `alertFollow`. This changes it to use a default value for `replay` instead of redefining the function with and without the parameter.