### PR TITLE
[Quality of Life] Check if H2 is in use

### DIFF
--- a/source/com/gmt2001/datastore/H2Store.java
+++ b/source/com/gmt2001/datastore/H2Store.java
@@ -112,6 +112,11 @@ public final class H2Store extends DataStore {
     }
 
     private void checkInUse(String configStr) {
+        Path dbfile = Paths.get("./config/", configStr + ".mv.db");
+
+        if (!Files.exists(dbfile)) {
+            return;
+        }
         try {
             JdbcConnectionPool connectionPool = JdbcConnectionPool.create("jdbc:h2:./config/" + configStr + ";DB_CLOSE_ON_EXIT=FALSE;MAX_LENGTH_INPLACE_LOB=2048", "", "");
 

--- a/source/com/gmt2001/datastore/H2Store.java
+++ b/source/com/gmt2001/datastore/H2Store.java
@@ -77,6 +77,8 @@ public final class H2Store extends DataStore {
             configStr = "phantombot.h2";
         }
 
+        this.checkInUse(configStr);
+
         try {
             if (this.needsUpgrade(configStr)) {
                 this.startUpgrade(configStr);
@@ -105,6 +107,23 @@ public final class H2Store extends DataStore {
                 this.finishUpgrade(configStr);
             }
         } catch (Exception ex) {
+            com.gmt2001.Console.err.printStackTrace(ex);
+        }
+    }
+
+    private void checkInUse(String configStr) {
+        try {
+            JdbcConnectionPool connectionPool = JdbcConnectionPool.create("jdbc:h2:./config/" + configStr + ";DB_CLOSE_ON_EXIT=FALSE;MAX_LENGTH_INPLACE_LOB=2048", "", "");
+
+            // Attempt to acquire a connection from the pool
+            connectionPool.getConnection().close();
+            connectionPool.dispose();
+        } catch (SQLException ex) {
+            // SQLException occurred, check if the SQL state code indicates the database is in use
+            if ("90020".equals(ex.getSQLState())) {
+                com.gmt2001.Console.err.println("Database is already in use. Please close any existing connections.");
+                Runtime.getRuntime().exit(-1);
+            }
             com.gmt2001.Console.err.printStackTrace(ex);
         }
     }


### PR DESCRIPTION
Checks if the `H2`-Database is already in use and send an error and shutdown the bot if it is.
This should help prevent cases of inexperienced users using the default datastore from opening multiple instances of the bot.

I considered doing the same for the `sqlite` and `mysql` datastores, but those are datastores that allow for concurrent connections. Thus, there is no reliable way of making sure this is not the case. Considered possibilities and why they're not suitable imo:

- A **locking file** for sqllite
Will not be deleted if phantombot, java or the system crashes and therefore not being reliable. Constantly writing to the locking file is just ugly and bad coding imo. Holding an open FileChannel to it might be a possibility here, which I'm too fond of. It could look sth like this:
```
try (RandomAccessFile raf = new RandomAccessFile(file, "rw");
             FileChannel channel = raf.getChannel()) {
            boolean isOpen = channel.isOpen();
} catch (Exception e) {
            // Error handling
}
```
- A **named pipe** for sqlite
Same as with a locking file ... it's not destroyed after a crash from phantombot or java or being killed in that matter
- **-wal** or **-shm** presence for sqllite
Same as with a locking file ... it's not destroyed after a crash from phantombot or java or being killed in that matter and used for recovery etc.
- **open connections** for mysql
There might be other connections to the database i.e. from some monitoring or an admin accessing the server
- **exclusive mode** for sqlite
Does not allow child processes to use the database and therefore not useable ... I've tried
- An **active value** inside a table
Is not removed or reset if a crash occurs
- A **timestamp** inside a table
Unnecessary writes to the database