### PR TITLE
Ticketraffle fixes

### DIFF
--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -520,4 +520,24 @@
         $.consoleLn('PhantomBot update 3.6.4 completed!');
         $.inidb.SetBoolean('updates', '', 'installedv3.6.4', true);
     }
+
+    /* version 3.6.5 updates */
+    if (!$.inidb.GetBoolean('updates', '', 'installedv3.6.5')) {
+        $.consoleLn('Starting PhantomBot update 3.6.5 updates...');
+
+        if ($.inidb.FileExists('traffleState')) {
+            var bools = JSON.parse($.inidb.get('traffleState', 'bools'));
+
+            $.inidb.SetBoolean('traffleState', '', 'followers', bools[0]);
+            $.inidb.RemoveKey('traffleState', '', 'bools');
+
+            if ($.inidb.FileExists('traffleSettings')) {
+                $.inidb.SetBoolean('traffleState', '', 'isActive', $.inidb.GetBoolean('traffleSettings', '', 'isActive'));
+                $.inidb.RemoveFile('traffleSettings');
+            }
+        }
+
+        $.consoleLn('PhantomBot update 3.6.5 completed!');
+        $.inidb.SetBoolean('updates', '', 'installedv3.6.5', true);
+    }
 })();

--- a/javascript-source/core/updates.js
+++ b/javascript-source/core/updates.js
@@ -528,14 +528,23 @@
         if ($.inidb.FileExists('traffleState')) {
             var bools = JSON.parse($.inidb.get('traffleState', 'bools'));
 
-            $.inidb.SetBoolean('traffleState', '', 'followers', bools[0]);
+            $.inidb.SetBoolean('traffleState', '', 'followers', (bools[0] === 'true'));
             $.inidb.RemoveKey('traffleState', '', 'bools');
 
             if ($.inidb.FileExists('traffleSettings')) {
-                $.inidb.SetBoolean('traffleState', '', 'isActive', $.inidb.GetBoolean('traffleSettings', '', 'isActive'));
-                $.inidb.RemoveFile('traffleSettings');
+                $.inidb.set('traffleState', 'isActive', $.inidb.get('traffleSettings', 'isActive'));
+                $.inidb.RemoveKey('traffleSettings', '', 'isActive');
             }
         }
+
+        $.inidb.set('traffleSettings', 'traffleMSGToggle', $.inidb.get('settings', 'tRaffleMSGToggle'));
+        $.inidb.set('traffleSettings', 'traffleMessage', $.inidb.get('settings', 'traffleMessage'));
+        $.inidb.set('traffleSettings', 'traffleMessageInterval', $.inidb.get('settings', 'traffleMessageInterval'));
+        $.inidb.set('traffleSettings', 'traffleLimiter', $.inidb.get('settings', 'tRaffleLimiter'));
+        $.inidb.RemoveKey('settings', '', 'traffleMSGToggle');
+        $.inidb.RemoveKey('settings', '', 'traffleMessage');
+        $.inidb.RemoveKey('settings', '', 'traffleMessageInterval');
+        $.inidb.RemoveKey('settings', '', 'traffleLimiter');
 
         $.consoleLn('PhantomBot update 3.6.5 completed!');
         $.inidb.SetBoolean('updates', '', 'installedv3.6.5', true);

