### PR TITLE
Update deps

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,7 +41,7 @@
     <property name="lib.extra.dir" location="${build.dir}/lib.extra" />
     <property name="java.source.level" value="11"/>
     <!-- Apache Ivy properties -->
-    <property name="ivy.install.version" value="2.5.0"/>
+    <property name="ivy.install.version" value="2.5.1"/>
     <condition property="ivy.home" value="${env.IVY_HOME}">
         <isset property="env.IVY_HOME"/>
     </condition>
@@ -314,6 +314,23 @@
                 <attribute name="Main-Class" value="tv.phantombot.PhantomBot" />
             </manifest>
         </jar>
+        <mkdir dir="${version.folder}/lib" />
+        <echo level="info" message="staging lib folder into build dir." />
+        <copy todir="${version.folder}/lib">
+            <fileset dir="${reference}">
+                <include name="*.jar" />
+                <exclude name="*sources.jar"/>
+                <exclude name="*javadoc.jar"/>
+            </fileset>
+        </copy>
+        <mkdir dir="${version.folder}/lib.extra" />
+        <copy todir="${version.folder}/lib.extra">
+            <fileset dir="${reference.extra}">
+                <include name="*.jar" />
+                <exclude name="*sources.jar"/>
+                <exclude name="*javadoc.jar"/>
+            </fileset>
+        </copy>
     </target>
 
     <target depends="compile.src,post.compile,git.revision" name="jar">

