### PR TITLE
Add option to clear command cooldowns on online event

### DIFF
--- a/javascript-source/core/bootstrap/900updates.js
+++ b/javascript-source/core/bootstrap/900updates.js
@@ -754,6 +754,14 @@
             }
         }
     });
+    addUpdate('3.8.4.0-3', 'installedv3.8.4.0-3', function() { // Ensure nightly bots which already have 3.8.4.0-2 get the change
+        let commands = $.inidb.GetKeyList('cooldown', '');
+        for (let i in commands) {
+            let json = JSON.parse($.inidb.get('cooldown', commands[i]));
+            json.clearOnOnline = false;
+            $.inidb.set('cooldown', command[i], JSON.stringify(json));
+        }
+    });
 
     // ------ Add updates above this line in execution order ------
 

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -83,15 +83,13 @@
      * @function loadCooldowns
      */
     function loadCooldowns() {
-        var commands = $.inidb.GetKeyList('cooldown', ''),
-            json,
-            i;
+        let commands = $.inidb.GetKeyList('cooldown', '');
 
         _cooldownsLock.lock();
         try {
-            for (i in commands) {
-                json = JSON.parse($.inidb.get('cooldown', commands[i]));
-                cooldowns[$.jsString(commands[i]).toLowerCase()] = new Cooldown(json.command.toLowerCase(), json.globalSec, json.userSec, json.modsSkip);
+            for (let i in commands) {
+                let json = JSON.parse($.inidb.get('cooldown', commands[i]));
+                cooldowns[$.jsString(commands[i]).toLowerCase()] = new Cooldown(json.command.toLowerCase(), json.globalSec, json.userSec, json.modsSkip, json.clearOnOnline);
             }
         } finally {
             _cooldownsLock.unlock();
@@ -466,23 +464,9 @@
         _cooldownsLock.lock();
         try {
             for (let command in cooldowns) {
-                if (command.clearOnOnline) {
+                if (cooldowns[command].clearOnOnline) {
                     clear(command);
-            }
-        }
-
-        if (action2 !== undefined) {
-            $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.setCombo' + modsSkip, command, secsG, secsU));
-        } else {
-            var messageType = type1.equalsIgnoreCase(Type.Global) ? "cooldown.coolcom.setGlobal" : "cooldown.coolcom.setUser";
-            $.say($.whisperPrefix(sender) + $.lang.get(messageType + modsSkip, command, (secsG === Operation.UnChanged ? secsU : secsG)));
                 }
-
-        if (action2 !== undefined) {
-            $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.setCombo' + modsSkip, command, secsG, secsU));
-        } else {
-            var messageType = type1.equalsIgnoreCase(Type.Global) ? "cooldown.coolcom.setGlobal" : "cooldown.coolcom.setUser";
-            $.say($.whisperPrefix(sender) + $.lang.get(messageType + modsSkip, command, (secsG === Operation.UnChanged ? secsU : secsG)));
             }
         } finally {
             _cooldownsLock.unlock();

--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -51,14 +51,16 @@
      * @param {Number}  globalSec
      * @param {Number}  userSec
      * @param {Boolean}  modsSkip
+     * @param {Boolean}  clearOnOnline
      */
-    function Cooldown(command, globalSec, userSec, modsSkip) {
+    function Cooldown(command, globalSec, userSec, modsSkip, clearOnOnline) {
         this.command = command;
         this.globalSec = globalSec;
         this.userSec = userSec;
         this.userTimes = [];
         this.globalTime = 0;
-        this.modsSkip = modsSkip;
+        this.modsSkip = modsSkip,
+        this.clearOnOnline = clearOnOnline;
     }
 
     /*
@@ -72,7 +74,8 @@
             command: String(command.command),
             globalSec: command.globalSec,
             userSec: command.userSec,
-            modsSkip: command.modsSkip
+            modsSkip: command.modsSkip,
+            clearOnOnline: command.clearOnOnline
         });
     }
 
@@ -259,7 +262,7 @@
         }
 
         if (!exists(command)) {
-            add(command, Operation.UnChanged, Operation.UnChanged, null);
+            add(command, Operation.UnChanged, Operation.UnChanged, null, null);
         }
 
         _cooldownsLock.lock();
@@ -282,8 +285,9 @@
      * @param {Number}  globalSec
      * @param {Number}  userSec
      * @param {Boolean} modsSkip
+     * @param {Boolean} clearOnOnline
      */
-    function add(command, globalSec, userSec, modsSkip) {
+    function add(command, globalSec, userSec, modsSkip, clearOnOnline) {
         command = (command !== undefined && command !== null ? $.jsString(command).toLowerCase() : null);
         _cooldownsLock.lock();
         try {
@@ -291,7 +295,8 @@
                 cooldowns[command] = new Cooldown(command,
                                                 (globalSec === Operation.UnChanged ? Operation.UnSet : globalSec),
                                                 (userSec === Operation.UnChanged ? Operation.UnSet : userSec),
-                                                modsSkip === undefined || modsSkip === null ? false : modsSkip);
+                                                (modsSkip === undefined || modsSkip === null ? false : modsSkip),
+                                                (clearOnOnline === undefined || clearOnOnline === null ? false : clearOnOnline));
             } else {
                 if (globalSec !== Operation.UnChanged) {
                     cooldowns[command].globalSec = globalSec;
@@ -301,6 +306,9 @@
                 }
                 if (modsSkip !== undefined && modsSkip !== null) {
                     cooldowns[command].modsSkip = modsSkip;
+                }
+                if (clearOnOnline !== undefined && clearOnOnline !== null) {
+                    cooldowns[command].clearOnOnline = clearOnOnline;
                 }
             }
 
@@ -319,14 +327,7 @@
     function remove(command) {
         command = (command !== undefined && command !== null ? $.jsString(command).toLowerCase() : null);
         $.inidb.del('cooldown', command);
-        _cooldownsLock.lock();
-        try {
-            if (cooldowns[command] !== undefined) {
-                delete cooldowns[command];
-            }
-        } finally {
-            _cooldownsLock.unlock();
-        }
+        clear(command);
     }
 
     /*
@@ -338,12 +339,38 @@
     function clear(command) {
         command = (command !== undefined && command !== null ? $.jsString(command).toLowerCase() : null);
         _cooldownsLock.lock();
+        _defaultCooldownsLock.lock();
         try {
             if (cooldowns[command] !== undefined) {
-                cooldowns[command].globalTime = 0;
-                cooldowns[command].userTimes = [];
+                delete cooldowns[command];
+            }
+            if (defaultCooldowns[command] !== undefined) {
+                delete defaultCooldowns[command];
             }
         } finally {
+            _defaultCooldownsLock.unlock();
+            _cooldownsLock.unlock();
+        }
+    }
+
+    /*
+     * @function clearAll
+     *
+     * @export $.coolDown
+     * @param {String}  command
+     */
+    function clearAll() {
+        _cooldownsLock.lock();
+        _defaultCooldownsLock.lock();
+        try {
+            for (let command in cooldowns) {
+                clear(command);
+            }
+            for (let command in defaultCooldowns) {
+                clear(command);
+            }
+        } finally {
+            _defaultCooldownsLock.unlock();
             _cooldownsLock.unlock();
         }
     }
@@ -353,83 +380,77 @@
      *
      * @param {String}  sender
      * @param {String}  command
-     * @param {String}  first
-     * @param {String}  second
-     * @param {Boolean} modsSkipIn
+     * @param {String[]}  args
      */
-    function handleCoolCom(sender, command, first, second, modsSkipIn) {
+    function handleCoolCom(sender, command, args) {
         command = (command !== undefined && command !== null ? $.jsString(command).toLowerCase() : null);
         sender = (sender !== undefined && sender !== null ? $.jsString(sender).toLowerCase() : null);
-        var action1 = first === undefined || first === null ? null : first.split("="),
-            type1   = action1 === null ? null : action1[0],
-            secsG   = Operation.UnChanged,
-            secsU   = Operation.UnChanged;
 
-        if (action1 === null) {
-            if (cooldowns[command] === undefined) {
-                $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.remove', command));
-            } else {
-                $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.setCombo' + (cooldowns[command].modsSkip ? 'ModsSkip' : ''), command, cooldowns[command].globalSec, cooldowns[command].userSec));
+        let secsU = $.getArgFromArray(args, Type.User, Operation.UnChanged),
+            secsG = $.getArgFromArray(args, Type.Global, Operation.UnChanged),
+            modsSkip = $.stringToBoolean($.getArgFromArray(args, 'modsskip', null)),
+            clearOnOnline = $.stringToBoolean($.getArgFromArray(args, 'clearOnOnline', null));
+
+        if (secsU === Operation.UnChanged && secsG === Operation.UnChanged) {
+            if (!isNaN(parseInt(args[0]))) {
+                secsG = parseInt(args[0]); //Assume global cooldown as first parameter if no specific cooldown type is specified
             }
-            return;
         }
 
-        if (modsSkipIn === undefined) {
-            modsSkipIn = null;
-        }
-
-        if (type1.equalsIgnoreCase('remove')) {
-            remove(command);
-            $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.remove', command));
-            return;
-        }
-
-        if (!isNaN(parseInt(type1)) && second === undefined) { //Only assume this is global if no secondary action is present
-            secsG = parseInt(type1);
-            type1 = Type.Global;
-        } else if ((!type1.equalsIgnoreCase(Type.Global) && !type1.equalsIgnoreCase(Type.User) && !type1.equalsIgnoreCase('modsskip')) || isNaN(parseInt(action1[1]))) {
+        // Error handling
+        if (secsU !== null && isNaN(parseInt(secsU))) {
             $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
             return;
-        } else {
-            secsG = type1.equalsIgnoreCase(Type.Global) ? parseInt(action1[1]) : secsG;
-            secsU = type1.equalsIgnoreCase(Type.User) ? parseInt(action1[1]) : secsU;
-            modsSkipIn = modsSkipIn === null && type1.equalsIgnoreCase('modsskip') ? action1[1] : modsSkipIn;
+        }
+        if (secsG !== null && isNaN(parseInt(secsG))) {
+            $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
+            return;
+        }
+        if (secsG === Operation.UnChanged && secsU === Operation.UnChanged && modsSkip === null && clearOnOnline === null) {
+            $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
+            return;
         }
 
-        if (second !== undefined){
-            var action2 = second.split("="),
-                type2   = action2[0];
-
-            if ((!type2.equalsIgnoreCase(Type.Global) && !type2.equalsIgnoreCase(Type.User) && !type2.equalsIgnoreCase('modsskip')) || isNaN(parseInt(action2[1])) || type2.equalsIgnoreCase(type1)) {
-                $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
-                return;
-            }
-
-            secsG = type2.equalsIgnoreCase(Type.Global) ? parseInt(action2[1]) : secsG;
-            secsU = type2.equalsIgnoreCase(Type.User) ? parseInt(action2[1]) : secsU;
-            modsSkipIn = modsSkipIn === null && type2.equalsIgnoreCase('modsskip') ? action2[1] : modsSkipIn;
-        }
-
-        var modsSkip = null;
-
-        if (modsSkipIn !== null) {
-            modsSkipIn = $.jsString(modsSkipIn).toLowerCase().trim();
-            modsSkip = modsSkipIn === 'true' || modsSkipIn === '1' || modsSkipIn === 'modsskip=true' || modsSkipIn === 'modsskip=1';
-        }
-
-        if (secsG === Operation.UnSet && secsU === Operation.UnSet && modsSkip !== true) {
+        // Handling
+        if (secsG === Operation.UnSet && secsU === Operation.UnSet) {
             remove(command);
             $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.remove', command));
             return;
         }
-
-        add(command, secsG, secsU, modsSkip);
+        add(command, secsG, secsU, modsSkip, clearOnOnline);
         clear(command);
 
-        if (modsSkip) {
-            modsSkip = 'ModsSkip';
-        } else {
-            modsSkip = '';
+        // Build the message
+        let message;
+        if (secsG === Operation.UnChanged && secsU === Operation.UnChanged) { // Cooldown times did not change only options changed
+            message =  $.lang.get('cooldown.coolcom.setoptions', command);
+        } else if (secsG !== Operation.UnChanged && secsU !== Operation.UnChanged) { // Both cooldown times changed
+            message = $.lang.get('cooldown.coolcom.setCombo', command, secsG, secsU);
+        } else { //Only one cooldown time changed
+            let messageType = secsU === Operation.UnChanged ? 'cooldown.coolcom.setGlobal' : 'cooldown.coolcom.setUser';
+            message =  $.lang.get(messageType, command, (secsU === Operation.UnChanged ? secsG : secsU));
+        }
+
+        if (modsSkip !== null) {
+            message += " " + $.lang.get('cooldown.coolcom.ModSkipAddon');
+        }
+        if (clearOnOnline !== null) {
+            message += " " + $.lang.get('cooldown.coolcom.OnlineClearAddon');
+        }
+
+        $.say($.whisperPrefix(sender) + message);
+    }
+
+    /*
+     * @event twitchOnline
+     */
+    $.bind('twitchOnline', function () {
+        _cooldownsLock.lock();
+        try {
+            for (let command in cooldowns) {
+                if (command.clearOnOnline) {
+                    clear(command);
+            }
         }
 
         if (action2 !== undefined) {
@@ -437,8 +458,18 @@
         } else {
             var messageType = type1.equalsIgnoreCase(Type.Global) ? "cooldown.coolcom.setGlobal" : "cooldown.coolcom.setUser";
             $.say($.whisperPrefix(sender) + $.lang.get(messageType + modsSkip, command, (secsG === Operation.UnChanged ? secsU : secsG)));
+                }
+
+        if (action2 !== undefined) {
+            $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.setCombo' + modsSkip, command, secsG, secsU));
+        } else {
+            var messageType = type1.equalsIgnoreCase(Type.Global) ? "cooldown.coolcom.setGlobal" : "cooldown.coolcom.setUser";
+            $.say($.whisperPrefix(sender) + $.lang.get(messageType + modsSkip, command, (secsG === Operation.UnChanged ? secsU : secsG)));
+            }
+        } finally {
+            _cooldownsLock.unlock();
         }
-    }
+    });
 
     /*
      * @event command
@@ -448,20 +479,36 @@
             command = event.getCommand(),
             args = event.getArgs(),
             action = args[0],
-            subAction = args[1],
-            actionArgs = args[2];
+            subAction = args[1];
 
         /*
-         * @commandpath coolcom [command] [user=seconds] [global=seconds] [modsskip=true] - Sets a cooldown for a command, default is global if no type and no secondary type is given. Using -1 for the seconds removes the cooldown. Specifying the 'modsskip' parameter with a value of 'true' enables moderators to ignore cooldowns for this command.
+         * @commandpath coolcom [command] [user=seconds] [global=seconds] [modsskip=false] [clearOnOnline=false] - Sets a cooldown for a command, default is global if no type and no secondary type is given. Using -1 for the seconds removes the cooldown. Specifying the 'modsskip' parameter with a value of 'true' enables moderators to ignore cooldowns for this command. Specifying the 'clearOnOnline' parameter with a value of 'true' clear the commands cooldowns when going online/live. 
          * @commandpath coolcom [command] remove - Removes any command-specific cooldown that was set on the specified command.
+         * @commandpath coolcom [command] clear - Clears all active cooldowns for the specified command.
          */
         if (command.equalsIgnoreCase('coolcom')) {
             if (action === undefined) {
                 $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.usage'));
+                $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.extras.usage'));
                 return;
             }
 
-            handleCoolCom(sender, action, subAction, actionArgs, args[3]);
+            if (subAction.equalsIgnoreCase('remove') || subAction.equalsIgnoreCase('clear')) {
+                if (!exists(action)) {
+                    $.say($.whisperPrefix(sender) + $.lang.get('cooldown.command.err', action));
+                    return;
+                }
+                if (subAction.equalsIgnoreCase('remove')) {
+                    remove(action);
+                    $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.remove', action));
+                } else {
+                    clear(action);
+                    $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.clear', action));
+                }
+                return;
+            }
+
+            handleCoolCom(sender, action, args.slice(1));
             return;
         }
 
@@ -498,6 +545,16 @@
                 defaultCooldownTime = parseInt(subAction);
                 $.setIniDbNumber('cooldownSettings', 'defaultCooldownTime', defaultCooldownTime);
                 $.say($.whisperPrefix(sender) + $.lang.get('cooldown.default.set', defaultCooldownTime));
+                return;
+            }
+
+            /*
+             * @commandpath cooldown clearall - Clears all active cooldowns
+             */
+            if (action.equalsIgnoreCase('clearall')) {
+                clearAll();
+                $.say($.whisperPrefix(sender) + $.lang.get('cooldown.coolcom.clear.all'));
+                return;
             }
         }
     });
@@ -510,6 +567,7 @@
         $.registerChatCommand('./core/commandCoolDown.js', 'cooldown', $.PERMISSION.Admin);
         $.registerChatSubcommand('cooldown', 'togglemoderators', $.PERMISSION.Admin);
         $.registerChatSubcommand('cooldown', 'setdefault', $.PERMISSION.Admin);
+        $.registerChatSubcommand('cooldown', 'clearall', $.PERMISSION.Admin);
         loadCooldowns();
     });
 
@@ -519,7 +577,7 @@
     $.bind('webPanelSocketUpdate', function(event) {
         if (event.getScript().equalsIgnoreCase('./core/commandCoolDown.js')) {
             if (event.getArgs()[0].equalsIgnoreCase('add')) {
-                add(event.getArgs()[1], parseInt(event.getArgs()[2]), parseInt(event.getArgs()[3]), $.jsString(event.getArgs()[4]) === '1');
+                add(event.getArgs()[1], parseInt(event.getArgs()[2]), parseInt(event.getArgs()[3]), $.jsString(event.getArgs()[4]) === '1', $.jsString(event.getArgs()[5]) === '1');
             } else if (event.getArgs()[0].equalsIgnoreCase('update')) {
                 defaultCooldownTime = $.getIniDbNumber('cooldownSettings', 'defaultCooldownTime', 5);
                 modCooldown = $.getIniDbBoolean('cooldownSettings', 'modCooldown', false);

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -461,11 +461,11 @@
         if (string === undefined || string === null) {
             return null;
         }
-        if (string.equalsIgnoreCase('true') || string === '1') {
+        if ($.equalsIgnoreCase(string, 'true') || string === '1') {
             return true;
         }
-        if (string.equalsIgnoreCase('false') || string === '0') {
-            return true;
+        if ($.equalsIgnoreCase(string, 'false') || string === '0') {
+            return false;
         }
         return null;
     }

--- a/javascript-source/core/misc.js
+++ b/javascript-source/core/misc.js
@@ -434,6 +434,42 @@
         }
     }
 
+    /**
+     * Returns a keys value from an arguments array which has a syntax of [key1=value1, key2=value2, key3=value3]
+     * @param {String[]} array
+     * @param {String} key
+     * @param {*} defaultValue
+     * @returns the value; the defaultValue if no array element with the key is not present; null if neither key is present nor a default value is provided
+     */
+    function getArgFromArray(array, key, defaultValue) {
+        for (let i = 0; i < array.length; i++) {
+            let pair = $.jsString(array[i]).split('=');
+            if (pair[0].equalsIgnoreCase(key)) {
+                return pair[1];
+            }
+        }
+
+        return defaultValue === undefined ? null : defaultValue;
+    }
+
+    /**
+     * Converts any possible boolean represented as a string ('1', '0', 'true', 'false') to a proper boolean
+     * @param {String} string
+     * @return the boolean; null if it's not a valid boolean represented as a string
+     */
+    function stringToBoolean(string) {
+        if (string === undefined || string === null) {
+            return null;
+        }
+        if (string.equalsIgnoreCase('true') || string === '1') {
+            return true;
+        }
+        if (string.equalsIgnoreCase('false') || string === '0') {
+            return true;
+        }
+        return null;
+    }
+
     /** Export functions to API */
     $.user = {
         isKnown: isKnown,
@@ -460,4 +496,6 @@
     $.getMessageWrites = getMessageWrites;
     $.sayWithTimeout = sayWithTimeout;
     $.usernameResolveIgnoreEx = usernameResolveIgnoreEx;
+    $.getArgFromArray = getArgFromArray;
+    $.stringToBoolean = stringToBoolean;
 })();

--- a/javascript-source/lang/english/core/core-commandCoolDown.js
+++ b/javascript-source/lang/english/core/core-commandCoolDown.js
@@ -16,16 +16,20 @@
  */
 
 $.lang.register('cooldown.set.togglemodcooldown', 'Command cooldowns have been $1 for moderators.');
-$.lang.register('cooldown.coolcom.usage', 'Usage: !coolcom [command] [seconds / global=seconds / user=seconds] [global=seconds / user=seconds] - Using -1 for the seconds removes the cooldown. Only specifying seconds assumes global only if no secondary argument is given!');
+$.lang.register('cooldown.coolcom.usage', 'Usage: !coolcom [command] [seconds / global=seconds / user=seconds] [modsskip=false] [clearononline=false] - Using -1 for the seconds removes the cooldown. Only specifying seconds assumes global only if no secondary argument is given!');
 $.lang.register('cooldown.coolcom.err', 'The minimum cooldown that can be set is 5 seconds.');
+$.lang.register('cooldown.coolcom.setoptions', 'Cooldown options for command !$1 changed.');
 $.lang.register('cooldown.coolcom.setGlobal', 'Cooldown for command !$1 has globally been set to $2 seconds.');
 $.lang.register('cooldown.coolcom.setUser', 'Cooldown for command !$1 has been set to $2 seconds individually for each user.');
 $.lang.register('cooldown.coolcom.setCombo', 'Cooldown for command !$1 has globally been set to $2 seconds and to $3 seconds individually for each user.');
-$.lang.register('cooldown.coolcom.setGlobalModsSkip', 'Cooldown for command !$1 has globally been set to $2 seconds. Moderators will skip the cooldown for this command.');
-$.lang.register('cooldown.coolcom.setUserModsSkip', 'Cooldown for command !$1 has been set to $2 seconds individually for each user. Moderators will skip the cooldown for this command.');
-$.lang.register('cooldown.coolcom.setComboModsSkip', 'Cooldown for command !$1 has globally been set to $2 seconds and to $3 seconds individually for each user. Moderators will skip the cooldown for this command.');
-$.lang.register('cooldown.coolcom.remove', 'Cooldown for command !$1 has been removed.');
+$.lang.register('cooldown.coolcom.ModSkipAddon', 'Moderators will skip the cooldown for this command.');
+$.lang.register('cooldown.coolcom.OnlineClearAddon', 'Cooldown(s) for this command will be cleared every time you go online.');
+$.lang.register('cooldown.coolcom.remove', 'Cooldown(s) for command !$1 has been removed.');
 $.lang.register('cooldown.cooldown.usage', 'Usage: !cooldown [togglemoderators / setdefault]');
 $.lang.register('cooldown.default.set', 'The default cooldown for commands without one has been set to $1 seconds.');
 $.lang.register('cooldown.default.usage', 'Usage: !cooldown setdefault [seconds] - Set a cooldown for commands that don\'t have one. Currently $1 seconds');
 $.lang.register('cooldown.adventure.err', 'Please use "!adventure set cooldown" to set the cooldown for adventures.');
+$.lang.register('cooldown.command.err', '!$1 does not exists or !$1 is not on cooldown!');
+$.lang.register('cooldown.coolcom.extras.usage', 'Extras usage: !coolcom [command] remove / clear');
+$.lang.register('cooldown.coolcom.clear', 'All active cooldowns for command !$1 have been successfully removed');
+$.lang.register('cooldown.coolcom.clear.all', 'All active cooldowns have been successfully removed');

--- a/resources/web/panel/js/pages/commands/custom.js
+++ b/resources/web/panel/js/pages/commands/custom.js
@@ -180,7 +180,7 @@ $(function () {
                     tables: ['command', 'permcom', 'cooldown', 'pricecom', 'paycom', 'disabledCommands', 'hiddenCommands'],
                     keys: [command, command, command, command, command, command, command]
                 }, function (e) {
-                    let cooldownJson = (e.cooldown === null ? {globalSec: -1, userSec: -1, modsSkip: false} : JSON.parse(e.cooldown)),
+                    let cooldownJson = (e.cooldown === null ? {globalSec: -1, userSec: -1, modsSkip: false, clearOnOnline: false} : JSON.parse(e.cooldown)),
                             tokenButton = '';
 
                     if (e.command.match(/\(customapi/gi) !== null) {
@@ -230,6 +230,9 @@ $(function () {
                                         // Append input box for mods skip cooldown.
                                         .append(helpers.getCheckBox('command-cooldown-modsskip', cooldownJson.modsSkip, 'Mods Skip Cooldown',
                                                 'If checked, moderators are exempt from cooldowns on this command.'))
+                                        // Append input box for clear cooldowns on online events
+                                        .append(helpers.getCheckBox('command-cooldown-clearononline', cooldownJson.clearOnOnline, 'Clear Cooldowns at stream start',
+                                                'If checked, the cooldowns for this command will be cleared when you go live.'))
                                         .append(helpers.getCheckBox('command-disabled', e.disabledCommands !== null, 'Disabled',
                                                 'If checked, the command cannot be used in chat.'))
                                         .append(helpers.getCheckBox('command-hidden', e.hiddenCommands !== null, 'Hidden',
@@ -244,6 +247,7 @@ $(function () {
                                 commandCooldownGlobal = $('#command-cooldown-global'),
                                 commandCooldownUser = $('#command-cooldown-user'),
                                 commandCooldownModsSkip = $('#command-cooldown-modsskip').is(':checked') ? '1' : '0',
+                                commandCooldownClearOnOnline = $('#command-cooldown-clearononline').is(':checked') ? '1' : '0',
                                 commandDisabled = $('#command-disabled').is(':checked'),
                                 commandHidden = $('#command-hidden').is(':checked');
 
@@ -273,7 +277,7 @@ $(function () {
                                             commandResponse.val(), JSON.stringify({disabled: commandDisabled})], function () {
                                             // Add the cooldown to the cache.
                                             socket.wsEvent('custom_command_edit_cooldown_ws', './core/commandCoolDown.js', null,
-                                                    ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val(), commandCooldownModsSkip], function () {
+                                                    ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val(), commandCooldownModsSkip, commandCooldownClearOnOnline], function () {
                                                 // Update command permission.
                                                 socket.sendCommand('edit_command_permission_cmd', 'permcomsilent ' + commandName.val() + ' ' +
                                                         helpers.getGroupIdByName(commandPermission.find(':selected').text(), true), function () {
@@ -352,6 +356,9 @@ $(function () {
                             // Append input box for mods skip cooldown.
                             .append(helpers.getCheckBox('command-cooldown-modsskip', false, 'Mods Skip Cooldown',
                                     'If checked, moderators are exempt from cooldowns on this command.'))
+                            // Append input box for clear cooldowns on online events
+                            .append(helpers.getCheckBox('command-cooldown-clearononline', false, 'Clear Cooldowns at stream start',
+                                    'If checked, the cooldowns for this command will be cleared when you go live.'))
                             .append(helpers.getCheckBox('command-disabled', false, 'Disabled',
                                     'If checked, the command cannot be used in chat.'))
                             .append(helpers.getCheckBox('command-hidden', false, 'Hidden',
@@ -366,6 +373,7 @@ $(function () {
                     commandCooldownGlobal = $('#command-cooldown-global'),
                     commandCooldownUser = $('#command-cooldown-user'),
                     commandCooldownModsSkip = $('#command-cooldown-modsskip').is(':checked') ? '1' : '0',
+                    commandCooldownClearOnOnline = $('#command-cooldown-clearononline').is(':checked') ? '1' : '0',
                     commandDisabled = $('#command-disabled').is(':checked'),
                     commandHidden = $('#command-hidden').is(':checked');
 
@@ -402,7 +410,7 @@ $(function () {
                                         ['add', commandName.val(), commandResponse.val(), JSON.stringify({disabled: commandDisabled})], function () {
                                     // Add the cooldown to the cache.
                                     socket.wsEvent('custom_command_cooldown_ws', './core/commandCoolDown.js', null,
-                                            ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val(), commandCooldownModsSkip], function () {
+                                            ['add', commandName.val(), commandCooldownGlobal.val(), commandCooldownUser.val(), commandCooldownModsSkip, commandCooldownClearOnOnline], function () {
                                         // Reload the table.
                                         loadCustomCommands();
                                         // Close the modal.

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -143,7 +143,7 @@ $(function () {
                         tables: ['permcom', 'cooldown', 'pricecom', 'paycom', 'disabledCommands'],
                         keys: [command, command, command, command, command]
                     }, function (e) {
-                        let cooldownJson = (e.cooldown === null ? {globalSec: -1, userSec: -1, modsSkip: false} : JSON.parse(e.cooldown));
+                        let cooldownJson = (e.cooldown === null ? {globalSec: -1, userSec: -1, modsSkip: false, clearOnOnline: false} : JSON.parse(e.cooldown));
 
                         // Get advance modal from our util functions in /utils/helpers.js
                         helpers.getAdvanceModal('edit-command', 'Edit Command', 'Save', $('<form/>', {
@@ -176,6 +176,9 @@ $(function () {
                                             // Append input box for mods skip cooldown.
                                             .append(helpers.getCheckBox('command-cooldown-modsskip', cooldownJson.modsSkip, 'Mods Skip Cooldown',
                                                     'If checked, moderators are exempt from cooldowns on this command.'))
+                                            // Append input box for clear cooldowns on online events
+                                            .append(helpers.getCheckBox('command-cooldown-clearononline', cooldownJson.clearOnOnline, 'Clear Cooldowns at stream start',
+                                                    'If checked, the cooldowns for this command will be cleared when you go live.'))
                                             .append(helpers.getCheckBox('command-disabled', e.disabledCommands !== null, 'Disabled',
                                                     'If checked, the command cannot be used in chat.'))
                                             // Callback function to be called once we hit the save button on the modal.
@@ -186,6 +189,7 @@ $(function () {
                                     commandCooldownGlobal = $('#command-cooldown-global'),
                                     commandCooldownUser = $('#command-cooldown-user'),
                                     commandCooldownModsSkip = $('#command-cooldown-modsskip').is(':checked') ? '1' : '0',
+                                    commandCooldownClearOnOnline = $('#command-cooldown-clearononline').is(':checked') ? '1' : '0',
                                     commandDisabled = $('#command-disabled').is(':checked');
 
                             // Handle each input to make sure they have a value.
@@ -205,7 +209,7 @@ $(function () {
                                         updateCommandDisabled(command, commandDisabled, function () {
                                             // Add the cooldown to the cache.
                                             socket.wsEvent('default_command_edit_cooldown_ws', './core/commandCoolDown.js', null,
-                                                    ['add', command, commandCooldownGlobal.val(), commandCooldownUser.val(), commandCooldownModsSkip], function () {
+                                                    ['add', command, commandCooldownGlobal.val(), commandCooldownUser.val(), commandCooldownModsSkip, commandCooldownClearOnOnline], function () {
                                                 // Edit the command permission.
                                                 socket.sendCommand('default_command_permisison_update', 'permcomsilent ' + command + ' ' +
                                                         helpers.getGroupIdByName(commandPermission.find(':selected').text(), true), function () {


### PR DESCRIPTION
- Adds an option to clear active cooldowns on online event (Allows users to create "single use" commands which can only be used once per stream, even if they stream multiple times a day)
- Adds a command that clears all active cooldowns
- Adds a command that clears the active cooldowns of a specific command
- Refactors the `handleCoolCom`-function and the output messages to reduce code duplication and readability
- Clear active cooldowns if cooldown time is unset (used to only work by changing the cooldown time via command, via panel works now as well)

![image](https://github.com/PhantomBot/PhantomBot/assets/572591/2388c605-cd94-43b5-9c07-6234d5f57fed)
![image](https://github.com/PhantomBot/PhantomBot/assets/572591/53569486-8cd3-4de1-8361-75c5cd6b7af0)
