### PR TITLE
Added page to configure stream overlay

### DIFF
--- a/resources/web/panel/index.html
+++ b/resources/web/panel/index.html
@@ -371,6 +371,13 @@
                                 </ul>
                             </li>
 
+                            <!-- Stream Overlay tab -->
+                            <li>
+                                <a href="#overlay.html" data-folder="overlay">
+                                    <i class="fa fa-circle-o"></i> <span> Stream Overlay</span>
+                                </a>
+                            </li>
+
                             <!-- Settings tab -->
                             <li class="treeview">
                                 <a href="#">

--- a/resources/web/panel/js/pages/overlay/overlay.js
+++ b/resources/web/panel/js/pages/overlay/overlay.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2016-2022 phantombot.github.io/PhantomBot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+$(function() {
+    // Constants
+    // Meta information for the database and to connect it to HTML
+    const moduleId = 'overlay';
+    const databaseModuleId = 'overlay_module';
+    const moduleConfigTable = 'overlay';
+    const formId = 'alertsOverlayModule';
+    const outputElementId = 'overlayUrl';
+
+    // Config entries
+    const enableAudioHooks = 'enableAudioHooks';
+    const audioHookVolume = 'audioHookVolume';
+    const enableFlyingEmotes = 'enableFlyingEmotes';
+    const enableGifAlerts = 'enableGifAlerts';
+    const gifAlertVolume = 'gifAlertVolume';
+    const enableVideoClips = 'enableVideoClips';
+    const videoClipVolume = 'videoClipVolume';
+    const enableDebug = 'enableDebug';
+
+    // members
+    let inputElements = null;
+    let outputElement = null;
+
+    function init() {
+        // This module cannot be enabled or disabled since it provides a resource and just helps to configure
+        // this resource file. The stored values are just the last used settings.
+        socket.getDBValues(databaseModuleId, {
+            tables: [
+                moduleConfigTable, moduleConfigTable, moduleConfigTable,
+                moduleConfigTable, moduleConfigTable, moduleConfigTable,
+                moduleConfigTable, moduleConfigTable,
+            ],
+            keys: [
+                enableAudioHooks, audioHookVolume, enableFlyingEmotes,
+                enableGifAlerts, gifAlertVolume, enableDebug,
+                enableVideoClips, videoClipVolume
+            ]
+        }, true, function(config) {
+            // handle boolean values
+            [
+                enableAudioHooks,
+                enableFlyingEmotes,
+                enableGifAlerts,
+                enableVideoClips,
+                enableDebug
+            ].forEach((key) => {
+                let inputNode = document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1));
+                // only accept 'true' and 'false' as valid
+                if (config[key] === 'true' || config[key] === 'false') {
+                    inputNode.checked = config[key] === 'true';
+                } else {
+                    // set the default value otherwise
+                    inputNode.checked = inputNode.defaultChecked;
+                }
+            });
+            // handle decimals
+            [audioHookVolume, gifAlertVolume, videoClipVolume].forEach((key) => {
+                let inputNode = document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1));
+                // Convert the value to a String and then to number to validate it
+                // and use the default value, if it's invalid
+                let value = Number(String(config[key]));
+                inputNode.value = isNaN(value) ? inputNode.placeholder : value;
+            });
+        });
+
+        // Connect DOM to Code
+
+        outputElement = document.forms[formId][outputElementId];
+        // get a list of all elements that should get an event listener on their change to trigger an update of the url
+        inputElements = document.forms[formId].getElementsByClassName('trigger-update');
+
+        Array.prototype.forEach.call(inputElements, (element) => {
+            element.addEventListener("change", (event) => {
+                buildOverlayUrl(event);
+                window.helpers.debounce(function() {
+                    save();
+                }, 1000)();
+            });
+        });
+
+        // finally generate the url once
+        buildOverlayUrl();
+    };
+
+
+    function buildOverlayUrl() {
+        outputElement.value = `${helpers.getBotSchemePath()}/alerts?`;
+        let stringSettings = Array.prototype.filter.call(inputElements, (element) => element.type !== 'checkbox')
+            .map((element) => {
+                let name = element.id.slice(moduleId.length);
+                return `${name[0].toLowerCase()}${name.slice(1)}=${element.value}`
+            })
+            .join('&');
+        let booleanSettings = Array.prototype.filter.call(inputElements, (element) => element.type === 'checkbox')
+            .map((element) => {
+                let name = element.id.slice(moduleId.length);
+                return `${name[0].toLowerCase()}${name.slice(1)}=${element.checked}`
+            })
+            .join('&');
+        outputElement.value += stringSettings + '&' + booleanSettings;
+    };
+
+    function save() {
+        // Collect values from the form with special caution to checkbox elements
+        let keysStrings = [audioHookVolume, gifAlertVolume, videoClipVolume];
+        let keysCheckboxes = [enableAudioHooks, enableFlyingEmotes, enableGifAlerts, enableVideoClips, enableDebug];
+        let valuesStrings = keysStrings.map(key => inputElements[moduleId + key[0].toUpperCase() + key.slice(1)].value);
+        let valuesCheckboxes = keysCheckboxes.map(key => inputElements[moduleId + key[0].toUpperCase() + key.slice(1)].checked);
+        let keys = keysStrings.concat(keysCheckboxes);
+        let values = valuesStrings.concat(valuesCheckboxes);
+        // Save the values in the database omitting the success callback because value changes can happen often and fast
+        socket.updateDBValues(databaseModuleId, {
+            tables: [
+                moduleConfigTable, moduleConfigTable, moduleConfigTable,
+                moduleConfigTable, moduleConfigTable, moduleConfigTable,
+                moduleConfigTable, moduleConfigTable
+            ],
+            keys: keys,
+            values: values
+        }, () => {});
+    };
+
+    init();
+});

