### PR TITLE
Switch from gosu to setpriv in docker-entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,45 +74,9 @@ ARG DATADIR=${BASEDIR}_data
 
 USER root
 
-ENV GOSU_VERSION 1.14
-
-RUN set -eux; \
-# save list of currently installed packages for later so we can clean up
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends ca-certificates wget; \
-	if ! command -v gpg; then \
-		apt-get install -y --no-install-recommends gnupg2 dirmngr; \
-	elif gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
-# "This package provides support for HKPS keyservers." (GnuPG 1.x only)
-		apt-get install -y --no-install-recommends gnupg-curl; \
-	fi; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	command -v gpgconf && gpgconf --kill all || :; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
-# clean up fetch dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-	chmod +x /usr/local/bin/gosu; \
-# verify that the binary works
-	gosu --version; \
-	gosu nobody true
-
 RUN set -eux;  \
     apt-get update; \
-    apt-get install -y --no-install-recommends python3; \
+    apt-get install -y --no-install-recommends util-linux python3; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$(id -u)" = '0' -a ! -v ALLOW_ROOT ]; then
 	chown -R phantombot:phantombot /opt/PhantomBot_data;
 	find /opt/PhantomBot \! -type l \! -user phantombot -exec chown phantombot:phantombot '{}' +
 	find /opt/PhantomBot_data \! -type l \! -user phantombot -exec chown phantombot:phantombot '{}' +
-	exec gosu phantombot "$0" "$@"
+	exec setpriv --reuid phantombot --regid phantombot --init-groups "$0" "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
When gosu was developed, setpriv was not yet part of most distributions. It is now, as mentioned in the [gosu README](https://github.com/tianon/gosu#setpriv) and does [exactly the same](https://github.com/tianon/gosu/issues/59).

### Benefits of setpriv:
- Simpler Dockerfile
- One less download
- No need to manage a version number in Dockerfile

### Test:
I've built the docker image and run it, it starts up fine.

### Security migitations:
A trivy scan showed the following warnings that will not appear with the new version:

    usr/local/bin/gosu (gobinary)
    =============================
    Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 1, CRITICAL: 0)
   
    ┌────────────────────────────────┬────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────────────────────────┐
    │            Library             │ Vulnerability  │ Severity │         Installed Version          │           Fixed Version           │                           Title                            │
    ├────────────────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────┤
    │ github.com/opencontainers/runc │ CVE-2022-29162 │ HIGH     │ v1.0.1                             │ v1.1.2                            │ runc: incorrect handling of inheritable capabilities       │
    │                                │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-29162                 │
    │                                ├────────────────┼──────────┤                                    ├───────────────────────────────────┼────────────────────────────────────────────────────────────┤
    │                                │ CVE-2021-43784 │ MEDIUM   │                                    │ 1.1.0                             │ runc: integer overflow in netlink bytemsg length field     │
    │                                │                │          │                                    │                                   │ allows attacker to override...                             │
    │                                │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-43784                 │
    │                                ├────────────────┤          │                                    ├───────────────────────────────────┼────────────────────────────────────────────────────────────┤
    │                                │ CVE-2022-24769 │          │                                    │ v1.1.2                            │ moby: Default inheritable capabilities for linux container │
    │                                │                │          │                                    │                                   │ should be empty                                            │
    │                                │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-24769                 │
    ├────────────────────────────────┼────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────────────────────────┤
    │ golang.org/x/sys               │ CVE-2022-29526 │          │ v0.0.0-20210817142637-7d9622a276b7 │ 0.0.0-20220412211240-33da011f77ad │ golang: syscall: faccessat checks wrong group              │
    │                                │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-29526                 │
    └────────────────────────────────┴────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────────────────────────┘
