### PR TITLE
Raffle fixes

### DIFF
--- a/javascript-source/lang/english/systems/systems-raffleSystem.js
+++ b/javascript-source/lang/english/systems/systems-raffleSystem.js
@@ -37,9 +37,9 @@ $.lang.register('rafflesystem.usage', 'Usage: !raffle [open / close / draw / res
 $.lang.register('rafflesystem.draw.usage', 'Usage: !raffle draw [amount (default = 1)] [prize points (default = 0)]');
 $.lang.register('rafflesystem.results', 'A raffle is still opened! Keyword: $1 - Total entries: $2');
 $.lang.register('rafflesystem.fee', ' - Entry fee: $1');
-$.lang.register('rafflesystem.subbonus.usage', 'Usage: !raffle subscriberbonus [1-10]');
+$.lang.register('rafflesystem.subbonus.usage', 'Usage: !raffle subscriberbonus [0-10]');
 $.lang.register('rafflesystem.subbonus.set', 'Subscriber bonus luck set to $1!');
-$.lang.register('rafflesystem.regbonus.usage', 'Usage: !raffle regularbonus [1-10]');
+$.lang.register('rafflesystem.regbonus.usage', 'Usage: !raffle regularbonus [0-10]');
 $.lang.register('rafflesystem.regbonus.set', 'Regular bonus luck set to $1!');
 $.lang.register('rafflesystem.whisper.winner.toggle', 'Raffle winners will $1 be whispered.');
 $.lang.register('rafflesystem.raffle.repick.toggle1', 'Raffle winners will no longer be repicked.');

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -631,7 +631,7 @@
              * @commandpath raffle subscriberbonus [0-10] - Sets the bonus luck for subscribers.
              */
             if (action.equalsIgnoreCase('subscriberbonus')) {
-                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 0) {
+                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 0 || parseInt(subAction) > 10) {
                     $.say($.whisperPrefix(sender) + $.lang.get('rafflesystem.subbonus.usage'));
                     return;
                 }
@@ -646,7 +646,7 @@
              * @commandpath raffle regularbonus [0-10] - Sets the bonus luck for regulars.
              */
             if (action.equalsIgnoreCase('regularbonus')) {
-                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 0) {
+                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 0 || parseInt(subAction) > 10) {
                     $.say($.whisperPrefix(sender) + $.lang.get('rafflesystem.regbonus.usage'));
                     return;
                 }

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -124,7 +124,7 @@
             tempKeyword = args[i].toLowerCase();
             i++;
 
-            if (keyword.startsWith('!')) {
+            if (tempKeyword.startsWith('!')) {
                 tempKeyword = ('!' + tempKeyword.match(/(!+)(.+)/)[2]);
             }
 

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -628,10 +628,10 @@
             }
 
             /**
-             * @commandpath raffle subscriberbonus [1-10] - Sets the bonus luck for subscribers.
+             * @commandpath raffle subscriberbonus [0-10] - Sets the bonus luck for subscribers.
              */
             if (action.equalsIgnoreCase('subscriberbonus')) {
-                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 1) {
+                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 0) {
                     $.say($.whisperPrefix(sender) + $.lang.get('rafflesystem.subbonus.usage'));
                     return;
                 }
@@ -643,10 +643,10 @@
             }
 
             /**
-             * @commandpath raffle regularbonus [1-10] - Sets the bonus luck for regulars.
+             * @commandpath raffle regularbonus [0-10] - Sets the bonus luck for regulars.
              */
             if (action.equalsIgnoreCase('regularbonus')) {
-                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 1) {
+                if (subAction === undefined || isNaN(parseInt(subAction)) || parseInt(subAction) < 0) {
                     $.say($.whisperPrefix(sender) + $.lang.get('rafflesystem.regbonus.usage'));
                     return;
                 }

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -280,7 +280,7 @@
      */
     function close(username) {
         /* Clear the timer if there is one active. */
-        clearInterval(timeout);
+        clearTimeout(timeout);
         clearInterval(interval);
         clearInterval(saveStateInterval);
 
@@ -368,6 +368,7 @@
         if (!openDraw) {
             close(undefined);
         }
+
         saveState();
     }
 
@@ -507,7 +508,7 @@
      */
     function clear() {
         /* Clear the timer if there is one active. */
-        clearInterval(timeout);
+        clearTimeout(timeout);
         clearInterval(interval);
         clearInterval(saveStateInterval);
         keyword = '';

--- a/javascript-source/systems/raffleSystem.js
+++ b/javascript-source/systems/raffleSystem.js
@@ -326,9 +326,7 @@
                 let remainingEntries = JSON.parse(JSON.stringify(entries));
                 while (newWinners.length < amount && remainingEntries.length > 0) {
                     let candidate = $.randElement(remainingEntries);
-
                     remainingEntries.splice(remainingEntries.indexOf(candidate), 1);
-
                     newWinners.push(candidate);
                 }
             }
@@ -479,20 +477,20 @@
         }
 
         /* Push the user into the array */
