### PR TITLE
Update Java libraries

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -133,6 +133,10 @@
         <ivy:checkdepsupdate/>
     </target>
 
+    <target depends="init-ivy" name="ivy-show-tree">
+        <ivy:dependencytree/>
+    </target>
+
     <target name="clearlib">
         <delete>
             <fileset dir="${reference}" includes="**/*.jar" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -38,21 +38,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <dependencies>
         <dependency org="com.discord4j" name="discord4j-core" rev="3.2.3"/>
         <dependency org="com.h2database" name="h2" rev="1.4.200"/>
-        <dependency org="com.rollbar" name="rollbar-java" rev="1.8.1"/>
-        <dependency org="commons-codec" name="commons-codec" rev="1.9"/>
-        <dependency org="commons-io" name="commons-io" rev="2.5"/>
-        <dependency org="io.netty" name="netty-codec-http" rev="4.1.79.Final"/>
-        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.79.Final" />
-        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.79.Final" />
-        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.0.16"/>
+        <dependency org="com.rollbar" name="rollbar-java" rev="1.9.0"/>
+        <dependency org="commons-codec" name="commons-codec" rev="1.15"/>
+        <dependency org="commons-io" name="commons-io" rev="2.11.0"/>
+        <dependency org="io.netty" name="netty-codec-http" rev="4.1.87.Final"/>
+        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.87.Final" />
+        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.87.Final" />
+        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.2"/>
         <dependency org="mysql" name="mysql-connector-java" rev="5.1.49"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
-        <dependency org="org.apache.commons" name="commons-text" rev="1.9"/>
-        <dependency org="org.json" name="json" rev="20200518"/>
+        <dependency org="org.apache.commons" name="commons-text" rev="1.10.0"/>
+        <dependency org="org.json" name="json" rev="20220924"/>
         <dependency org="org.mozilla" name="rhino" rev="1.7.14"/>
         <dependency org="org.slf4j" name="slf4j-nop" rev="1.7.25"/>
         <dependency org="com.twitter" name="twitter-api-java-sdk" rev="2.0.2" />
-        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.39.4.1"/>
+        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.40.1.0"/>
         <dependency org="com.vdurmont" name="emoji-java" rev="5.1.1" />
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
Some updates for Java libraries. Only non-major updates where the libraries are backwards compatible.

### Not updated
- H2 Database (would definitely break)
- MySQL connector (Major version, not sure about compability)
- SLF4J (Major version, not sure about compability)

### Test
I've built the docker image and run it, it starts up fine. Jumps in major versions would probably need more testing.

### Migitated security issues
A trivy scan showed the following warnings that will not appear with the new version:

    ┌──────────────────────────────────────────────────────────────┬─────────────────────┬──────────┬───────────────────┬────────────────────────────┬─────────────────────────────────────────────────────────────┐
    │                           Library                            │    Vulnerability    │ Severity │ Installed Version │       Fixed Version        │                            Title                            │
    │ commons-io:commons-io (commons-io-2.5.jar)                   │ CVE-2021-29425      │ MEDIUM   │ 2.5               │ 2.7                        │ apache-commons-io: Limited path traversal in Apache Commons │
    │                                                              │                     │          │                   │                            │ IO 2.2 to 2.6                                               │
    │                                                              │                     │          │                   │                            │ https://avd.aquasec.com/nvd/cve-2021-29425                  │
    ├──────────────────────────────────────────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────────┼─────────────────────────────────────────────────────────────┤
    │ io.netty:netty-codec-http                                    │ CVE-2022-41915      │          │ 4.1.79.Final      │ 4.1.86                     │ Netty project is an event-driven asynchronous network       │
    │ (netty-codec-http-4.1.79.Final.jar)                          │                     │          │                   │                            │ application fram ...                                        │
    │                                                              │                     │          │                   │                            │ https://avd.aquasec.com/nvd/cve-2022-41915                  │
    ├──────────────────────────────────────────────────────────────┼─────────────────────┤          ├───────────────────┼────────────────────────────┼─────────────────────────────────────────────────────────────┤
    │ io.projectreactor.netty:reactor-netty-http                   │ CVE-2022-31684      │          │ 1.0.22            │ 1.0.24                     │ reactor-netty-http: Log request headers in some cases of    │
    │ (reactor-netty-http-1.0.22.jar)                              │                     │          │                   │                            │ invalid HTTP requests                                       │
    │                                                              │                     │          │                   │                            │ https://avd.aquasec.com/nvd/cve-2022-31684                  │
    ├──────────────────────────────────────────────────────────────┼─────────────────────┼──────────┼───────────────────┼────────────────────────────┼─────────────────────────────────────────────────────────────┤
    │ org.apache.commons:commons-text (commons-text-1.9.jar)       │ CVE-2022-42889      │ CRITICAL │ 1.9               │ 1.10.0                     │ apache-commons-text: variable interpolation RCE             │
    │                                                              │                     │          │                   │                            │ https://avd.aquasec.com/nvd/cve-2022-42889                  │
	└──────────────────────────────────────────────────────────────┴─────────────────────┴──────────┴───────────────────┴────────────────────────────┴─────────────────────────────────────────────────────────────┘