### PR TITLE
Move dependencies to own layers in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
 Dockerfile
 docker-compose.yml
+
+lib
+
+bin
+build
+dist
+out


### PR DESCRIPTION
This patch creates separate cache layers for the Docker build.
- Ivy dependencies are predownloaded before the rest of the code is added to the image, so they won't be downloaded again as long as the layer is cached
- The Java libraries are copied to the publish image from an extra folder, creating a new cached layer
- Downloading the Python dependencies is also copied to a point befor the rest of the build is added to the image

If the dependencies don't change, new code changes will now only create less than 18MB of new layers (used to be 63MB before).

I've tried multiple builds, changing either some source code or dependencies and they behaved as expectet. The resulting Docker image also starts up as usual.