--- a/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-ticketraffleSystem.js
@@ -32,7 +32,9 @@ $.lang.register('ticketrafflesystem.winner.multiple.award', 'The winners have be
 $.lang.register('ticketrafflesystem.only.buy.amount', 'You can only buy $1 ticket(s)');
 $.lang.register('ticketrafflesystem.only.buy.amount.limiter', 'You can only buy $1 ticket(s) because you receive a bonus of $2 %');
 $.lang.register('ticketrafflesystem.limit.hit', 'You\'re only allowed to buy a maximum of $1 ticket(s). You currently have $2 tickets.');
-$.lang.register('ticketrafflesystem.limit.hit.limiter', 'You\'re only allowed to buy a maximum of $1 ticket(s) because the you receive a bonus of $2 %. You currently have $3 tickets.');
+$.lang.register('ticketrafflesystem.limit.hit.limiter', 'You\'re only allowed to buy a maximum of $1 ticket(s) because you receive a bonus of $2 %. You currently have $3 tickets.');
+$.lang.register('ticketrafflesystem.limit.hit.bonus', 'You\'re only allowed to buy a maximum of $1 ticket(s). You currently have $2 (+ $3 bonus) tickets.');
+$.lang.register('ticketrafflesystem.limit.hit.limiter.bonus', 'You\'re only allowed to buy a maximum of $1 ticket(s) because the you receive a bonus of $2 %. You currently have $3 (+ $4 bonus) tickets.');
 $.lang.register('ticketrafflesystem.settings.err.open', 'You cannot change this setting while a raffle is open!');
 $.lang.register('ticketrafflesystem.err.not.following', 'You need to be following to enter.');
 $.lang.register('ticketrafflesystem.err.points', 'You don\'t have enough $1 to enter.');

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -356,14 +356,14 @@
         if (!$.inidb.exists('ticketsList', user.toLowerCase())) {
             return 0;
         }
-        return $.inidb.get('ticketsList', user.toLowerCase())[POS.times];
+        return JSON.parse($.inidb.get('ticketsList', user.toLowerCase()))[POS.times];
     }
 
     function getBonusTickets(user) {
         if (!$.inidb.exists('ticketsList', user.toLowerCase())) {
             return 0;
         }
-        return $.inidb.get('ticketsList', user.toLowerCase())[POS.bonus];
+        return JSON.parse($.inidb.get('ticketsList', user.toLowerCase()))[POS.bonus];
     }
 
     function userGetsBonus(user, event) {

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -42,7 +42,7 @@
     };
 
     function reloadTRaffle() {
-        msgToggle = $.getIniDbBoolean('traffleSettings', 'traffleMSGToggle');
+        msgToggle = $.inidb.GetBoolean('traffleSettings', '', 'traffleMSGToggle');
         raffleMessage = $.getSetIniDbString('traffleSettings', 'traffleMessage');
         messageInterval = $.getSetIniDbNumber('traffleSettings', 'traffleMessageInterval');
         limiter = $.inidb.GetBoolean('traffleSettings', '', 'traffleLimiter');
@@ -131,7 +131,7 @@
         maxEntries = parseInt($.inidb.get('traffleState', 'maxEntries'));
         totalEntries = parseInt($.inidb.get('traffleState', 'totalEntries'));
         totalTickets = parseInt($.inidb.get('traffleState', 'totalTickets'));
-        hasDrawn = $.inidb.HasKey('traffleState', '', 'uniqueEntries');
+        hasDrawn = $.inidb.GetBoolean('traffleState', '', 'hasDrawn');
         followers = $.inidb.GetBoolean('traffleState', '', 'followers');
         raffleStatus = $.inidb.GetBoolean('traffleState', '', 'isActive');
 
@@ -163,7 +163,7 @@
         $.inidb.set('traffleState', 'totalEntries', totalEntries);
         $.inidb.set('traffleState', 'totalTickets', totalTickets);
         $.inidb.set('traffleState', 'uniqueEntries', JSON.stringify(uniqueEntries));
-        $.inidb.set('traffleState', 'hasDrawn', hasDrawn);
+        $.inidb.SetBoolean('traffleState', 'hasDrawn', hasDrawn);
     }
 
     function closeRaffle() {
@@ -198,7 +198,7 @@
         }
 
         hasDrawn = true;
