### PR TITLE
Added option to warn the chat when raiding to an offline channel

### DIFF
--- a/javascript-source/handlers/raidHandler.js
+++ b/javascript-source/handlers/raidHandler.js
@@ -23,7 +23,7 @@
             raidReward = $.getSetIniDbNumber('raidSettings', 'raidReward', 0),
             raidOutMessage = $.getSetIniDbString('raidSettings', 'raidOutMessage', 'We are going to raid (username)! Go to their channel (url) now!'),
             raidOutSpam = $.getSetIniDbNumber('raidSettings', 'raidOutSpam', 1),
-            raidOutOfflineMessage = $.getSetIniDbString('raidSettings', 'raidOutOfflineMessage', 'Note: That channel is offline!  Use /unraid if you wish to cancel . . .');
+            raidOutOfflineMessage = $.getSetIniDbString('raidSettings', 'raidOutOfflineMessage', null);
 
     /*
      * @function Reloads the raid variables from the panel.

--- a/javascript-source/handlers/raidHandler.js
+++ b/javascript-source/handlers/raidHandler.js
@@ -22,7 +22,8 @@
             raidIncMinViewers = $.getSetIniDbNumber('raidSettings', 'raidMinViewers', 0),
             raidReward = $.getSetIniDbNumber('raidSettings', 'raidReward', 0),
             raidOutMessage = $.getSetIniDbString('raidSettings', 'raidOutMessage', 'We are going to raid (username)! Go to their channel (url) now!'),
-            raidOutSpam = $.getSetIniDbNumber('raidSettings', 'raidOutSpam', 1);
+            raidOutSpam = $.getSetIniDbNumber('raidSettings', 'raidOutSpam', 1),
+            raidOutOfflineMessage = $.getSetIniDbString('raidSettings', 'raidOutOfflineMessage', 'Note: That channel is offline!  Use /unraid if you wish to cancel . . .');
 
     /*
      * @function Reloads the raid variables from the panel.
@@ -35,6 +36,7 @@
         raidReward = $.getIniDbNumber('raidSettings', 'raidReward');
         raidOutMessage = $.getIniDbString('raidSettings', 'raidOutMessage');
         raidOutSpam = $.getIniDbNumber('raidSettings', 'raidOutSpam');
+        raidOutOfflineMessage = $.getIniDbNumber('raidSettings', 'raidOutOfflineMessage');
     }
 
     /*
@@ -124,6 +126,10 @@
      */
     function handleOutRaid(username) {
         var message = raidOutMessage;
+        var offlinemsg = raidOutOfflineMessage;
+
+        // Use the .raid command.
+        $.say('.raid ' + username);
 
         // Replace tags.
         if (message.match(/\(username\)/)) {
@@ -139,9 +145,11 @@
             $.say(message);
         }
 
-        // Use the .raid command.
-        $.say('.raid ' + username);
-        // Increase out going raids.
+        if(!$.isOnline(username)){
+            $.say(offlinemsg);
+        }
+
+        // Increment outgoing raids count for this target channel.
         saveOutRaidForUsername(username + '', $.getViewers($.channelName) + '');
     }
 
@@ -322,6 +330,21 @@
             }
 
             /*
+             * @commandpath raid setoutgoingofflinemessage [message] - Sets the outgoing warning message for when you raid someone who is offline
+             */
+            if (action.equalsIgnoreCase('setoutgoingofflinemessage')) {
+                if (subAction === undefined) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('raidhandler.out.messageoffline.usage'));
+                    return;
+                }
+
+                raidOutOfflineMessage = args.slice(1).join(' ');
+                $.setIniDbString('raidSettings', 'raidOutOfflineMessage', raidOutOfflineMessage);
+                $.say($.whisperPrefix(sender) + $.lang.get('raidhandler.out.messageoffline.set'));
+                return;
+            }
+
+            /*
              * @commandpath raid setoutgoingmessagespam [amount] - Sets the amount of times that the outgoing raid message is sent in chat. Maximum is 10 times.
              */
             if (action.equalsIgnoreCase('setoutgoingmessagespam')) {
@@ -378,6 +401,7 @@
         $.registerChatSubcommand('./handlers/raidHandler.js', 'raid', 'setnewincomingmessage', $.PERMISSION.Admin);
         $.registerChatSubcommand('./handlers/raidHandler.js', 'raid', 'setoutgoingmessage', $.PERMISSION.Admin);
         $.registerChatSubcommand('./handlers/raidHandler.js', 'raid', 'setoutgoingmessagespam', $.PERMISSION.Admin);
+        $.registerChatSubcommand('./handlers/raidHandler.js', 'raid', 'setoutgoingofflinemessage', $.PERMISSION.Admin);
     });
 
     /* Export to API */

--- a/javascript-source/handlers/raidHandler.js
+++ b/javascript-source/handlers/raidHandler.js
@@ -36,7 +36,7 @@
         raidReward = $.getIniDbNumber('raidSettings', 'raidReward');
         raidOutMessage = $.getIniDbString('raidSettings', 'raidOutMessage');
         raidOutSpam = $.getIniDbNumber('raidSettings', 'raidOutSpam');
-        raidOutOfflineMessage = $.getIniDbNumber('raidSettings', 'raidOutOfflineMessage');
+        raidOutOfflineMessage = $.getIniDbString('raidSettings', 'raidOutOfflineMessage');
     }
 
     /*

--- a/javascript-source/lang/english/handlers/handlers-raidHandler.js
+++ b/javascript-source/lang/english/handlers/handlers-raidHandler.js
@@ -33,3 +33,5 @@ $.lang.register('raidhandler.spam.amount.set', 'Successfully updated the outgoin
 $.lang.register('raidhandler.lookup.usage', 'Usage: !raid lookup [username]');
 $.lang.register('raidhandler.lookup.user', '$1 has raided this channel a total of $2 time(s). Their last raid was on $3 with $4 viewers.');
 $.lang.register('raidhandler.lookup.user.404', '$1 has never raided this channel.');
+$.lang.register('raidhandler.out.messageoffline.usage', 'Usage: !raid setoutgoingofflinemessage [message]');
+$.lang.register('raidhandler.out.messageoffline.set', 'Successfully updated the outgoing raid offline warning message!');


### PR DESCRIPTION
You rarely want to raid to a channel that is not streaming.  The mobile app generally refuses to follow such a raid, leaving mobile users stuck on the raiding channel while everyone else goes nowhere good.  The web page will raid, and strand web twitch viewers in a dead chat.  

This is usually due to a typo or miscommunication.  PhantomBot can help avoid raid train breakdown!

I added a chat command to set what PB will say after the raiding message _if_ the recipient is currently not streaming.  You can then use /unraid and fix the situation before it is too late.

` !raid setoutgoingofflinemessage [message]`

If you never set one, behavior will be consistent (no offline warning).

I've been using this feature for a couple of months now and it works great for me.  It has saved some difficulty!  

```username: !raid lisabei
username used: /raid lisabei.
BotName: Raid now departing for lisabei!
BotName:  Custom Test Warning: That channel is currently offline! But I'm sure you know what you're doing.