+        let entryAmount = 1;
+        if (subscriberBonus > 0 && $.checkUserPermission(username, tags, $.PERMISSION.Sub)) {
+            entryAmount += subscriberBonus;
+        } else if (regularBonus > 0 && $.checkUserPermission(username, tags, $.PERMISSION.Regular)) {
+            entryAmount += regularBonus;
+        }
+
         _entriesLock.lock();
         try {
-            entered[username] = true;
-            entries.push(username);
-            let i;
-            if (subscriberBonus > 0 && $.checkUserPermission(username, tags, $.PERMISSION.Sub)) {
-                for (i = 0; i < subscriberBonus; i++) {
-                    entries.push(username);
-                }
-            } else if (regularBonus > 0 && $.checkUserPermission(username, tags, $.PERMISSION.Regular)) {
-                for (i = 0; i < regularBonus; i++) {
-                    entries.push(username);
-                }
+            for (let i = 0; i < entryAmount; i++) {
+                entries.push(username);
             }
+
+            entered[username] = true;
         } finally {
             _entriesLock.unlock();
         }

--- a/resources/web/panel/js/pages/giveaways/raffle.js
+++ b/resources/web/panel/js/pages/giveaways/raffle.js
@@ -150,8 +150,8 @@ $(function () {
                 case helpers.handleInputString(keyword):
                 case helpers.handleInputNumber(cost, 0):
                 case helpers.handleInputNumber(timer, 0):
-                case helpers.handleInputNumber(regLuck, 1, 10):
-                case helpers.handleInputNumber(subLuck, 1, 10):
+                case helpers.handleInputNumber(regLuck, 0, 10):
+                case helpers.handleInputNumber(subLuck, 0, 10):
                     break;
                 default:
                     socket.updateDBValues('update_raffle_settings', {

--- a/resources/web/panel/pages/giveaways/raffle.html
+++ b/resources/web/panel/pages/giveaways/raffle.html
@@ -123,15 +123,15 @@
 
                             <!-- Regular luck -->
                             <div class="form-group">
-                                <label for="raffle-reg">Regular Luck</label>
-                                <input type="number" min="1" max="10" class="form-control" id="raffle-reg" value="1"
+                                <label for="raffle-reg">Regular Luck (Bonus Entries)</label>
+                                <input type="number" min="0" max="10" class="form-control" id="raffle-reg" value="1"
                                     data-toggle="tooltip" title="How many more times a regular is likely to win."/>
                             </div>
 
                             <!-- Subscriber luck -->
                             <div class="form-group">
-                                <label for="raffle-sub">Subscriber Luck</label>
-                                <input type="number" min="1" max="10" class="form-control" id="raffle-sub" value="1"
+                                <label for="raffle-sub">Subscriber Luck (Bonus Entries)</label>
+                                <input type="number" min="0" max="10" class="form-control" id="raffle-sub" value="1"
                                     data-toggle="tooltip" title="How many more times a subscriber is likely to win."/>
                             </div>
 


### PR DESCRIPTION
Included fixes:
- Clear timeouts correctly with `clearTimeout` instead of using `clearInterval`
- Clarify what **Subscriber Luck** and **Regular Luck** actually means (according to the help tooltip)
- Allow having subscriber and regular luck to be equal to the luck of a normal user by entering `0`
- Limit the `!raffle subscriberbonus` and `!raffle regularbonus` to a maximum of 10 as described everywhere
- Fix possible NullPointerException if consecutive raffles are opened that switch between having and not having an exclamation mark before the actual keyword `!keyword` or `keyword`
`[05-05-2023 @ 16:11:04.746 GMT] [init.js:481] Error with Event Handler [command] Script [./systems/raffleSystem.js] Stacktrace [open()@raffleSystem.js:131 > raffleSystem.js:567 > init.js:473 > init.js:728] Exception [TypeError: Cannot read property "2" from null]`