--- a/resources/web/panel/js/utils/helpers.js
+++ b/resources/web/panel/js/utils/helpers.js
@@ -1262,6 +1262,21 @@ $(function () {
         return parsedDate;
     };
 
+    /**
+     * Returns a function prototype that sets a timeout in the future and executes the given function then
+     *
+     * @param func the function to debounce
+     * @param timeout the timespan to debounce in ms
+     * @returns {(function(...[*]=): void)|*} the given function wrapped in the debounce functionality
+     */
+    helpers.debounce = function(func, timeout = 300){
+      let timer;
+      return (...args) => {
+          window.clearInterval(timer);
+          timer = window.setTimeout(() => { func.apply(this, args); }, timeout);
+      }
+    };
+
     helpers.parseHashmap = function () {
         var hash = window.location.hash.slice(1);
         var kvs = hash.split('&');

--- a/resources/web/panel/pages/overlay/overlay.html
+++ b/resources/web/panel/pages/overlay/overlay.html
@@ -1,0 +1,148 @@
+<!--
+    Copyright (C) 2016-2022 phantombot.github.io/PhantomBot
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<style type="text/css">
+    #overlayUrl{
+        color: transparent !important; text-shadow: 0 0 5px hsla(0, 0%, 100%, .5);
+    }
+    #overlayUrl:focus{
+        color: inherit !important; text-shadow: 0 0 0;
+    }
+</style>
+
+<main>
+    <!-- Header -->
+    <section class="content-header">
+        <h1>Overlay</h1>
+        <ol class="breadcrumb">
+            <li><a href="javascript:void(0);"><i class="fa fa-dashboard"></i> Home</a></li>
+            <li>Alerts</li>
+            <li class="active">Overlay</li>
+        </ol>
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+        <form role="form" id="alertsOverlayModule">
+            <!-- Audio Hooks -->
+            <div class="box box-solid">
+                <div class="box-header with-border">
+                    <label class="switch" data-toggle="tooltip" title="Module toggle">
+                        <input type="checkbox" class="trigger-update" id="overlayEnableAudioHooks" checked="">
+                        <span class="slider round"></span>
+                    </label>
+                    <h3 class="box-title">Allow Audio Hooks</h3>
+                    <span class="help-block">Enables to play audio commands.</span>
+                </div>
+                <!-- Box content -->
+                <div class="box-body">
+                    <div class="form-group">
+                        <label for="overlayAudioHookVolume">Audio Hook Volume</label>
+                        <input type="number" class="form-control trigger-update" id="overlayAudioHookVolume" placeholder="0.8"
+                               value="0.8" min="0.0"
+                               step=".05" max="1.0"/>
+                        <span class="help-block">Sets the volume of Audio Alerts where 1.0 full volume and 0.0 is silent.</span>
+                    </div>
+                </div>
+            </div>
+            <!-- Flying Emoticons -->
+            <div class="box box-solid">
+                <div class="box-header">
+                    <label class="switch" data-toggle="tooltip" title="Module toggle">
+                        <input type="checkbox" class="trigger-update" id="overlayEnableFlyingEmotes" checked="">
+                        <span class="slider round"></span>
+                    </label>
+                    <h3 class="box-title">Show flying emotes</h3>
+                    <span class="help-block">Show emotes from the chat flying up on the screen</span>
+                </div>
+            </div>
+            <!-- Gif alerts -->
+            <div class="box box-solid">
+                <div class="box-header with-border">
+                    <label class="switch" data-toggle="tooltip" title="Module toggle">
+                        <input type="checkbox" class="trigger-update" id="overlayEnableGifAlerts" checked="">
+                        <span class="slider round"></span>
+                    </label>
+                    <h3 class="box-title">Gif Alerts</h3>
+                    <span class="help-block">Show gif alerts for several events on the screen.</span>
+                </div>
+                <!-- Box content -->
+                <div class="box-body">
+                    <div class="form-group">
+                        <label for="overlayAudioHookVolume">Gif Alerts Audio Volume</label>
+                        <input type="number" class="form-control trigger-update" id="overlayGifAlertVolume" placeholder="0.8"
+                               value="0.8" min="0.0"
+                               step=".05" max="1.0"/>
+                        <span class="help-block">Sets the volume of Audio Alerts where 1.0 full volume and 0.0 is silent.</span>
+                    </div>
+                </div>
+            </div>
+            <!-- Video clips -->
+            <div class="box box-solid">
+                <div class="box-header with-border">
+                    <label class="switch" data-toggle="tooltip" title="Module toggle">
+                        <input type="checkbox" class="trigger-update" id="overlayEnableVideoClips" checked="">
+                        <span class="slider round"></span>
+                    </label>
+                    <h3 class="box-title">Video Clip Overlay</h3>
+                    <span class="help-block">Enables processing video clips triggered from Cockpit.</span>
+                </div>
+                <!-- Box content -->
+                <div class="box-body">
+                    <div class="form-group">
+                        <label for="overlayVideoClipVolume">Video Clip Volume</label>
+                        <input type="number" class="form-control trigger-update" id="overlayVideoClipVolume" placeholder="0.8"
+                               value="0.8" min="0.0"
+                               step=".05" max="1.0"/>
+                        <span class="help-block">Sets the volume of video clips where 1.0 full volume and 0.0 is silent.</span>
+                    </div>
+                </div>
+            </div>
+            <!-- Debug Information -->
+            <div class="box box-solid">
+                <div class="box-header">
+                    <label class="switch" data-toggle="tooltip" title="Module toggle">
+                        <input type="checkbox" class="trigger-update" id="overlayEnableDebug">
+                        <span class="slider round"></span>
+                    </label>
+                    <h3 class="box-title">Show Debug Information</h3>
+                    <span class="help-block">Show debug information on screen.</span>
+                </div>
+            </div>
+            <!-- Output URL -->
+            <div class="box box-solid">
+                <div class="box-header">
+                    <h3 class="box-title">Overlay URL</h3>
+                    <span class="help-block">Use this URL and add it to your browser source in your stream software.
+                    Don't show or send it to anyone. Click into the box to make the contents visible.</span>
+                </div>
+                <div class="box-body">
+                    <div class="form-group">
+                        <label>Overlay URL</label>
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="overlayUrl" readonly=""/>
+                            <span class="input-group-btn">
+                                <button type="button" class="btn btn-primary btn-flat" id="overlayCopyButton"
+                                        data-toggle="tooltip" title="Copy the Overlay url" disabled="">Copy</button>
+                        </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </section>
+
+    <!-- overlay -->
+    <script src="/panel/js/pages/overlay/overlay.js"></script>
+</main>


### PR DESCRIPTION
Hi again, I had another thing on my list regarding the stream overlay and because the first user on Discord already asked I've noticed, that I moved it aside to reduce the PR size.
I accidentally found the Stream Overlay functionality when I was clicking through the settings. It's a bit hidden in on Audio Hooks page and deserves to be much more prominent! So I made a page to configure the enabled features and added it to the menu.

I've made the following changes:
- `resources/web/panel/index.html`: Added Stream Overlay page to the menu
- `resources/web/panel/[js|pages]/overlay/overlay.[js|html]`: Files to configure the overlay
- `resources/web/panel/js/utils/helpers.js`: Added a method to debounce input (used to avoid many writing requests to the database). Taken fron [freecodecamp.org](https://www.freecodecamp.org/news/javascript-debounce-example/)