### PR TITLE
Band-aid the noticeSystem

### DIFF
--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -262,7 +262,7 @@
             }
         }
 
-        if (notice === null) {
+        if (notice === null || notice === undefined) {
             noticeLock.unlock();
             return false;
         }

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -111,7 +111,8 @@
     /**
      * @function startNoticeTimer
      */
-    function startNoticeTimer(idx, retryCall = false) {
+    function startNoticeTimer(idx, retryCall) {
+        retryCall = (retryCall === undefined || retryCall === null) ? false : retryCall;
         noticeLock.lock();
         stopNoticeTimer(idx);
 

--- a/javascript-source/systems/noticeSystem.js
+++ b/javascript-source/systems/noticeSystem.js
@@ -31,7 +31,6 @@
             messageCounts = [],
             lastNoticesSent = [],
             lastTimeNoticesSent = [];
-    loadNotices();
 
     /**
      * @function loadNotices
@@ -943,6 +942,7 @@
      */
     $.bind('initReady', function () {
         $.registerChatCommand('./systems/noticeSystem.js', 'notice', $.PERMISSION.Admin);
+        loadNotices();
         startNoticeTimers();
     });
 

--- a/resources/web/panel/js/pages/timers/timers.js
+++ b/resources/web/panel/js/pages/timers/timers.js
@@ -24,7 +24,7 @@
         const idPrefix = groupData === null ? 'add-' : 'edit-';
         const title = groupData === null ? 'Add Group' : 'Edit Group',
               name = groupData === null ? '' : groupData.name,
-              noticeToggle  = groupData === null ? 'Yes' : (groupData.noticeToggle === true ? 'Yes' : 'No'),
+              noticeToggle = groupData === null ? 'Yes' : (groupData.noticeToggle === true ? 'Yes' : 'No'),
               noticeOfflineToggle = groupData === null ? 'No' : (groupData.noticeOfflineToggle === true ? 'Yes' : 'No'),
               intervalMin = groupData === null ? '10' : groupData.intervalMin,
               intervalMax = groupData === null ? '' : (intervalMin === groupData.intervalMax ? '' : groupData.intervalMax),
@@ -214,7 +214,7 @@
                     socket.getDBValue('timer_group_edit_get', 'notices', groupId, function(e) {
                         let groupData = e.notices;
                         if (groupData === null) {
-                            run();  // group doesn't exist anymore => reload
+                            run(); // group doesn't exist anymore => reload
                         }
                         groupData = JSON.parse(groupData);
                         openGroupModal(groupData, function(result) {
@@ -286,7 +286,7 @@
         socket.getDBValue('timer_messages_edit_get', 'notices', String(groupId), function(e) {
             let groupData = e.notices;
             if (groupData === null) {
-                run();  // group doesn't exist anymore => reload
+                run(); // group doesn't exist anymore => reload
                 return;
             }
             groupData = JSON.parse(groupData);


### PR DESCRIPTION
Adds a missing check for undefined in the notice-system to prevent:

`[ERROR] [init.js:357] Error with Event Handler [initReady] Script [./systems/noticeSystem.js] Stacktrace [sendNotice()@noticeSystem.js:273 > trySendNotice()@noticeSystem.js:194 > startNoticeTimer()@noticeSystem.js:130 > startNoticeTimers()@noticeSystem.js:103 > noticeSystem.js:865 > init.js:349 > init.js:480] Exception [TypeError: Cannot call method "startsWith" of undefined]`