### PR TITLE
Raffle: fix parsing undefined

### DIFF
--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -202,7 +202,14 @@
         subscribers = bools[1];
         usePoints = bools[2];
         status = bools[3];
-        lastWinners = $.inidb.HasKey('raffleresults', '', 'winner') ? JSON.parse($.inidb.get('raffleresults', 'winner')) : []; //Consider raffles saved before this change
+        lastWinners = [];
+        if ($.inidb.HasKey('raffleresults', '', 'winner')) { //Consider raffles saved before this change
+            var temp = $.inidb.get('raffleresults', 'winner');
+            if (temp !== undefined && !temp.equalsIgnoreCase('undefined')) {
+                lastWinners = JSON.parse(temp); //lastWinners found
+            }
+        }
+
         hasDrawn = bools.length !== 5 ? false : bools[4]; //Consider raffles saved before this change
 
         if (status === true) {
@@ -247,7 +254,11 @@
         $.inidb.set('raffleState', 'timerTime', timerTime);
         $.inidb.set('raffleState', 'startTime', startTime);
         $.inidb.set('raffleState', 'bools', JSON.stringify([followers, subscribers, usePoints, status, hasDrawn]));
-        $.inidb.set('raffleresults', 'winner', JSON.stringify(lastWinners));
+        if (lastWinners.length >= 0){
+            $.inidb.set('raffleresults', 'winner', JSON.stringify(lastWinners));
+        } else if ($.inidb.HasKey('raffleresults', '', 'winner')) { //No winners but key present - we have to remove it
+            $.inidb.del('raffleresults', 'winner');
+        }
     }
 
     /**

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -87,7 +87,7 @@
         hasDrawn = false;
         $.inidb.RemoveFile('ticketsList');
         $.inidb.RemoveFile('entered');
-        $.inidb.set('raffleresults', 'ticketRaffleEntries', 0);
+        $.inidb.set('traffleresults', 'ticketRaffleEntries', 0);
         entries = "";
         entries = [];
 
@@ -306,7 +306,7 @@
     function incr(user, times) {
         if (!$.inidb.exists('entered', user.toLowerCase())) {
             $.inidb.SetBoolean('entered', '', user.toLowerCase(), true);
-            $.inidb.incr('raffleresults', 'ticketRaffleEntries', 1);
+            $.inidb.incr('traffleresults', 'ticketRaffleEntries', 1);
         }
         $.inidb.incr('ticketsList', user.toLowerCase(), times);
 
@@ -441,7 +441,7 @@
                 clear();
                 $.inidb.RemoveFile('ticketsList');
                 $.inidb.RemoveFile('entered');
-                $.inidb.set('raffleresults', 'ticketRaffleEntries', 0);
+                $.inidb.set('traffleresults', 'ticketRaffleEntries', 0);
                 entries = [];
                 saveState();
                 if (!sender.equalsIgnoreCase($.botName)) {


### PR DESCRIPTION
Fixes `[ERROR] [init.js:341] Error with Event Handler [initReady] Script [./systems/raffleSystem.js] Stacktrace [reopen()@raffleSystem.js:205 > raffleSystem.js:702 > init.js:333 > init.js:464] Exception [SyntaxError: Unexpected token: u]`

Also, future proofing Traffle by moving its results over to the according DB table instead into a single table as it was the case for a long time