--- a/development-resources/rollbar/rollbar-settings.php
+++ b/development-resources/rollbar/rollbar-settings.php
@@ -79,12 +79,12 @@ $filters = array(
     ),
     array(
         'exception' => array(
-            'class' => 'com.mysql.jdbc.exceptions.jdbc4.MySQLQueryInterruptedException'
+            'class' => 'com.mysql.cj.jdbc.exceptions.MySQLQueryInterruptedException'
         )
     ),
     array(
         'exception' => array(
-            'class' => 'com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException'
+            'class' => 'java.sql.SQLNonTransientConnectionException'
         )
     ),
     array(

--- a/ivy.xml
+++ b/ivy.xml
@@ -49,7 +49,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.93.Final" />
         <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.93.Final" />
         <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.7"/>
-        <dependency org="mysql" name="mysql-connector-java" rev="5.1.49"/>
+        <dependency org="com.mysql" name="mysql-connector-j" rev="8.0.33"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
         <dependency org="org.apache.commons" name="commons-text" rev="1.10.0"/>
         <dependency org="org.json" name="json" rev="20230227"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -44,18 +44,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <dependency org="com.h2database" name="h2" rev="1.4.200" conf="lib.extra->default"/>
         <dependency org="com.rollbar" name="rollbar-java" rev="1.10.0"/>
         <dependency org="commons-codec" name="commons-codec" rev="1.15"/>
-        <dependency org="commons-io" name="commons-io" rev="2.11.0"/>
-        <dependency org="io.netty" name="netty-codec-http" rev="4.1.79.Final"/>
-        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.79.Final" />
-        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.79.Final" />
-        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.0.16"/>
+        <dependency org="commons-io" name="commons-io" rev="2.12.0"/>
+        <dependency org="io.netty" name="netty-codec-http" rev="4.1.93.Final"/>
+        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.93.Final" />
+        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.93.Final" />
+        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.7"/>
         <dependency org="mysql" name="mysql-connector-java" rev="5.1.49"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
         <dependency org="org.apache.commons" name="commons-text" rev="1.10.0"/>
         <dependency org="org.json" name="json" rev="20230227"/>
         <dependency org="org.mozilla" name="rhino" rev="1.7.14"/>
-        <dependency org="org.slf4j" name="slf4j-nop" rev="1.7.25"/>
-        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.41.0.0"/>
+        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.7"/>
+        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.42.0.0"/>
         <dependency org="com.vdurmont" name="emoji-java" rev="5.1.1" />
     </dependencies>
 </ivy-module>

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2023-05-29 10:53:43</div>
+        2023-05-29 13:40:19</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2023-03-26 15:54:09</div>
+        2023-05-29 10:53:43</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>
@@ -32,20 +32,20 @@
                 </tr>
                 <tr>
                     <td class="title">Revisions</td><td class="value">1
-        (1 searched <img src="https://ant.apache.org/ivy/images/searched.gif" alt="searched" title="module revisions which required a search with a dependency resolver to be resolved">,
-        1 downloaded <img src="https://ant.apache.org/ivy/images/downloaded.gif" alt="downloaded" title="module revisions for which ivy file was downloaded by dependency resolver">,
+        (0 searched <img src="https://ant.apache.org/ivy/images/searched.gif" alt="searched" title="module revisions which required a search with a dependency resolver to be resolved">,
+        0 downloaded <img src="https://ant.apache.org/ivy/images/downloaded.gif" alt="downloaded" title="module revisions for which ivy file was downloaded by dependency resolver">,
         0 evicted <img src="https://ant.apache.org/ivy/images/evicted.gif" alt="evicted" title="module revisions which were evicted by others">,
         0 errors <img src="https://ant.apache.org/ivy/images/error.gif" alt="error" title="module revisions on which error occurred">)</td>
                 </tr>
                 <tr>
                     <td class="title">Artifacts</td><td class="value">1
-        (1 downloaded,
+        (0 downloaded,
         0 failed)</td>
                 </tr>
                 <tr>
                     <td class="title">Artifacts size</td><td class="value">2250 kB
-        (2250 kB downloaded,
-        0 kB in cache)</td>
+        (0 kB downloaded,
+        2250 kB in cache)</td>
                 </tr>
             </table>
             <h2>Dependencies Overview</h2>
@@ -60,7 +60,7 @@
                         <td><a href="#com.h2database-h2"> h2
         by
         com.h2database</a></td><td><a href="#com.h2database-h2-1.4.200">1.4.200</a></td><td align="center">release</td><td align="center">public</td><td align="center">false</td><td align="center"><span style="padding-right:3px;"><a href="https://h2database.com/html/license.html">MPL 2.0 or EPL 1.0</a></span></td><td align="center">2250 kB
-    </td><td align="center"><img src="https://ant.apache.org/ivy/images/searched.gif" alt="searched" title="required a search in repository"><img src="https://ant.apache.org/ivy/images/downloaded.gif" alt="downloaded" title="downloaded from repository"></td>
+    </td><td align="center"></td>
                     </tr>
                 </tbody>
             </table>
@@ -70,7 +70,7 @@
             </h3>
             <h4>
                 <a name="com.h2database-h2-1.4.200"></a>
-           Revision: 1.4.200<span style="padding-left:15px;"><img src="https://ant.apache.org/ivy/images/searched.gif" alt="searched" title="required a search in repository"><img src="https://ant.apache.org/ivy/images/downloaded.gif" alt="downloaded" title="downloaded from repository"></span>
+           Revision: 1.4.200<span style="padding-left:15px;"></span>
             </h4>
             <table class="header">
                 <tr>
@@ -80,7 +80,7 @@
                     <td class="title">Status</td><td class="value">release</td>
                 </tr>
                 <tr>
-                    <td class="title">Publication</td><td class="value">20191014032514</td>
+                    <td class="title">Publication</td><td class="value">20191014092514</td>
                 </tr>
                 <tr>
                     <td class="title">Resolver</td><td class="value">public</td>
@@ -90,8 +90,8 @@
                 </tr>
                 <tr>
                     <td class="title">Artifacts size</td><td class="value">2250 kB
-          (2250 kB downloaded,
-          0 kB in cache)</td>
+          (0 kB downloaded,
+          2250 kB in cache)</td>
                 </tr>
                 <tr>
                     <td class="title">Licenses</td><td class="value"><span style="padding-right:3px;"><a href="https://h2database.com/html/license.html">MPL 2.0 or EPL 1.0</a></span></td>
@@ -127,7 +127,7 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td>h2</td><td>jar</td><td>jar</td><td align="center">successful</td><td align="center">2250 kB</td>
+                        <td>h2</td><td>jar</td><td>jar</td><td align="center">no</td><td align="center">2250 kB</td>
                     </tr>
                 </tbody>
             </table>

--- a/source/com/gmt2001/RollbarProvider.java
+++ b/source/com/gmt2001/RollbarProvider.java
@@ -152,11 +152,11 @@ public final class RollbarProvider implements AutoCloseable {
                                     return true;
                                 }
 
-                                if (error.getClass().equals(com.mysql.jdbc.exceptions.jdbc4.MySQLQueryInterruptedException.class)) {
+                                if (error.getClass().equals(com.mysql.cj.jdbc.exceptions.MySQLQueryInterruptedException.class)) {
                                     return true;
                                 }
 
-                                if (error.getClass().equals(com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException.class)) {
+                                if (error.getClass().equals(java.sql.SQLNonTransientConnectionException.class)) {
                                     return true;
                                 }
 

--- a/source/com/gmt2001/datastore/MySQLStore.java
+++ b/source/com/gmt2001/datastore/MySQLStore.java
@@ -17,7 +17,7 @@
 package com.gmt2001.datastore;
 
 import biz.source_code.miniConnectionPoolManager.MiniConnectionPoolManager;
-import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
@@ -54,7 +54,7 @@ public final class MySQLStore extends DataStore {
         super(configStr);
 
         try {
-            Class.forName("com.mysql.jdbc.Driver");
+            Class.forName("com.mysql.cj.jdbc.Driver");
         } catch (ClassNotFoundException ex) {
             ex.printStackTrace(System.err);
         }


### PR DESCRIPTION
Updates deps and adds lib copy task to `jar-only` target

## Tested
- Compiled successfully after an ivy-clean-retrieve
- Ran without errors
- Panel is functional
- Twitch commands
- Discord commands work

## Changed dependencies and notable changes:
**full changelogs linked**
- [io-netty](https://netty.io/news/index.html) from `4.1.79-final` to `4.1.93-final`
plethora of fixes including some memory leaks
- [comms-io](https://commons.apache.org/proper/commons-io/changes-report.html) from `2.11.0` to `2.12.0`
- [reactor-netty](https://github.com/reactor/reactor-netty/releases) from `1.0.16` to `1.1.7` (`1.0.32` available)
Upgrade dependencies, fix null pointer exceptions and header handling, memory leak fixes
- [slf4j](https://www.slf4j.org/news.html) from `1.7.25` to `2.0.7` (`1.7.36` available)
General bug fixes, removal of `android` and `jcl` modules
- [sqlite-jdbc](https://github.com/xerial/sqlite-jdbc/releases) from `3.41.0.0` to `3.42.0.0`
General additions and fixes
- [ivy](https://ant.apache.org/ivy/history/2.5.1/release-notes.html) from `2.5.0` to `2.5.1`
FIX: `CVE-2022-37865` `CVE-2022-37866` and HTTP header trouble with some servers
- [mysql-connector]() from `5.1.49` to `8.0.33`
Needed changes implemented according to [their migration guide](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-upgrading-to-8.0.html)
Compatibility for MySQL 5.7 (probably also 5.6) and MySQL 8.0 more info on the respective [compatibility doc](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-versions.html) (older versions are [not supported anymore](https://www.mysql.com/support/supportedplatforms/database.html))
MySQL `5.7` will be EOL on October 21, 2023

Edit: added mysql-connector information