### PR TITLE
Fix: Autolevel

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -359,6 +359,26 @@
     }
 
     /**
+     * @function isViewer
+     * @export $
+     * @param {string} username
+     * @returns {boolean}
+     */
+    function isViewer(username) {
+        return queryDBPermission(username.toLowerCase()) === PERMISSION.Viewer;
+    }
+
+    /**
+     * @function hasPermissionLevel
+     * @export $
+     * @param {string} username
+     * @returns {boolean}
+     */
+    function hasPermissionLevel(username) {
+        return queryDBPermission(username.toLowerCase()) !== PERMISSION.None;
+    }
+
+    /**
      * @function hasModeO
      * @export $
      * @param {string} username
@@ -1388,6 +1408,8 @@
     $.isDonator = isDonator;
     $.isVIP = isVIP;
     $.isRegular = isRegular;
+    $.isViewer = isViewer;
+    $.hasPermissionLevel = hasPermissionLevel;
     $.hasModeO = hasModeO;
     $.hasModList = hasModList;
     $.getUserGroupId = getUserGroupId;

--- a/javascript-source/core/timeSystem.js
+++ b/javascript-source/core/timeSystem.js
@@ -527,7 +527,7 @@
                         && (!$.hasPermissionLevel(username) || $.isViewer(username)) //Assume users without permissions level are viewers, if they are too new the check will fail in the next condition
                         && $.inidb.exists('time', username)
                         && Math.floor(parseInt($.inidb.get('time', username)) / 3600) >= hoursForLevelUp) {
-                        if (!$.hasModList(username)) { // Added a second check here to be 100% sure the user is not a mod.
+                        if (!$.hasModList(username) && !$.hasModeO(username)) { // Added a second check here to be 100% sure the user is not a mod.
                             $.setUserGroupById(username, $.PERMISSION.Regular);
                             if (timeLevelWarning) {
                                 $.say($.lang.get(

--- a/javascript-source/core/timeSystem.js
+++ b/javascript-source/core/timeSystem.js
@@ -516,28 +516,26 @@
     // Interval for auto level to regular
     inter = setInterval(function () {
         var username,
-                i;
+            i;
 
         if (levelWithTime) {
             for (i in $.users) {
                 if ($.users[i] !== null) {
                     username = $.users[i].toLowerCase();
-                    if (!$.checkUserPermission(username, undefined, $.PERMISSION.Mod)
-                        && !$.checkUserPermission(username, undefined, $.PERMISSION.Admin)
-                        && !$.checkUserPermission(username, undefined, $.PERMISSION.Sub)
-                        && !$.checkUserPermission(username, undefined, $.PERMISSION.VIP)
+                    // Only level viewers to regulars and ignore TwitchBots
+                    if (!$.isTwitchBot(username)
+                        && (!$.hasPermissionLevel(username) || $.isViewer(username)) //Assume users without permissions level are viewers, if they are too new the check will fail in the next condition
                         && $.inidb.exists('time', username)
-                        && Math.floor(parseInt($.inidb.get('time', username)) / 3600) >= hoursForLevelUp
-                        && $.checkUserPermission(username, undefined, $.getLowestIDSubVIP())) {
+                        && Math.floor(parseInt($.inidb.get('time', username)) / 3600) >= hoursForLevelUp) {
                         if (!$.hasModList(username)) { // Added a second check here to be 100% sure the user is not a mod.
                             $.setUserGroupById(username, $.PERMISSION.Regular);
                             if (timeLevelWarning) {
                                 $.say($.lang.get(
-                                        'timesystem.autolevel.promoted',
-                                        $.username.resolve(username),
-                                        $.getGroupNameById($.PERMISSION.Regular).toLowerCase(),
-                                        hoursForLevelUp
-                                        )); //No whisper mode needed here.
+                                    'timesystem.autolevel.promoted',
+                                    $.username.resolve(username),
+                                    $.getGroupNameById($.PERMISSION.Regular).toLowerCase(),
+                                    hoursForLevelUp
+                                )); //No whisper mode needed here.
                             }
                         }
                     }


### PR DESCRIPTION
- Fixes user autoleveling.
- Ignores Twitch bots (they do not need to be leveled since the user added them to the bot list and wants them ignored anyway)
- Halves required lookup queries for each user check in the loop and should thus reduce server load