### PR TITLE
Prevent downloading openjdk again in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
     mkdir -p "${BUILDDIR}" "${DATADIR}"; \
     apt-get update; \
-    apt-get install -y --no-install-recommends ant; \
+    cd root; apt-get download ant; \
+    dpkg --ignore-depends=default-jre-headless --install ant_*.deb; \
     apt-get clean; \
     rm -rf \
         /var/lib/apt/lists/* \
         /tmp/* \
-        /var/tmp/*
+        /var/tmp/* \
+        /root/*.deb
 
 COPY . "${BUILDDIR}"
 


### PR DESCRIPTION
I've noticed that during the docker build, the installation of ant will download OpenJDK, which won't be used after that. This patch will prevent that download, saving about 25MB of traffic and hopefully speeding up the build a little bit, which might be relevant for cloud based builds.

The dockerfile gets a little more complex this way, and if ant was ever to add a dependency, it would fail.

Tested by building the Docker image and starting it.