### PR TITLE
Fix mod staying mod after unmod

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -1056,6 +1056,8 @@
                     setUserGroupById(username, PERMISSION.Sub);
                 } else if (isVIP(username)) {
                     setUserGroupById(username, PERMISSION.VIP);
+                } else {
+                    setUserGroupById(username, PERMISSION.Viewer);
                 }
             }
         } else if (event.getMode().equalsIgnoreCase('vip')) {


### PR DESCRIPTION
Fix mod staying mod after unmod
OMode did not set the database permission back to viewer if the user being unmodded was neither a vip nor a sub