### PR TITLE
[Feature] Command restrictions + small extras

### DIFF
--- a/javascript-source/core/commandCoolDown.js
+++ b/javascript-source/core/commandCoolDown.js
@@ -580,6 +580,13 @@
         if (event.getScript().equalsIgnoreCase('./core/commandCoolDown.js')) {
             if (event.getArgs()[0].equalsIgnoreCase('add')) {
                 add(event.getArgs()[1], parseInt(event.getArgs()[2]), parseInt(event.getArgs()[3]), $.jsString(event.getArgs()[4]) === '1', $.jsString(event.getArgs()[5]) === '1');
+                let command = $.jsString(event.getArgs()[1]).trim(),
+                    subCommand = null;
+                if (command.indexOf(' ') !== -1) {
+                    subCommand = command.split(' ')[1];
+                    command = command.split(' ')[0];
+                }
+                $.setCommandRestriction(command, subCommand, $.getCommandRestrictionByName($.jsString(event.getArgs()[6])));
             } else if (event.getArgs()[0].equalsIgnoreCase('update')) {
                 defaultCooldownTime = $.getIniDbNumber('cooldownSettings', 'defaultCooldownTime', 5);
                 modCooldown = $.getIniDbBoolean('cooldownSettings', 'modCooldown', false);

--- a/javascript-source/core/commandRegister.js
+++ b/javascript-source/core/commandRegister.js
@@ -383,13 +383,13 @@
      */
     function getCommandRestrictionByName(restrictionName) {
         restrictionName = $.jsString(restrictionName).toLowerCase();
-        if (restrictionName.equalsIgnoreCase('none')) {
+        if ($.equalsIgnoreCase(restrictionName, 'none')) {
             return RESTRICTION.NONE;
         }
-        if (restrictionName.equalsIgnoreCase('online')) {
+        if ($.equalsIgnoreCase(restrictionName, 'online')) {
             return RESTRICTION.ONLINE;
         }
-        if (restrictionName.equalsIgnoreCase('offline')) {
+        if ($.equalsIgnoreCase(restrictionName, 'offline')) {
             return RESTRICTION.OFFLINE;
         }
         return null;

--- a/javascript-source/core/coreCommands.js
+++ b/javascript-source/core/coreCommands.js
@@ -84,7 +84,11 @@
             }
 
             $.say($.lang.get('corecommands.settimevar.success', action, time));
-        } else if (command.equalsIgnoreCase('synconline')) {
+        }
+        /*
+        * @commandpath synconline (silent) - Synchronizes the stream status (online/offline); Specifying the silent parameter suppresses success and failure messages
+        */
+        else if (command.equalsIgnoreCase('synconline')) {
             let silent = false;
             if (action !== undefined && $.jsString(action) === 'silent') {
                 silent = true;
@@ -100,6 +104,41 @@
                 if (!silent) {
                     $.say($.lang.get('corecommands.synconline.failure'));
                 }
+            }
+        }
+        /*
+        * @commandpath setcommandrestriction [none/online/offline] [command] (subcommand) - Set online/offline only restriction for the specific; subcommand is an optional parameter
+        */ 
+        else if (command.equalsIgnoreCase('setcommandrestriction')) {
+            if (action === undefined || args[1] === undefined) {
+                $.say($.lang.get('corecommands.setcommandrestriction.usage'));
+                return;
+            }
+
+            let restriction = $.jsString(action).toLowerCase(),
+                com = $.jsString(args[1]).toLowerCase(),
+                subCom = args.length >= 3 ? $.jsString(args[2]).toLowerCase() : null;
+
+            if ($.getCommandRestrictionByName(restriction) === null) {
+                $.say($.lang.get('corecommands.setcommandrestriction.usage'));
+                return;
+            }
+
+            if(!$.commandExists(com)) {
+                $.say($.lang.get('corecommands.setcommandrestriction.error', 'Command', action));
+                return;
+            }
+
+            if (subCom !== null && !$.subCommandExists(com, subCom)) {
+                $.say($.lang.get('corecommands.setcommandrestriction.error', 'Subcommand', com + " " + subCom));
+                return;
+            }
+
+            $.setCommandRestriction(com, subCom, $.getCommandRestrictionByName(restriction));
+            if (subCom !== null) {
+                $.say($.lang.get('corecommands.setcommandrestriction.success', 'subcommand', com + ' ' + subCom, restriction));
+            } else {
+                $.say($.lang.get('corecommands.setcommandrestriction.success', 'command', com, restriction));
             }
         }
     });
@@ -121,5 +160,6 @@
         $.registerChatCommand('./core/coreCommands.js', 'shoutoutapitoggle', $.PERMISSION.Mod);
         $.registerChatCommand('./core/coreCommands.js', 'settimevar', $.PERMISSION.Mod);
         $.registerChatCommand('./core/coreCommands.js', 'synconline', $.PERMISSION.Mod);
+        $.registerChatCommand('./core/coreCommands.js', 'setcommandrestriction', $.PERMISSION.Admin);
     });
 })();

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -645,8 +645,8 @@
                         Packages.tv.phantombot.PhantomBot.instance().getSession().getModerationStatus();
                     }
 
