### PR TITLE
Fixes for command cooldowns

### DIFF
--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -390,9 +390,9 @@
      */
     $.bind('webPanelSocketUpdate', function(event) {
         if (event.getScript().equalsIgnoreCase('./core/commandCoolDown.js')) {
-            if (event.getArgs()[0] === 'add') {
-                add(event.getArgs()[1], event.getArgs()[2], event.getArgs()[3]);
-            } else if (event.getArgs()[0] === 'update') {
+            if (event.getArgs()[0].equalsIgnoreCase('add')) {
+                add(event.getArgs()[1], parseInt(event.getArgs()[2]), parseInt(event.getArgs()[3]));
+            } else if (event.getArgs()[0].equalsIgnoreCase('update')) {
                 defaultCooldownTime = $.getIniDbNumber('cooldownSettings', 'defaultCooldownTime', 5);
                 modCooldown = $.getIniDbBoolean('cooldownSettings', 'modCooldown', false);
             } else {

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -172,11 +172,12 @@ $(function() {
                                 // Append input box for per-user cooldown.
                                 .append(helpers.getInputGroup('command-cooldown-user', 'number', 'Per-User Cooldown (Seconds)', '-1', cooldownJson.userSec,
                                     'Per-User cooldown of the command in seconds. -1 removes per-user cooldown.'))
-                                .append(helpers.getCheckBox('command-disabled', e.disabledCommands != null, 'Disabled',
+                                .append(helpers.getCheckBox('command-disabled', e.disabledCommands !== null, 'Disabled',
                                     'If checked, the command cannot be used in chat.'))
                                 // Callback function to be called once we hit the save button on the modal.
                         })), function() {
-                            let commandPermission = $('#command-permission'),
+                            let commandName = $('#command-name'),
+                                commandPermission = $('#command-permission'),
                                 commandCost = $('#command-cost'),
                                 commandReward = $('#command-reward'),
                                 commandCooldownGlobal = $('#command-cooldown-global'),


### PR DESCRIPTION
Fix another occurrence of `commandName` not being defined
As well as the websocket event breaking due to ESLint converting normal equality to strict equality ... changed it to proper string comparisons. This was caused in [#2746](https://github.com/PhantomBot/PhantomBot/pull/2746)