### PR TITLE
Fix potential permission bugs

### DIFF
--- a/javascript-source/core/bootstrap/900updates.js
+++ b/javascript-source/core/bootstrap/900updates.js
@@ -724,6 +724,27 @@
         }
     });
 
+    addUpdate('3.8.4.0', 'installedv3.8.4.0', function() {
+        //Remove $.PERMISSION.None
+        let keys = $.inidb.GetKeysByLikeValues('preSubGroup', '', $.javaString('99'));
+        for (let key in keys) {
+            $.inidb.del('preSubGroup', key);
+        }
+
+        //Remove $.PERMISSION.Viewer and save some space since default of $.PERMISSION.Viewer will be set if no value could be found in the db
+        let keys2 = $.inidb.GetKeysByLikeValues('preSubGroup', '', $.javaString('7'));
+        for (let key in keys2) {
+            $.inidb.del('preSubGroup', key);
+        }
+
+        // Set any users with $.PERMISSION.NONE to $.PERMISSION.Viewer
+        let keys3 = $.inidb.GetKeysByLikeValues('group', '', $.javaString('99'));
+        for (let key in keys3) {
+            $.inidb.set('group', key, $.javaString('7'));
+        }
+
+    });
+
     // ------ Add updates above this line in execution order ------
 
     if ($.changed !== undefined && $.changed !== null && $.changed === true && !$.inidb.GetBoolean('updates', '', 'installedNewBot')) {

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -560,7 +560,9 @@
      * @param {Number} id
      */
     function setUserGroupById(username, id) {
-        $.setIniDbNumber('group', username.toLowerCase(), id);
+        if (id < PERMISSION.None) {
+            $.setIniDbNumber('group', username.toLowerCase(), id);
+        }
     }
 
     /**
@@ -738,6 +740,7 @@
                 setUserGroupById(username, PERMISSION.Sub);
             }
 
+            oldID = (oldID > PERMISSION.Regular) ? PERMISSION.Regular : oldID; //Only save meaningful permissions
             $.setIniDbNumber('preSubGroup', username, oldID); //Save the old (permission) id for reference when the subscription runs out
         } else if (!isInCache && oldID === PERMISSION.Sub) { //User is not in the subscriber cache but holds subscriber permissions according to the database
             if (isVIP(username)) { //User is a VIP - Set permission to VIP


### PR DESCRIPTION
### Changes
- Ensure only valid permission are saved in the database (`group` table)
- Only save valuable permissions in the `preSubGroup` table

### Cleanup, in case it already has happened
- Clean up database (group and preSubGroup) from values we do not need in it
