### PR TITLE
Fix bug where isPlaying did not get reset on failure

### DIFF
--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -329,6 +329,7 @@ $(function () {
 
             if (audioFile.length === 0) {
                 printDebug('Failed to find audio file.', true);
+                isPlaying = false;
                 return;
             }
 


### PR DESCRIPTION
isPlaying doesn't reset when it fails to load an audio file for whatever reason. If this happens no other alerts will play.