### PR TITLE
Added the ability to use UID and GID variables

### DIFF
--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 set -e
 
+id phantombot
+
+if [[ ${UID+x} && ${GID+x} ]]; then
+	if [[ "$(id -u phantombot)" != $UID ]]; then
+		echo "Setting user to UID/GID: $UID / $GID"
+		groupmod -g $GID phantombot
+		usermod -u $UID -g $GID phantombot
+	fi
+fi
+
+id phantombot
+
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' -a ! -v ALLOW_ROOT ]; then
+	mkdir -p /opt/PhantomBot_data/logs /opt/PhantomBot_data/dbbackup /opt/PhantomBot_data/addons /opt/PhantomBot_data/config /opt/PhantomBot_data/gameslist
+	touch /opt/PhantomBot_data/gameslist/gamesList.txt
+	chown -R phantombot:phantombot /opt/PhantomBot_data;
 	find /opt/PhantomBot \! -type l \! -user phantombot -exec chown phantombot:phantombot '{}' +
 	find /opt/PhantomBot_data \! -type l \! -user phantombot -exec chown phantombot:phantombot '{}' +
 	exec gosu phantombot "$0" "$@"

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-id phantombot
-
 if [[ ${UID+x} && ${GID+x} ]]; then
 	if [[ "$(id -u phantombot)" != $UID ]]; then
 		echo "Setting user to UID/GID: $UID / $GID"
@@ -10,8 +8,6 @@ if [[ ${UID+x} && ${GID+x} ]]; then
 		usermod -u $UID -g $GID phantombot
 	fi
 fi
-
-id phantombot
 
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' -a ! -v ALLOW_ROOT ]; then


### PR DESCRIPTION
Honestly I never found myself to be able to use the `--user` directive with mounted volumes instead of named ones, so with a bit of trial and error I managed to put up a little modification of `docker-entrypoint.sh` to support them.