-        $.inidb.set('traffleState', 'hasDrawn', hasDrawn);
+        $.inidb.SetBoolean('traffleState', '', 'hasDrawn', hasDrawn);
 
         if (raffleStatus) {
             closeRaffle(); //Close the raffle if it's open. Why draw a winner when new users can still enter?

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -163,7 +163,7 @@
         $.inidb.set('traffleState', 'totalEntries', totalEntries);
         $.inidb.set('traffleState', 'totalTickets', totalTickets);
         $.inidb.set('traffleState', 'uniqueEntries', JSON.stringify(uniqueEntries));
-        $.inidb.SetBoolean('traffleState', 'hasDrawn', hasDrawn);
+        $.inidb.SetBoolean('traffleState', '', 'hasDrawn', hasDrawn);
     }
 
     function closeRaffle() {

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -23,10 +23,10 @@
         maxEntries = 0,
         followers = false,
         raffleStatus = false,
-        msgToggle = $.getSetIniDbBoolean('settings', 'tRaffleMSGToggle', false),
-        raffleMessage = $.getSetIniDbString('settings', 'traffleMessage', 'A raffle is still opened! Type !tickets (amount) to enter. (entries) users have entered so far.'),
-        messageInterval = $.getSetIniDbNumber('settings', 'traffleMessageInterval', 0),
-        limiter = $.getSetIniDbNumber('settings', 'tRaffleLimiter', false),
+        msgToggle = $.getSetIniDbBoolean('traffleSettings', 'traffleMSGToggle', false),
+        raffleMessage = $.getSetIniDbString('traffleSettings', 'traffleMessage', 'A raffle is still opened! Type !tickets (amount) to enter. (entries) users have entered so far.'),
+        messageInterval = $.getSetIniDbNumber('traffleSettings', 'traffleMessageInterval', 0),
+        limiter = $.getSetIniDbNumber('traffleSettings', 'traffleLimiter', false),
         totalEntries = 0,
         totalTickets = 0,
         a = '',
@@ -42,10 +42,10 @@
     };
 
     function reloadTRaffle() {
-        msgToggle = $.getIniDbBoolean('settings', 'tRaffleMSGToggle');
-        raffleMessage = $.getSetIniDbString('settings', 'traffleMessage');
-        messageInterval = $.getSetIniDbNumber('settings', 'traffleMessageInterval');
-        limiter = $.inidb.GetBoolean('settings', '', 'tRaffleLimiter');
+        msgToggle = $.getIniDbBoolean('traffleSettings', 'traffleMSGToggle');
+        raffleMessage = $.getSetIniDbString('traffleSettings', 'traffleMessage');
+        messageInterval = $.getSetIniDbNumber('traffleSettings', 'traffleMessageInterval');
+        limiter = $.inidb.GetBoolean('traffleSettings', '', 'traffleLimiter');
 
     }
 
@@ -502,11 +502,11 @@
             if (action.equalsIgnoreCase('messagetoggle')) {
                 if (msgToggle) {
                     msgToggle = false;
-                    $.inidb.set('settings', 'tRaffleMSGToggle', msgToggle);
+                    $.inidb.set('traffleSettings', 'traffleMSGToggle', msgToggle);
                     $.say($.whisperPrefix(sender) + $.lang.get('ticketrafflesystem.msg.disabled'));
                 } else {
                     msgToggle = true;
-                    $.inidb.set('settings', 'tRaffleMSGToggle', msgToggle);
+                    $.inidb.set('traffleSettings', 'traffleMSGToggle', msgToggle);
                     $.say($.whisperPrefix(sender) + $.lang.get('ticketrafflesystem.msg.enabled'));
                 }
                 return;
@@ -522,7 +522,7 @@
                 }
 
                 limiter = !limiter;
-                $.inidb.SetBoolean('settings', '', 'tRaffleLimiter', limiter);
+                $.inidb.SetBoolean('traffleSettings', '', 'traffleLimiter', limiter);
                 if (limiter) {
                     $.say($.whisperPrefix(sender) + $.lang.get('ticketrafflesystem.limiter.enabled'));
                 } else {
@@ -541,7 +541,7 @@
                 }
 
                 raffleMessage = argString.replace(action, '').trim();
-                $.inidb.set('settings', 'traffleMessage', raffleMessage);
+                $.inidb.set('traffleSettings', 'traffleMessage', raffleMessage);
                 $.say($.whisperPrefix(sender) + $.lang.get('ticketrafflesystem.auto.msg.set', raffleMessage));
                 $.log.event(sender + ' changed the auto announce message to ' + raffleMessage);
                 return;
@@ -557,7 +557,7 @@
                 }
 
                 messageInterval = parseInt(args[1]);
-                $.inidb.set('settings', 'traffleMessageInterval', messageInterval);
+                $.inidb.set('traffleSettings', 'traffleMessageInterval', messageInterval);
                 $.say($.whisperPrefix(sender) + $.lang.get('ticketrafflesystem.auto.msginterval.set', messageInterval));
                 $.log.event(sender + ' changed the auto announce interval to ' + messageInterval);
                 return;

--- a/javascript-source/systems/ticketraffleSystem.js
+++ b/javascript-source/systems/ticketraffleSystem.js
@@ -111,14 +111,14 @@
         }, 5 * 6e4);
 
         $.log.event(user + ' opened a ticket raffle.');
