### PR TITLE
Add git files and java runtimes to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 Dockerfile
 docker-compose.yml
+.git*
 
+resources/java-runtime*
 lib
 
 bin


### PR DESCRIPTION
The whole git history and java runtimes where unneccessarily copied to the build image.

This shrinks the build image from 1.3GB to 673MB and speeds up the build a bit.