-                    // Check if the command exists or if the module is disabled.
-                    if (!$.commandExists(command) || !isModuleEnabled($.getCommandScript(command))) {
+                    // Check if the command exists or if the module is disabled or if the command is restricted.
+                    if (!$.commandExists(command) || !isModuleEnabled($.getCommandScript(command)) || !$.commandRestrictionMet(command, subCommand)) {
                         return;
                     }
 

--- a/javascript-source/lang/english/core/core-coreCommands.js
+++ b/javascript-source/lang/english/core/core-coreCommands.js
@@ -24,3 +24,6 @@ $.lang.register('corecommands.settimevar.usage', 'Usage: !settimevar (varName) (
 $.lang.register('corecommands.settimevar.success', 'Set the timevar $1 to the time $2');
 $.lang.register('corecommands.synconline.success', 'Syncing title, game, and online state with Twitch API. This may take a moment');
 $.lang.register('corecommands.synconline.failure', 'Stream status cache is not ready yet, please try again in 30 seconds');
+$.lang.register('corecommands.setcommandrestriction.usage', 'Usage: !setcommandrestriction [none/online/offline] [command] (subcommand) - The subcommand variable is optional');
+$.lang.register('corecommands.setcommandrestriction.error', '$1 !$2 does not exist!');
+$.lang.register('corecommands.setcommandrestriction.success', 'Successfully changed the $1 restriction for !$2 to $3');

--- a/resources/web/panel/js/pages/commands/default.js
+++ b/resources/web/panel/js/pages/commands/default.js
@@ -206,7 +206,7 @@ $(function () {
                                     commandCooldownModsSkip = $('#command-cooldown-modsskip').is(':checked') ? '1' : '0',
                                     commandCooldownClearOnOnline = $('#command-cooldown-clearononline').is(':checked') ? '1' : '0',
                                     commandDisabled = $('#command-disabled').is(':checked'),
-                                    commandRestriction = $('#command-restriction option:selected').text().replace(/\bonly\b/g, '').trim().toLowerCase();
+                                    commandRestriction = $('#command-restriction option:selected').text().replace(/\b(on|only)\b/g, '').trim().toLowerCase();
                             // Handle each input to make sure they have a value.
                             switch (false) {
                                 case helpers.handleInputNumber(commandCost):

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -1346,6 +1346,9 @@ public final class PhantomBot implements Listener {
      * doCheckPhantomBotUpdate
      */
     private void doCheckPhantomBotUpdate() {
+        if (RepoVersion.isEdgeBuild() || RepoVersion.isCustomBuild()) {
+            this.dataStore.del("settings", "newrelease_info");
+        }
         ExecutorService.scheduleAtFixedRate(() -> {
             if (!RepoVersion.isEdgeBuild() && !RepoVersion.isCustomBuild()) {
                 try {


### PR DESCRIPTION
- Adds the ability to set default commands to be online or offline only
- Adds missing commandpath annotation for `synconline`
- Remove the `newrelease_info` key from the database if the bot is running a custom or edge build, so the panel does not keep nagging about an update if that key was present previously

I did not see a better way to do this but deemed this feature as useful for some use cases since we already have matching command tags. Open for suggestions.

Marked as draft until #3264 is merged due to upcoming merge conflicts, which I'll fix once the aforementioned PR is merged

![image](https://github.com/PhantomBot/PhantomBot/assets/572591/d56f698d-459c-43d3-941d-a4cf30e59c23)
![image](https://github.com/PhantomBot/PhantomBot/assets/572591/1efc87e0-0a39-4727-8669-a59cf406cfb7)