-        $.inidb.SetBoolean('traffleSettings', '', 'isActive', true);
+        $.inidb.SetBoolean('traffleState', '', 'isActive', raffleStatus);
         saveState();
     }
 
     function reopen() {
         if (!$.inidb.FileExists('traffleState') || !$.inidb.HasKey('traffleState', '', 'cost') || !$.inidb.HasKey('traffleState', '', 'entries')
                 || !$.inidb.HasKey('traffleState', '', 'subTMulti') || !$.inidb.HasKey('traffleState', '', 'regTMulti') || !$.inidb.HasKey('traffleState', '', 'maxEntries')
-                || !$.inidb.HasKey('traffleState', '', 'bools') || !$.inidb.HasKey('traffleState', '', 'totalEntries') || !$.inidb.HasKey('traffleState', '', 'totalTickets')
+                || !$.inidb.HasKey('traffleState', '', 'followers') || !$.inidb.HasKey('traffleState', '', 'isActive') || !$.inidb.HasKey('traffleState', '', 'totalEntries') || !$.inidb.HasKey('traffleState', '', 'totalTickets')
                 || !$.inidb.HasKey('traffleState', '', 'uniqueEntries') || !$.inidb.HasKey('traffleState', '', 'hasDrawn')) {
             return;
         }
@@ -129,15 +129,13 @@
         subTMulti = parseInt($.inidb.get('traffleState', 'subTMulti'));
         regTMulti = parseInt($.inidb.get('traffleState', 'regTMulti'));
         maxEntries = parseInt($.inidb.get('traffleState', 'maxEntries'));
-        var bools = JSON.parse($.inidb.get('traffleState', 'bools'));
         totalEntries = parseInt($.inidb.get('traffleState', 'totalEntries'));
         totalTickets = parseInt($.inidb.get('traffleState', 'totalTickets'));
         hasDrawn = $.inidb.HasKey('traffleState', '', 'uniqueEntries');
-        followers = bools[0];
-        raffleStatus = bools[1];
+        followers = $.inidb.GetBoolean('traffleState', '', 'followers');
+        raffleStatus = $.inidb.GetBoolean('traffleState', '', 'isActive');
 
         if (raffleStatus === true) {
-            $.inidb.SetBoolean('traffleSettings', '', 'isActive', true);
             if (followers) {
                 a = $.lang.get('ticketrafflesystem.msg.need.to.be.following');
             }
@@ -160,7 +158,8 @@
         $.inidb.set('traffleState', 'subTMulti', subTMulti);
         $.inidb.set('traffleState', 'regTMulti', regTMulti);
         $.inidb.set('traffleState', 'maxEntries', maxEntries);
-        $.inidb.set('traffleState', 'bools', JSON.stringify([followers, raffleStatus]));
+        $.inidb.SetBoolean('traffleState', '', 'isActive', raffleStatus);
+        $.inidb.SetBoolean('traffleState', '', 'followers', followers);
         $.inidb.set('traffleState', 'totalEntries', totalEntries);
         $.inidb.set('traffleState', 'totalTickets', totalTickets);
         $.inidb.set('traffleState', 'uniqueEntries', JSON.stringify(uniqueEntries));
@@ -171,7 +170,6 @@
         raffleStatus = false;
         clearInterval(interval);
         clearInterval(saveStateInterval);
-        $.inidb.SetBoolean('traffleSettings', '', 'isActive', false);
         saveState();
     }
 
@@ -189,7 +187,6 @@
         totalTickets = 0;
         regTMulti = 1;
         subTMulti = 1;
-        $.inidb.SetBoolean('traffleSettings', '', 'isActive', false);
         saveState();
     }
 

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -231,8 +231,8 @@ $(function () {
     // Raffle settings button.
     $('#ticket-raffle-settings').on('click', function () {
         socket.getDBValues('get_traffle_settings', {
-            tables: ['settings', 'settings', 'settings', 'settings'],
-            keys: ['tRaffleMSGToggle', 'traffleMessage', 'traffleMessageInterval', 'tRaffleLimiter']
+            tables: ['traffleSettings', 'traffleSettings', 'traffleSettings', 'traffleSettings'],
+            keys: ['traffleMSGToggle', 'traffleMessage', 'traffleMessageInterval', 'traffleLimiter']
         }, true, function (e) {
             helpers.getModal('traffle-settings-modal', 'Ticket Raffle Settings', 'Save', $('<form/>', {
                 'role': 'form'
@@ -274,8 +274,8 @@ $(function () {
                         break;
                     default:
                         socket.updateDBValues('update_traffle_settings_2', {
-                            tables: ['settings', 'settings', 'settings', 'settings'],
-                            keys: ['tRaffleMSGToggle', 'traffleMessage', 'traffleMessageInterval', 'tRaffleLimiter'],
+                            tables: ['traffleSettings', 'traffleSettings', 'traffleSettings', 'traffleSettings'],
+                            keys: ['traffleMSGToggle', 'traffleMessage', 'traffleMessageInterval', 'traffleLimiter'],
                             values: [warningMsg, raffleMessage.val(), raffleTimer.val(), limiter]
                         }, function () {
                             socket.sendCommand('raffle_reload_cmd', 'reloadtraffle', function () {

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -17,7 +17,7 @@
 
 $(run = function () {
     socket.getDBValues('traffle_module_status_toggle', {
-        tables: ['modules', 'traffleSettings', 'traffleState'],
+        tables: ['modules', 'traffleState', 'traffleState'],
         keys: ['./systems/ticketraffleSystem.js', 'isActive', 'hasDrawn']
     }, true, function (e) {
         if (!helpers.handleModuleLoadUp(['ticketRaffleListModule', 'ticketRaffleModal'], e['./systems/ticketraffleSystem.js'], 'ticketRaffleModuleToggle')) {
@@ -220,7 +220,7 @@ $(function () {
             'class': 'fa fa-unlock-alt'
         })).append('&nbsp; Open').removeClass('btn-warning').addClass('btn-success');
 
-        $('#traffle-list-title').val("Ticket Raffle List");
+        $('#traffle-list-title').val('Ticket Raffle List');
 
         // Close raffle but don't pick a winner.
         socket.sendCommand('reset_traffle_cmd', 'traffle reset', function () {

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -43,8 +43,10 @@ $(run = function () {
                         'html': results[i].key
                     }));
 
+                    let ticketJSON = JSON.parse(results[i].value);
+
                     tr.append($('<td/>', {
-                        'html': results[i].value
+                        'html': (ticketJSON[0] + ' (+' + ticketJSON[1] + ')')
                     }));
 
                     table.append(tr);

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -257,10 +257,10 @@ $(function () {
                 'role': 'form'
             })
             // Add toggle for warning messages.
-            .append(helpers.getDropdownGroup('warning-msg', 'Enable Warning Messages', (e['tRaffleMSGToggle'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
+            .append(helpers.getDropdownGroup('warning-msg', 'Enable Warning Messages', (e['traffleMSGToggle'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
                 'If warning messages should be said in chat when a user already entered, or doesn\'t have enough points.'))
             // Add toggle for the limiter.
-            .append(helpers.getDropdownGroup('limiter', 'Enable limiter', (e['tRaffleLimiter'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
+            .append(helpers.getDropdownGroup('limiter', 'Enable limiter', (e['traffleLimiter'] === 'true' ? 'Yes' : 'No'), ['Yes', 'No'],
                 'ON: Limit the total amount of tickets (bought tickets + bonus tickets) to the set limit. OFF: Limit only the amount of bought tickets.'))))),
             function () {
                 let raffleTimer = $('#msg-timer'),

--- a/resources/web/panel/js/pages/giveaways/ticketRaffle.js
+++ b/resources/web/panel/js/pages/giveaways/ticketRaffle.js
@@ -58,7 +58,7 @@ $(run = function () {
          * @function Loads the raffle winners.
          */
         helpers.temp.loadWinners = function () {
-            socket.getDBValue('get_traffle_list', 'traffleresults', 'winner', function (results) {
+            socket.getDBValue('get_traffle_winner_list', 'traffleresults', 'winner', function (results) {
                 const table = $('#ticket-raffle-table');
 
                 $('#traffle-list-title').text("Ticket Raffle Winners");


### PR DESCRIPTION
Fixes panel counting/showing bonus tickets in the entries list. This PR introduces the same syntax for the ticket count as chat commands to the panel:
![image](https://user-images.githubusercontent.com/572591/183246819-6d3d8017-1f02-43d1-95b9-6157a66d7c4e.png)

This needed a change to the database, where the bonus tickets are also saved instead of only dynamically calculating them. This introduces a small issue when updating the bot while there is an active ticket raffle in the saved state. Since there is only partly information about the users' sub status, the update may fail to properly calculate and save the users' bonus tickets. See `line 603 `and onwards in the changed `javascript-source/systems/ticketraffleSystem.js` ... there is no event to properly check for the users' sub status. Though I believe this is a rare edge case and notifying the users in the update notes to close any open ticket raffles before updating should be an acceptable solution to a proper update.

Further fixes and changes:
- Since a traffleSettings table already exists, the ticket raffle settings were moved from the general settings table to that table.
- Duplicated isActive variable now only exists in the raffleState table as it is part of the state and not a setting. This duplication lead to the ticketraffle status not properly being read when restarting the bot.
- Diversified the output text
- Fixed users can buy tickets over the limit because I cannot math correctly