### PR TITLE
Add vscode devcontainer and make build commands

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.1/containers/java/.devcontainer/base.Dockerfile
+
+# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
+ARG VARIANT="17-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
+
+# [Option] Install Maven
+ARG INSTALL_MAVEN="false"
+ARG MAVEN_VERSION=""
+# [Option] Install Gradle
+ARG INSTALL_GRADLE="false"
+ARG GRADLE_VERSION=""
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
+    && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends ant sqlite3
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.1/containers/java
+{
+    "name": "Java",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            // Update the VARIANT arg to pick a Java version: 11, 17
+            // Append -bullseye or -buster to pin to an OS version.
+            // Use the -bullseye variants on local arm64/Apple Silicon.
+            "VARIANT": "11",
+            // Options
+            "INSTALL_MAVEN": "false",
+            "INSTALL_GRADLE": "false",
+            "NODE_VERSION": "lts/*"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "java.jdt.ls.java.home": "/docker-java-home"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "vscjava.vscode-java-pack",
+                "alexcvzz.vscode-sqlite"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "java -version",
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+#!/usr/bin/make
+
+.PHONY: build run rebuild kill
+
+PROJECT_NAME = PhantomBot
+PROJECT_VERSION = custom
+BASEDIR = "./dist"
+BUILDDIR := "${PROJECT_NAME}-${PROJECT_VERSION}"
+RUNTIMEPATH := "${BUILDDIR}/java-runtime-linux/bin/java"
+LAUNCHPATH := "${BUILDDIR}/launch-service.sh"
+
+export LAUNCHPATH
+
+build:
+	echo "Building PhantomBot!" \
+	&& mkdir -p "${BASEDIR}" \
+	&& cd "${BASEDIR}" \
+	&& ant -noinput -buildfile ../build.xml -Disdocker=true ${ANT_ARGS} jar \
+	&& chmod u+x ${RUNTIMEPATH} \
+	&& chmod u+x ${LAUNCHPATH}
+
+run:
+	if [ -f ${JARPATH} ]; then \
+		${BASEDIR}/${LAUNCHPATH}; \
+	fi;
+
+rebuild: build run
+
+kill:
+	kill $$(ps aux | grep '[P]hantomBot.jar' | awk '{print $$2}')

--- a/development-resources/DEVSETUP.md
+++ b/development-resources/DEVSETUP.md
@@ -64,4 +64,18 @@ You can get Eclipse [here](https://www.eclipse.org/downloads/).
 10. Click **Browse** to select `build.xml` from destination folder. Also mark *Link to the buildfile in the file system*. Press **Finish**
   `./libraries` has been automatically imported to *Referenced Libraries*.
 
+## Visual Studio Code - Dev Container
+You can get Visual Studio Code [here](https://code.visualstudio.com/).
+Using Dev Containers also requires that you have Docker installed, full guide to getting started with Dev Containers is [here](https://code.visualstudio.com/docs/devcontainers/tutorial).
+
+1. Fork the [PhantomBot repository](https://github.com/PhantomBot/PhantomBot).
+2. Check out your fork and open it in Visual Studio Code.
+2. Run the `Dev Containers: Open Folder in Container...` command from the Command Palette (F1) or quick actions Status bar item.
+3. Wait for the container to download and configure.
+4. Once the container is running, open up a terminal.
+5. Use the command `make build` to build PhantomBot (builds into the folder 'dist/PhantomBot-custom').
+6. Use the command `make run` to start your newly built PhantomBot instance. You should be prompted to open up PhantomBot in a browser. If not, open a browser and enter the URL `https://localhost:25000/`.
+7. To stop PhantomBot, kill the process in the terminal with the keyboard command 'Ctrl+C'. If your instance of PhantomBot has crashed and is running as a zombie process, open a new terminal in the devcontainer and run the command `make kill`.
+8. If you need to quickly rebuild PhantomBot and start the process, the command `make rebuild` will build and run PhantomBot.
+
 DONE! Happy coding <3

--- a/development-resources/DEVSETUP.md
+++ b/development-resources/DEVSETUP.md
@@ -70,12 +70,12 @@ Using Dev Containers also requires that you have Docker installed, full guide to
 
 1. Fork the [PhantomBot repository](https://github.com/PhantomBot/PhantomBot).
 2. Check out your fork and open it in Visual Studio Code.
-2. Run the `Dev Containers: Open Folder in Container...` command from the Command Palette (F1) or quick actions Status bar item.
-3. Wait for the container to download and configure.
-4. Once the container is running, open up a terminal.
-5. Use the command `make build` to build PhantomBot (builds into the folder 'dist/PhantomBot-custom').
-6. Use the command `make run` to start your newly built PhantomBot instance. You should be prompted to open up PhantomBot in a browser. If not, open a browser and enter the URL `https://localhost:25000/`.
-7. To stop PhantomBot, kill the process in the terminal with the keyboard command 'Ctrl+C'. If your instance of PhantomBot has crashed and is running as a zombie process, open a new terminal in the devcontainer and run the command `make kill`.
-8. If you need to quickly rebuild PhantomBot and start the process, the command `make rebuild` will build and run PhantomBot.
+3. Run the `Dev Containers: Open Folder in Container...` command from the Command Palette (F1) or quick actions Status bar item.
+4. Wait for the container to download and configure.
+5. Once the container is running, open up a terminal.
+6. Use the command `make build` to build PhantomBot (builds into the folder 'dist/PhantomBot-custom').
+7. Use the command `make run` to start your newly built PhantomBot instance. You should be prompted to open up PhantomBot in a browser. If not, open a browser and enter the URL `https://localhost:25000/`.
+8. To stop PhantomBot, kill the process in the terminal with the keyboard command 'Ctrl+C'. If your instance of PhantomBot has crashed and is running as a zombie process, open a new terminal in the devcontainer and run the command `make kill`.
+9. If you need to quickly rebuild PhantomBot and start the process, the command `make rebuild` will build and run PhantomBot.
 
 DONE! Happy coding <3


### PR DESCRIPTION
I've added a devcontainer config for VSCode and a Makefile to allow those using VSCode to quickly build and run PhantomBot if they prefer to use Docker for their dev environments.