### PR TITLE
Fixed getUser for discord to resolve mentions as well

### DIFF
--- a/source/tv/phantombot/discord/util/DiscordUtil.java
+++ b/source/tv/phantombot/discord/util/DiscordUtil.java
@@ -787,7 +787,7 @@ public class DiscordUtil {
             com.gmt2001.Console.debug.println(members.count().block());
         }
 
-        Flux<Member> filteredMembers = members.filter(user -> user.getDisplayName().equalsIgnoreCase(userName) || user.getUsername().equalsIgnoreCase(userName) || user.getMention().equalsIgnoreCase(userName) || user.getNicknameMention().equalsIgnoreCase(userName));
+        Flux<Member> filteredMembers = members.filter(user -> user.getDisplayName().equalsIgnoreCase(userName) || user.getUsername().equalsIgnoreCase(userName) || user.getMention().equalsIgnoreCase(userName) || user.getNicknameMention().equalsIgnoreCase(userName) || user.getId().asString().equalsIgnoreCase(userName));
 
         if (PhantomBot.getEnableDebugging()) {
             com.gmt2001.Console.debug.println(filteredMembers.count().block());


### PR DESCRIPTION
when doing @user then using (touser) in a discord tag it would display the users ID instead of mentioning them as it should. This simply adds the id to the checks to return the proper user if available.

Here is before and after results:
![image](https://user-images.githubusercontent.com/4360314/211177075-96090dcd-91ed-4a09-98a2-4df3c3a350bb.png)
Command:
`(@sender) slaps (touser) around a bit with a large trout`