### PR TITLE
Update streamHandler.js

### DIFF
--- a/javascript-source/discord/handlers/streamHandler.js
+++ b/javascript-source/discord/handlers/streamHandler.js
@@ -61,7 +61,7 @@
     function getTrimmedGameName() {
         var game = $.jsString($.twitchcache.getGameTitle());
 
-        return (game.length > 15 ? game.slice(0, 15) + '...' : game);
+        return (game.length > 45 ? game.slice(0, 45) + '...' : game);
     }
 
     function sanitizeTitle(s) {


### PR DESCRIPTION
No clue what the reason is for chopping off the name of the game after just 15 characters.
I took 45, but that is arbitrary as well.

I can imagine some UI issues on some devices occured in the past, but other content should get sliced than as well.
This works great on my 5 year old Android phone. 45 characters doesnt reach the end of a line in discord.

**Testresults**
I already use 45 for a long time; digged up an old post of the bot and one of today with the current nightly.

![image](https://user-images.githubusercontent.com/11378079/185664403-1ea31660-50a4-41c7-9b0f-8067a0ec8b65.png)
![image](https://user-images.githubusercontent.com/11378079/185664692-b5783b3a-bc6e-4ce9-b68e-f4bfa3270a84.png)


