### PR TITLE
TicketRaffle: Limiter

### DIFF
--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -30,7 +30,10 @@ $.lang.register('ticketrafflesystem.winner.multiple', 'The winners of this ticke
 $.lang.register('ticketrafflesystem.winner.single.award', 'The winner has been awarded: $1!');
 $.lang.register('ticketrafflesystem.winner.multiple.award', 'The winners have been awarded: $1 each!');
 $.lang.register('ticketrafflesystem.only.buy.amount', 'You can only buy $1 ticket(s)');
+$.lang.register('ticketrafflesystem.only.buy.amount.limiter', 'You can only buy $1 ticket(s) because you receive a bonus of $2 %');
 $.lang.register('ticketrafflesystem.limit.hit', 'You\'re only allowed to buy a maximum of $1 ticket(s). You currently have $2 tickets.');
+$.lang.register('ticketrafflesystem.limit.hit.limiter', 'You\'re only allowed to buy a maximum of $1 ticket(s) because the you receive a bonus of $2 %. You currently have $3 tickets.');
+$.lang.register('ticketrafflesystem.settings.err.open', 'You cannot change this setting while a raffle is open!');
 $.lang.register('ticketrafflesystem.err.not.following', 'You need to be following to enter.');
 $.lang.register('ticketrafflesystem.err.points', 'You don\'t have enough $1 to enter.');
 $.lang.register('ticketrafflesystem.err.not.enoughUsers', 'Not enough users have entered to draw $1 winners.');
@@ -39,6 +42,8 @@ $.lang.register('ticketrafflesystem.entered.bonus', '$1 (+ $2 bonus) entries add
 $.lang.register('ticketrafflesystem.usage', 'Usage: !traffle open [max entries] [regulars ticket multiplier (default = 1)] [subscribers ticket multiplier (default = 1)] [cost] [-followers]');
 $.lang.register('ticketrafflesystem.msg.enabled', 'Ticket raffle message\'s have been enabled.');
 $.lang.register('ticketrafflesystem.msg.disabled', 'Ticket raffle message\'s have been disabled.');
+$.lang.register('ticketrafflesystem.limiter.enabled', 'Ticket limiter enabled. Bonus tickets count towards the ticket limit!');
+$.lang.register('ticketrafflesystem.limiter.disabled', 'Ticket limiter disabled. Bonus tickets do not count towards the ticket limit!');
 $.lang.register('ticketrafflesystem.ticket.usage', 'Usage: !tickets (amount / max) - And you currently have $1 tickets.');
 $.lang.register('ticketrafflesystem.ticket.usage.bonus', 'Usage: !tickets (amount / max) - And you currently have $1 (+ $2 bonus) tickets.');
 $.lang.register('ticketrafflesystem.auto.msginterval.set', 'Message interval set to $1 minutes.');

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -254,7 +254,7 @@
 
         if (limiter) {
             multiplier = calcBonus(user, event, 1);
-            tmpMax = Math.floor(maxEntries / multiplier);
+            tmpMax = maxEntries / multiplier;
         }
 
         if (isNaN(parseInt(arg)) && ($.equalsIgnoreCase(arg, "max") || $.equalsIgnoreCase(arg, "all"))) {
@@ -269,13 +269,17 @@
         }
 
         var bonus = calcBonus(user, event, baseAmount),
-            amount = baseAmount + bonus;
+            amount = baseAmount;
+
+        if (limiter) {
+            amount = Math.round(amount + bonus); //Math.Round because we can be limited by the bit length i.e 1/3 = 0.333333333.....
+        }
 
 
-        if (baseAmount > tmpMax || baseAmount === 0 || baseAmount < 0) {
+        if (amount > maxEntries || baseAmount === 0 || baseAmount < 0) {
             if (msgToggle) {
                 if (limiter) {
-                    $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.only.buy.amount.limiter', tmpMax, multiplier*100));
+                    $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.only.buy.amount.limiter', Math.ceil(tmpMax), multiplier * 100));
                 } else {
                     $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.only.buy.amount', maxEntries));
                 }
@@ -283,10 +287,10 @@
             return;
         }
 
-        if (getTickets(user) + baseAmount > tmpMax) {
+        if (getTickets(user) + amount > maxEntries) {
             if (msgToggle) {
                 if (limiter) {
-                    $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.limit.hit.limiter', tmpMax, multiplier*100, getTickets(user)));
+                    $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.limit.hit.limiter', Math.ceil(tmpMax), multiplier * 100, getTickets(user)));
                 } else {
                     $.say($.whisperPrefix(user) + $.lang.get('ticketrafflesystem.limit.hit', maxEntries, getTickets(user)));
                 }
@@ -307,7 +311,7 @@
             totalEntries++;
         }
 
-        totalTickets += amount;
+        totalTickets += baseAmount + bonus;
 
         if (cost !== 0) {
             $.inidb.decr('points', user, (baseAmount * cost));

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -55,7 +55,7 @@ $(run = function () {
         /**
          * @function Loads the raffle winners.
          */
-         helpers.temp.loadWinners = function () {
+        helpers.temp.loadWinners = function () {
             socket.getDBValue('get_traffle_list', 'traffleresults', 'winner', function (results) {
                 const table = $('#ticket-raffle-table');
 
@@ -116,7 +116,7 @@ $(run = function () {
             });
             $('#ticket-draw-raffle').ready(function(){
                 $('#ticket-draw-raffle').prop('disabled', true);
-            });            
+            });
         }
     });
 });
@@ -126,7 +126,7 @@ $(function () {
     // Module toggle.
     $('#ticketRaffleModuleToggle').on('change', function () {
         socket.sendCommandSync('traffle_system_module_toggle_cmd',
-                'module ' + ($(this).is(':checked') ? 'enablesilent' : 'disablesilent') + ' ./systems/ticketraffleSystem.js', run);
+            'module ' + ($(this).is(':checked') ? 'enablesilent' : 'disablesilent') + ' ./systems/ticketraffleSystem.js', run);
     });
 
     // Open/close raffle button.
@@ -155,13 +155,13 @@ $(function () {
                         })).append('&nbsp; Close').removeClass('btn-success').addClass('btn-warning');
                     });
 
-                $('#traffle-list-title').text("Ticket Raffle List");
-                $('#ticket-draw-raffle').prop('disabled', false);
+                    $('#traffle-list-title').text("Ticket Raffle List");
+                    $('#ticket-draw-raffle').prop('disabled', false);
 
-                // Reset the timer in case we destroyed it after the last draw
-                timers.push(setInterval(function () {
-                    helpers.temp.loadRaffleList();
-                }, 5e3));
+                    // Reset the timer in case we destroyed it after the last draw
+                    timers.push(setInterval(function () {
+                        helpers.temp.loadRaffleList();
+                    }, 5e3));
             }
         } else {
             socket.sendCommandSync('close_traffle_cmd', 'traffle close', function () {
@@ -181,7 +181,7 @@ $(function () {
     $('#ticket-draw-raffle').on('click', function () {
         const   drawAmount = $('#ticket-raffle-draw'),
                 prize = $('#ticket-raffle-prize');
-   
+
         switch (false) {
             case helpers.handleInputNumber(drawAmount, 1):
             case helpers.handleInputNumber(prize, 0):
@@ -229,58 +229,62 @@ $(function () {
     // Raffle settings button.
     $('#ticket-raffle-settings').on('click', function () {
         socket.getDBValues('get_traffle_settings', {
-            tables: ['settings', 'settings', 'settings'],
-            keys: ['tRaffleMSGToggle', 'traffleMessage', 'traffleMessageInterval']
+            tables: ['settings', 'settings', 'settings', 'settings'],
+            keys: ['tRaffleMSGToggle', 'traffleMessage', 'traffleMessageInterval', 'tRaffleLimiter']
         }, true, function (e) {
             helpers.getModal('traffle-settings-modal', 'Ticket Raffle Settings', 'Save', $('<form/>', {
                 'role': 'form'
             })
-                    // Add the div for the col boxes.
-                    .append($('<div/>', {
-                        'class': 'panel-group',
-                        'id': 'accordion'
-                    })
-                            // Append first collapsible accordion.
-                            .append(helpers.getCollapsibleAccordion('main-1', 'Timed Message Settings', $('<form/>', {
-                                'role': 'form'
-                            })
-                                    // Append interval box for the message
-                                    .append(helpers.getInputGroup('msg-timer', 'number', 'Message Interval (Minutes)', '', e['traffleMessageInterval'],
-                                            'How often the raffle message is said in chat while a raffle is active.'))
-                                    // Append message box for the message
-                                    .append(helpers.getTextAreaGroup('msg-msg', 'text', 'Raffle Message', '', e['traffleMessage'],
-                                            'What message is said at every interval while the raffle is active. Tags: (amount) and (entries)'))))
-                            // Append second collapsible accordion.
-                            .append(helpers.getCollapsibleAccordion('main-2', 'Extra Settings', $('<form/>', {
-                                'role': 'form'
-                            })
-                                    // Add toggle for warning messages.
-                                    .append(helpers.getDropdownGroup('warning-msg', 'Enable Warning Messages', (e['tRaffleMSGToggle'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
-                                            'If warning messages should be said in chat when a user already entered, or doesn\'t have enough points.'))))),
-                    function () {
-                        let raffleTimer = $('#msg-timer'),
-                                raffleMessage = $('#msg-msg'),
-                                warningMsg = $('#warning-msg').find(':selected').text() === 'Yes';
+            // Add the div for the col boxes.
+            .append($('<div/>', {
+                'class': 'panel-group',
+                'id': 'accordion'
+            })
+            // Append first collapsible accordion.
+            .append(helpers.getCollapsibleAccordion('main-1', 'Timed Message Settings', $('<form/>', {
+                'role': 'form'
+            })
+            // Append interval box for the message
+            .append(helpers.getInputGroup('msg-timer', 'number', 'Message Interval (Minutes)', '', e['traffleMessageInterval'],
+                'How often the raffle message is said in chat while a raffle is active.'))
+            // Append message box for the message
+            .append(helpers.getTextAreaGroup('msg-msg', 'text', 'Raffle Message', '', e['traffleMessage'],
+                'What message is said at every interval while the raffle is active. Tags: (amount) and (entries)'))))
+            // Append second collapsible accordion.
+            .append(helpers.getCollapsibleAccordion('main-2', 'Extra Settings', $('<form/>', {
+                'role': 'form'
+            })
+            // Add toggle for warning messages.
+            .append(helpers.getDropdownGroup('warning-msg', 'Enable Warning Messages', (e['tRaffleMSGToggle'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
+                'If warning messages should be said in chat when a user already entered, or doesn\'t have enough points.'))
+            // Add toggle for the limiter.
+            .append(helpers.getDropdownGroup('limiter', 'Enable limiter', (e['tRaffleLimiter'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
+                'ON: Limit the total amount of tickets (bought tickets + bonus tickets) to the set limit. OFF: Limit only the amount of bought tickets.'))))),
+            function () {
+                let raffleTimer = $('#msg-timer'),
+                    raffleMessage = $('#msg-msg'),
+                    warningMsg = $('#warning-msg').find(':selected').text() === 'Yes',
+                    limiter = $('#limiter').find(':selected').text() === 'Yes';
 
-                        switch (false) {
-                            case helpers.handleInputNumber(raffleTimer):
-                            case helpers.handleInputString(raffleMessage):
-                                break;
-                            default:
-                                socket.updateDBValues('update_traffle_settings_2', {
-                                    tables: ['settings', 'settings', 'settings'],
-                                    keys: ['tRaffleMSGToggle', 'traffleMessage', 'traffleMessageInterval'],
-                                    values: [warningMsg, raffleMessage.val(), raffleTimer.val()]
-                                }, function () {
-                                    socket.sendCommand('raffle_reload_cmd', 'reloadtraffle', function () {
-                                        // Close the modal.
-                                        $('#traffle-settings-modal').modal('toggle');
-                                        // Warn the user.
-                                        toastr.success('Successfully updated ticket raffle settings!');
-                                    });
-                                });
-                        }
-                    }).modal('toggle');
+                switch (false) {
+                    case helpers.handleInputNumber(raffleTimer):
+                    case helpers.handleInputString(raffleMessage):
+                        break;
+                    default:
+                        socket.updateDBValues('update_traffle_settings_2', {
+                            tables: ['settings', 'settings', 'settings', 'settings'],
+                            keys: ['tRaffleMSGToggle', 'traffleMessage', 'traffleMessageInterval', 'tRaffleLimiter'],
+                            values: [warningMsg, raffleMessage.val(), raffleTimer.val(), limiter]
+                        }, function () {
+                            socket.sendCommand('raffle_reload_cmd', 'reloadtraffle', function () {
+                                // Close the modal.
+                                $('#traffle-settings-modal').modal('toggle');
+                                // Warn the user.
+                                toastr.success('Successfully updated ticket raffle settings!');
+                            });
+                        });
+                }
+            }).modal('toggle');
         });
     });
 });


### PR DESCRIPTION
Adds a configurable limiter to the tickerraffles.

1. **Disabled limiter (as default in PB):**
A user can buy tickets up to the maximum and then receives a bonus depending on the multiplier set and the user's group.
Therefore, the user can have more tickets than is set by the streamer.

2. **Enabled limiter:**
A user can buy tickets til his total amount of tickets reaches the defined maximum, this total amount of tickets includes the bonus tickets granted.

This limiter can be toggled with `!traffle limitertoggle` or via the panel in the ticketraffle settings
![image](https://user-images.githubusercontent.com/572591/180217574-a63abff8-72b4-4c48-92ed-a57d7184bc56.png)
