### PR TITLE
Don't parse undefined object

### DIFF
--- a/javascript-source/commands/customCommands.js
+++ b/javascript-source/commands/customCommands.js
@@ -887,10 +887,10 @@
 
         if (event.getScript().equalsIgnoreCase('./commands/customCommands.js')) {
             var args = event.getArgs(),
-                    eventName = args[0] + '',
-                    command = args[1] + '',
-                    commandLower = command.toLowerCase() + '',
-                    extra = args[3] === null ? {} : JSON.parse(args[3]);
+                eventName = args[0] + '',
+                command = args[1] + '',
+                commandLower = command.toLowerCase() + '',
+                extra = (args[3] === null || args[3] === undefined) ? {} : JSON.parse(args[3]);
             if (eventName === 'remove') {
                 if (customCommands[commandLower] !== undefined) {
                     delete customCommands[commandLower];


### PR DESCRIPTION
Prevents error from being logged on deleting a custom command:
`[ERROR] [init.js:346] Error with Event Handler [webPanelSocketUpdate] Script [./commands/customCommands.js] Stacktrace [customCommands.js:889 > init.js:338 > init.js:696] Exception [SyntaxError: Unexpected token: u]`