### PR TITLE
Fix QueueSystem

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -690,7 +690,7 @@
             if (isVIP(username)) {
                 setUserGroupById(username, PERMISSION.VIP);
             } else if ($.inidb.exists('preSubGroup', username)) {
-                setUserGroupById( username, $.getIniDbNumber('preSubGroup', username, PERMISSION.Viewer));
+                setUserGroupById(username, $.getIniDbNumber('preSubGroup', username, PERMISSION.Viewer));
                 $.inidb.del('preSubGroup', username);
             } else {
                 setUserGroupById(username, PERMISSION.Viewer);
@@ -1239,7 +1239,7 @@
             }
 
             $.say($.whisperPrefix(sender) + $.lang.get('permissions.group.set.success', $.username.resolve(username), getGroupNameById(groupId) + ' (' + groupId + ')'));
-            $.setUserGroupById(username, groupId);
+            setUserGroupById(username, groupId);
             if (groupId <= PERMISSION.Mod) {
                 addModeratorToCache(username);
             } else {

--- a/javascript-source/systems/queueSystem.js
+++ b/javascript-source/systems/queueSystem.js
@@ -166,7 +166,7 @@
         var zone = $.inidb.exists('settings', 'timezone') ? $.inidb.get('settings', 'timezone') : 'GMT';
         var ldate = Packages.java.time.ZonedDateTime.ofInstant(Packages.java.time.Instant.ofEpochMilli(time), Packages.java.time.ZoneId.of(zone));
         var date = ldate.format(Packages.java.time.format.DateTimeFormatter.ofPattern('HH:mm:ss z'));
-        var string = $.getTimeString(Packages.java.time.Duration.between(date, Packages.java.time.ZonedDateTime.now()).toSeconds());
+        var string = $.getTimeString(Packages.java.time.Duration.between(ldate, Packages.java.time.ZonedDateTime.now()).toSeconds());
 
         if (simple === undefined) {
             return date + ' ' + $.lang.get('queuesystem.time.info', string);

--- a/resources/web/panel/js/pages/extra/queue.js
+++ b/resources/web/panel/js/pages/extra/queue.js
@@ -125,13 +125,15 @@ $(function () {
     const QUEUE_SCRIPT = './systems/queueSystem.js';
     let canUpdate = true;
 
+    $('#queue-perm').append(helpers.getDropdownGroup('queue-permission', 'User Level', helpers.getGroupNameById(7), helpers.getPermGroupNames()));
+
     /*
      * @function Clears the input boxes of the queue.
      */
     const clearQueueInput = function () {
         $('#queue-title').val('');
         $('#queue-cost, #queue-size').val('0');
-        $('#queue-permission').val('Viewers');
+        $('#queue-permission').val(helpers.getGroupNameById(7));
     };
 
     // Toggle for the module.

--- a/resources/web/panel/pages/extra/queue.html
+++ b/resources/web/panel/pages/extra/queue.html
@@ -94,18 +94,7 @@
                             </div>
 
                             <!-- Queue permission -->
-                            <div class="form-group">
-                                <label for="queue-permission">User Level</label>
-                                <select class="form-control" id="queue-permission">
-                                    <option selected="selected" hidden="hidden">Viewers</option>
-                                    <option>Caster</option>
-                                    <option>Administrators</option>
-                                    <option>Moderators</option>
-                                    <option>Subscribers</option>
-                                    <option>Donators</option>
-                                    <option>Regulars</option>
-                                    <option>Viewers</option>
-                                </select>
+                            <div class="form-group" id="queue-perm" >
                             </div>
                         </div>
 


### PR DESCRIPTION
Have the queueSystem also use the new user level/permission syntax:
![image](https://user-images.githubusercontent.com/572591/180200869-ce609c48-6dca-43c9-a122-4fd5860280ff.png)

Fix queueSystem not being able to join and accompanied error:
`[ERROR] [init.js:323] Error with Event Handler [command] Script [./systems/queueSystem.js] Stacktrace [date()@queueSystem.js:169 > join()@queueSystem.js:118 > queueSystem.js:411 > init.js:315 > init.js:566] Exception [InternalError: Can't find method java.time.Duration.between(java.lang.String,java.time.ZonedDateTime). (queueSystem.js#169)]`