### PR TITLE
Allow encodeurl/encodeurlparam to handle newlines

### DIFF
--- a/javascript-source/core/transformers/misc.js
+++ b/javascript-source/core/transformers/misc.js
@@ -50,7 +50,7 @@
      * @cached
      */
     function encodeurl(args) {
-        if ((match = args.args.match(/^ (.*)$/))) {
+        if ((match = args.args.match(/^ (.*)$/m))) {
             return {
                 result: encodeURI(match[1]),
                 cache: true
@@ -65,7 +65,7 @@
      * @cached
      */
     function encodeurlparam(args) {
-        if ((match = args.args.match(/^ (.*)$/))) {
+        if ((match = args.args.match(/^ (.*)$/m))) {
             return {
                 result: encodeURIComponent(match[1]),
                 cache: true


### PR DESCRIPTION
Added m to allow user entered responses to contain newlines without failing to match.

(Should the same be done to the other transformers?  I don't know if there is any downside) 

See https://discord.com/channels/107910097937682432/247160900115628032

Tested:
User redemption text included a stray %0A (linefeed)
PB would display the full raw customapi unprocessed
With this change, it ran the customapi correctly and passed the %0A to the server to handle

First pull request, did I do the thing??