### PR TITLE
Adventure cleanup and fixes

### DIFF
--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -95,7 +95,7 @@
      * loadStoriesFromPrefix('adventuresystem.stories.custom');
      */
     function loadStoriesFromPrefix(prefix) {
-        for (let storyId; $.lang.exists(prefix + '.' + storyId + '.title'); storyId++) {
+        for (let storyId = 1; $.lang.exists(prefix + '.' + storyId + '.title'); storyId++) {
             let lines = [];
             for (let chapterId = 1; $.lang.exists(prefix + '.' + storyId + '.chapter.' + chapterId); chapterId++) {
                 lines.push($.lang.get(prefix + '.' + storyId + '.chapter.' + chapterId));
@@ -107,7 +107,7 @@
                 lines: lines
             });
 
-            $.consoleDebug($.lang.get('adventuresystem.loaded.prefix', storyId - 1, prefix));
+            $.consoleDebug($.lang.get('adventuresystem.loaded.prefix', storyId, prefix));
         }
     }
 

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -189,7 +189,6 @@
      * @function calculateResult
      */
     function calculateResult() {
-        $.consoleLn('Calculating Results now!');
         _currentAdventureLock.lock();
         try {
             for (let i in currentAdventure.users) {
@@ -202,10 +201,6 @@
         } finally {
             _currentAdventureLock.unlock();
         }
-
-        $.consoleLn('Results are:');
-        $.consoleLn('Winners: ' + adventureUsersListJoin(currentAdventure.users));
-        $.consoleLn('Loosers: ' + adventureUsersListJoin(currentAdventure.caught));
     }
 
     /**
@@ -244,7 +239,6 @@
         }
 
         setTimeout(function() {
-            $.consoleLn('Running Story now!');
             runStory();
         }, joinTime * 1e3);
 
@@ -353,8 +347,6 @@
             currentAdventure.story = story;
             currentAdventure.progress = 0;
             currentAdventure.gameState = 2;
-            $.consoleLn('Starting story: ' + currentAdventure.story.title);
-            $.consoleLn('Adventure state: ' + currentAdventure.gameState + ' with progress: ' + currentAdventure.progress);
         } finally {
             _currentAdventureLock.unlock();
         }
@@ -364,19 +356,14 @@
         timer = setInterval(function() {
             _currentAdventureLock.lock();
             try {
-                $.consoleLn('Story tick progress : ' + currentAdventure.progress + ' out of ' + currentAdventure.story.lines.length);
                 if (currentAdventure.progress < currentAdventure.story.lines.length) {
                     let line = replaceTags(currentAdventure.story.lines[currentAdventure.progress]);
                     if (line !== '') {
                         $.say(line.replace(/\(game\)/g, $.twitchcache.getGameTitle() + ''));
                     }
-
-                    $.consoleLn('Story tick said line: ' + line);
                 } else {
-                    $.consoleLn('Story tick finishing story!');
                     endHeist();
                     clearInterval(timer);
-                    $.consoleLn('Story tick finished story!');
                 }
 
                 currentAdventure.progress++;
@@ -397,16 +384,12 @@
 
         _currentAdventureLock.lock();
         try {
-            $.consoleLn('Story End - Calculating survivor payouts!');
             for (let i in currentAdventure.survivors) {
                 let pay = (currentAdventure.survivors[i].bet * (gainPercent / 100));
-                $.consoleLn('Story End - Calculating survivor payouts ( ' + pay + ' ' + $.pointNameMultiple + ') for' + currentAdventure.survivors[i].username);
                 $.inidb.incr('adventurePayouts', currentAdventure.survivors[i].username, pay);
                 $.inidb.incr('adventurePayoutsTEMP', currentAdventure.survivors[i].username, pay);
                 $.inidb.incr('points', currentAdventure.survivors[i].username, currentAdventure.survivors[i].bet + pay);
             }
-
-            $.consoleLn('Story End - Payouts  complete!');
 
             for (let i in currentAdventure.survivors) {
                 let username = currentAdventure.survivors[i].username;
@@ -414,33 +397,23 @@
                 temp.push($.viewer.getByLogin(username).name() + ' (+' + $.getPointsString($.inidb.get('adventurePayoutsTEMP', currentAdventure.survivors[i].username)) + ')');
             }
 
-            $.consoleLn('Story End - Ending line is: ' + temp.join(', '));
-
             if (temp.length === 0) {
-                $.consoleLn('Story End - using no win end line');
                 $.say($.lang.get('adventuresystem.completed.no.win'));
             } else if (((maxlength + 14) + $.channelName.length) > 512) {
-                $.consoleLn('Story End - using shortened end line');
                 $.say($.lang.get('adventuresystem.completed.win.total', currentAdventure.survivors.length, currentAdventure.caught.length)); //in case too many people enter.
             } else {
-                $.consoleLn('Story End - using full end line');
                 $.say($.lang.get('adventuresystem.completed', temp.join(', ')));
             }
         } finally {
             _currentAdventureLock.unlock();
         }
 
-        $.consoleLn('Story End - resetting adventure!');
         clearCurrentAdventure();
-        $.consoleLn('Story End - Preparing cooldown!');
         $.coolDown.set('adventure', true, coolDown, undefined);
-        $.consoleLn('Story End - add cooldown message? : ' + coolDownAnnounce);
         if (coolDownAnnounce) {
             setTimeout(function() {
-                $.consoleLn('Story Cooldown - Sending cooldown timeout message!');
                 $.say($.lang.get('adventuresystem.reset', $.pointNameMultiple));
             }, coolDown * 1000);
-            $.consoleLn('Story End - Cooldown message set!');
         }
     }
 

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -56,10 +56,7 @@
      * @function loadStories
      */
     function loadStories() {
-        currentAdventure.users = [];
-        currentAdventure.survivors = [];
-        currentAdventure.caught = [];
-        currentAdventure.gameState = 0;
+        clearCurrentAdventure();
 
         stories = [];
 
@@ -93,13 +90,9 @@
      * loadStoriesFromPrefix('adventuresystem.stories.custom');
      */
     function loadStoriesFromPrefix(prefix) {
-        let storyId = 1,
-            chapterId,
-            lines;
-
-        for (storyId; $.lang.exists(prefix + '.' + storyId + '.title'); storyId++) {
-            lines = [];
-            for (chapterId = 1; $.lang.exists(prefix + '.' + storyId + '.chapter.' + chapterId); chapterId++) {
+        for (let storyId; $.lang.exists(prefix + '.' + storyId + '.title'); storyId++) {
+            let lines = [];
+            for (let chapterId = 1; $.lang.exists(prefix + '.' + storyId + '.chapter.' + chapterId); chapterId++) {
                 lines.push($.lang.get(prefix + '.' + storyId + '.chapter.' + chapterId));
             }
 
@@ -108,9 +101,9 @@
                 title: $.lang.get(prefix + '.' + storyId + '.title'),
                 lines: lines
             });
-        }
 
-        $.consoleDebug($.lang.get('adventuresystem.loaded.prefix', storyId - 1, prefix));
+            $.consoleDebug($.lang.get('adventuresystem.loaded.prefix', storyId - 1, prefix));
+        }
     }
 
     /**

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -393,7 +393,7 @@
 
             for (let i in currentAdventure.survivors) {
                 let username = currentAdventure.survivors[i].username;
-                maxlength += username.length();
+                maxlength += username.length;
                 temp.push($.viewer.getByLogin(username).name() + ' (+' + $.getPointsString($.inidb.get('adventurePayoutsTEMP', currentAdventure.survivors[i].username)) + ')');
             }
 

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -189,6 +189,7 @@
      * @function calculateResult
      */
     function calculateResult() {
+        $.consoleLn('Calculating Results now!');
         _currentAdventureLock.lock();
         try {
             for (let i in currentAdventure.users) {
@@ -201,6 +202,10 @@
         } finally {
             _currentAdventureLock.unlock();
         }
+
+        $.consoleLn('Results are:');
+        $.consoleLn('Winners: ' + adventureUsersListJoin(currentAdventure.users));
+        $.consoleLn('Loosers: ' + adventureUsersListJoin(currentAdventure.caught));
     }
 
     /**
@@ -239,6 +244,7 @@
         }
 
         setTimeout(function() {
+            $.consoleLn('Running Story now!');
             runStory();
         }, joinTime * 1e3);
 
@@ -347,6 +353,8 @@
             currentAdventure.story = story;
             currentAdventure.progress = 0;
             currentAdventure.gameState = 2;
+            $.consoleLn('Starting story: ' + currentAdventure.story.title);
+            $.consoleLn('Adventure state: ' + currentAdventure.gameState + ' with progress: ' + currentAdventure.progress);
         } finally {
             _currentAdventureLock.unlock();
         }
@@ -356,14 +364,19 @@
         timer = setInterval(function() {
             _currentAdventureLock.lock();
             try {
+                $.consoleLn('Story tick progress : ' + currentAdventure.progress + ' out of ' + currentAdventure.story.lines.length);
                 if (currentAdventure.progress < currentAdventure.story.lines.length) {
                     let line = replaceTags(currentAdventure.story.lines[currentAdventure.progress]);
                     if (line !== '') {
                         $.say(line.replace(/\(game\)/g, $.twitchcache.getGameTitle() + ''));
                     }
+
+                    $.consoleLn('Story tick said line: ' + line);
                 } else {
+                    $.consoleLn('Story tick finishing story!');
                     endHeist();
                     clearInterval(timer);
+                    $.consoleLn('Story tick finished story!');
                 }
 
                 currentAdventure.progress++;
@@ -384,12 +397,16 @@
 
         _currentAdventureLock.lock();
         try {
+            $.consoleLn('Story End - Calculating survivor payouts!');
             for (let i in currentAdventure.survivors) {
                 let pay = (currentAdventure.survivors[i].bet * (gainPercent / 100));
+                $.consoleLn('Story End - Calculating survivor payouts ( ' + pay + ' ' + $.pointNameMultiple + ') for' + currentAdventure.survivors[i].username);
                 $.inidb.incr('adventurePayouts', currentAdventure.survivors[i].username, pay);
                 $.inidb.incr('adventurePayoutsTEMP', currentAdventure.survivors[i].username, pay);
                 $.inidb.incr('points', currentAdventure.survivors[i].username, currentAdventure.survivors[i].bet + pay);
             }
+
+            $.consoleLn('Story End - Payouts  complete!');
 
             for (let i in currentAdventure.survivors) {
                 let username = currentAdventure.survivors[i].username;
@@ -397,23 +414,33 @@
                 temp.push($.viewer.getByLogin(username).name() + ' (+' + $.getPointsString($.inidb.get('adventurePayoutsTEMP', currentAdventure.survivors[i].username)) + ')');
             }
 
+            $.consoleLn('Story End - Ending line is: ' + temp.join(', '));
+
             if (temp.length === 0) {
+                $.consoleLn('Story End - using no win end line');
                 $.say($.lang.get('adventuresystem.completed.no.win'));
             } else if (((maxlength + 14) + $.channelName.length) > 512) {
+                $.consoleLn('Story End - using shortened end line');
                 $.say($.lang.get('adventuresystem.completed.win.total', currentAdventure.survivors.length, currentAdventure.caught.length)); //in case too many people enter.
             } else {
+                $.consoleLn('Story End - using full end line');
                 $.say($.lang.get('adventuresystem.completed', temp.join(', ')));
             }
         } finally {
             _currentAdventureLock.unlock();
         }
 
+        $.consoleLn('Story End - resetting adventure!');
         clearCurrentAdventure();
+        $.consoleLn('Story End - Preparing cooldown!');
         $.coolDown.set('adventure', true, coolDown, undefined);
+        $.consoleLn('Story End - add cooldown message? : ' + coolDownAnnounce);
         if (coolDownAnnounce) {
             setTimeout(function() {
+                $.consoleLn('Story Cooldown - Sending cooldown timeout message!');
                 $.say($.lang.get('adventuresystem.reset', $.pointNameMultiple));
             }, coolDown * 1000);
+            $.consoleLn('Story End - Cooldown message set!');
         }
     }
 

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -336,9 +336,13 @@
             }
         }
 
-        do {
+        if (lastStory !== undefined && lastStory.title !== undefined) {
+            do {
+                story = $.randElement(temp);
+            } while (story.title === lastStory.title);
+        } else {
             story = $.randElement(temp);
-        } while (story.title === lastStory.title && stories.length !== 1);
+        }
 
         lastStory = story;
 
@@ -352,6 +356,7 @@
         }
 
         $.say($.lang.get('adventuresystem.runstory', story.title, currentAdventure.users.length));
+        calculateResult();
 
         timer = setInterval(function() {
             _currentAdventureLock.lock();
@@ -363,7 +368,6 @@
                     }
                 } else {
                     endHeist();
-                    clearInterval(timer);
                 }
 
                 currentAdventure.progress++;
@@ -379,8 +383,6 @@
     function endHeist() {
         let maxlength = 0,
             temp = [];
-
-        calculateResult();
 
         _currentAdventureLock.lock();
         try {
@@ -408,6 +410,7 @@
             _currentAdventureLock.unlock();
         }
 
+        clearInterval(timer);
         clearCurrentAdventure();
         $.coolDown.set('adventure', true, coolDown, undefined);
         if (coolDownAnnounce) {

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -318,15 +318,6 @@
         let temp = [],
             story;
 
-        _currentAdventureLock.lock();
-        try {
-            currentAdventure.gameState = 2;
-        } finally {
-            _currentAdventureLock.unlock();
-        }
-
-        calculateResult();
-
         let game = $.getGame($.channelName);
 
         for (let i in stories) {
@@ -355,6 +346,7 @@
         try {
             currentAdventure.story = story;
             currentAdventure.progress = 0;
+            currentAdventure.gameState = 2;
         } finally {
             _currentAdventureLock.unlock();
         }
@@ -387,6 +379,8 @@
     function endHeist() {
         let maxlength = 0,
             temp = [];
+
+        calculateResult();
 
         _currentAdventureLock.lock();
         try {

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -495,6 +495,7 @@
              */
             if (action.equalsIgnoreCase('top5')) {
                 top5();
+                return;
             }
 
             /**

--- a/javascript-source/lang/english/games/games-adventureSystem.js
+++ b/javascript-source/lang/english/games/games-adventureSystem.js
@@ -26,7 +26,7 @@ $.lang.register('adventuresystem.join.needpoints', 'You can not join with $1, yo
 $.lang.register('adventuresystem.join.notpossible', 'You can not join now.');
 $.lang.register('adventuresystem.join.success', 'You have joined the adventure with $1!');
 $.lang.register('adventuresystem.loaded', 'Loaded adventure stories (found $1).');
-$.lang.register('adventuresystem.loaded.prefix', 'Loaded $1 adventure stories from $2.');
+$.lang.register('adventuresystem.loaded.prefix', 'Loaded adventure story with id $1 from prefix $2.');
 $.lang.register('adventuresystem.payoutwhisper', 'Adventure completed, $1 + $2 has been added to your balance.');
 $.lang.register('adventuresystem.runstory', 'Starting adventure "$1" with $2 player(s).');
 $.lang.register('adventuresystem.set.success', 'Set $1 to $2.');


### PR DESCRIPTION
Changes:
- use let instead of var
- consistent styling 
- acquire locks on missing spots
- keep track of most things inside the currentAdventure object
- fix adventure never ending when it has survivors
- fix the same adventure occurring back to back

Working properly now even if there are survivors
![image](https://user-images.githubusercontent.com/572591/236005324-240c3984-dd66-46b5-b5cc-a5fff9467967.png)
![image](https://user-images.githubusercontent.com/572591/236005360-8391288a-39e6-4507-a51f-14294cf7ee0b.png)
