### PR TITLE
Fix discord set and removerole + Update d4j

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <conf name="lib.extra"/>
     </configurations>
     <dependencies defaultconf="default">
-        <dependency org="com.discord4j" name="discord4j-core" rev="3.2.4"/>
+        <dependency org="com.discord4j" name="discord4j-core" rev="3.2.5"/>
         <dependency org="com.h2database" name="h2" rev="2.1.214"/>
         <dependency org="com.h2database" name="h2" rev="1.4.200" conf="lib.extra->default"/>
         <dependency org="com.rollbar" name="rollbar-java" rev="1.10.0"/>

--- a/javascript-source/discord/core/misc.js
+++ b/javascript-source/discord/core/misc.js
@@ -195,7 +195,7 @@
      * @export $.discord
      */
     function setRole(role, username) {
-        return $.discordAPI.addRole(role, username);
+        $.discordAPI.addRole(role, username);
     }
 
     function sanitizeChannelName(channel) {

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2023-05-29 13:40:19</div>
+        2023-06-22 14:16:50</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>


### PR DESCRIPTION
Fixes `addRole` and `removeRole` functions as well as the `setRole` and `removeRole` command tags

Updates `Discord4J` from `3.2.4` to `3.2.5`

Both changes are tested and properly report/handle
- debug flow:
```
[06-22-2023 @ 12:25:29.151 GMT] [DISCORD] [#general] teenystinytony: !role2
[06-22-2023 @ 12:25:29.153 GMT] [DEBUG] [onEvent()@ScriptEventManager.java:80] Dispatched event DiscordChannelMessageEvent
[06-22-2023 @ 12:25:29.155 GMT] [DEBUG] [addRole()@DiscordUtil.java:960] teenystinytony > role2
[06-22-2023 @ 12:25:29.155 GMT] [DEBUG] [getUserAsync()@DiscordUtil.java:744] teenystinytony
[06-22-2023 @ 12:25:29.156 GMT] [DEBUG] [getUserAsync()@DiscordUtil.java:745] 4
[06-22-2023 @ 12:25:29.156 GMT] [DEBUG] [getUserAsync()@DiscordUtil.java:751] 1
[06-22-2023 @ 12:25:29.157 GMT] [DEBUG] [lambda$addRole$92()@DiscordUtil.java:962] Member{} PartialMember{data=MemberData{nick=Possible{Optional.empty}, roles=[J@3ac86fc5, joinedAt=2022-04-04T17:07:20.629000+00:00, premiumSince=Possible{Optional.empty}, deaf=false, mute=false, communicationDisabledUntil=Possible{Optional.empty}, flags=0, user=UserData{id=848684040085307423, globalName=TeenysTinyTony, username=teenystinytony, discriminator=0, banner=Possible.absent, accentColor=Possible.absent, bot=Possible.absent, system=Possible.absent, mfaEnabled=Possible.absent, locale=Possible.absent, verified=Possible.absent, email=Possible.absent, flags=Possible.absent, premiumType=Possible.absent, publicFlags=Possible{0}}, pending=Possible{false}, permissions=Possible.absent}, guildId=944720672217772154} User{data=UserData{id=848684040085307423, globalName=TeenysTinyTony, username=teenystinytony, discriminator=0, banner=Possible.absent, accentColor=Possible.absent, bot=Possible.absent, system=Possible.absent, mfaEnabled=Possible.absent, locale=Possible.absent, verified=Possible.absent, email=Possible.absent, flags=Possible.absent, premiumType=Possible.absent, publicFlags=Possible{0}}}
[06-22-2023 @ 12:25:29.158 GMT] [DEBUG] [getRoleAsync()@DiscordUtil.java:815] role2
[06-22-2023 @ 12:25:29.158 GMT] [DEBUG] [getRoleAsync()@DiscordUtil.java:816] 4
[06-22-2023 @ 12:25:29.159 GMT] [DEBUG] [getRoleAsync()@DiscordUtil.java:822] 1
[06-22-2023 @ 12:25:29.160 GMT] [DEBUG] [lambda$addRole$93()@DiscordUtil.java:975] Role{data=RoleData{id=1121330707571163146, name=role2, color=3066993, hoist=true, permissions=1879049360, mentionable=true, icon=Possible{Optional.empty}, unicodeEmoji=Possible{Optional.empty}, tags=Possible{RoleTagsData{botId=Possible.absent, integrationId=Possible.absent, premiumSubscriber=Possible.absent}}, position=1, managed=false}, guildId=944720672217772154}
[06-22-2023 @ 12:25:29.163 GMT] [DEBUG] [onEvent()@ScriptEventManager.java:80] Dispatched event DiscordChannelCommandEvent
```

- errors and exceptions:
```
[06-22-2023 @ 12:25:22.524 GMT] [DISCORD] [#general] teenystinytony: !role3
[06-22-2023 @ 12:25:22.529 GMT] [DEBUG] [onEvent()@ScriptEventManager.java:80] Dispatched event DiscordChannelMessageEvent
[06-22-2023 @ 12:25:22.531 GMT] [DEBUG] [addRole()@DiscordUtil.java:960] teenystinytony > Te1232st
[06-22-2023 @ 12:25:22.533 GMT] [DEBUG] [getUserAsync()@DiscordUtil.java:744] teenystinytony
[06-22-2023 @ 12:25:22.534 GMT] [DEBUG] [getUserAsync()@DiscordUtil.java:745] 4
[06-22-2023 @ 12:25:22.535 GMT] [DEBUG] [getUserAsync()@DiscordUtil.java:751] 1
[06-22-2023 @ 12:25:22.536 GMT] [DEBUG] [lambda$addRole$92()@DiscordUtil.java:962] Member{} PartialMember{data=MemberData{nick=Possible{Optional.empty}, roles=[J@3fad7792, joinedAt=2022-04-04T17:07:20.629000+00:00, premiumSince=Possible{Optional.empty}, deaf=false, mute=false, communicationDisabledUntil=Possible{Optional.empty}, flags=0, user=UserData{id=848684040085307423, globalName=TeenysTinyTony, username=teenystinytony, discriminator=0, banner=Possible.absent, accentColor=Possible.absent, bot=Possible.absent, system=Possible.absent, mfaEnabled=Possible.absent, locale=Possible.absent, verified=Possible.absent, email=Possible.absent, flags=Possible.absent, premiumType=Possible.absent, publicFlags=Possible{0}}, pending=Possible{false}, permissions=Possible.absent}, guildId=944720672217772154} User{data=UserData{id=848684040085307423, globalName=TeenysTinyTony, username=teenystinytony, discriminator=0, banner=Possible.absent, accentColor=Possible.absent, bot=Possible.absent, system=Possible.absent, mfaEnabled=Possible.absent, locale=Possible.absent, verified=Possible.absent, email=Possible.absent, flags=Possible.absent, premiumType=Possible.absent, publicFlags=Possible{0}}}
[06-22-2023 @ 12:25:22.538 GMT] [DEBUG] [getRoleAsync()@DiscordUtil.java:815] Te1232st
[06-22-2023 @ 12:25:22.540 GMT] [DEBUG] [getRoleAsync()@DiscordUtil.java:816] 4
[06-22-2023 @ 12:25:22.541 GMT] [DEBUG] [getRoleAsync()@DiscordUtil.java:822] 0
[lambda$getRoleAsync$72()@DiscordUtil.java:828]
java.util.NoSuchElementException: Unable to find roleName [Te1232st]
        at tv.phantombot.discord.util.DiscordUtil.getRoleAsync(DiscordUtil.java:826)
        at tv.phantombot.discord.util.DiscordUtil.addRole(DiscordUtil.java:974)
        at tv.phantombot.discord.util.DiscordUtil.lambda$addRole$92(DiscordUtil.java:963)
        at reactor.core.publisher.LambdaMonoSubscriber.onNext(LambdaMonoSubscriber.java:171)
        at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onNext(MonoPeekTerminal.java:180)
        at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onNext(FluxMap.java:224)
        at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:74)
        at reactor.core.publisher.Operators$MonoInnerProducerBase.complete(Operators.java:2811)
        at reactor.core.publisher.MonoSingle$SingleSubscriber.onComplete(MonoSingle.java:180)
        at reactor.core.publisher.FluxLimitRequest$FluxLimitRequestSubscriber.onNext(FluxLimitRequest.java:104)
        at reactor.core.publisher.FluxFilter$FilterSubscriber.onNext(FluxFilter.java:113)
        at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:74)
        at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
        at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
        at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:122)
        at reactor.core.publisher.FluxFlatMap$FlatMapMain.tryEmitScalar(FluxFlatMap.java:489)
        at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:422)
        at reactor.core.publisher.FluxFlattenIterable$FlattenIterableSubscriber.drainAsync(FluxFlattenIterable.java:453)
        at reactor.core.publisher.FluxFlattenIterable$FlattenIterableSubscriber.drain(FluxFlattenIterable.java:724)
        at reactor.core.publisher.FluxFlattenIterable$FlattenIterableSubscriber.onNext(FluxFlattenIterable.java:256)
        at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:74)
        at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onNext(FluxFilterFuseable.java:118)
        at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2545)
        at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.request(FluxFilterFuseable.java:191)
        at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2341)
        at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2215)
        at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onSubscribe(FluxFilterFuseable.java:87)
        at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55)
        at reactor.core.publisher.Mono.subscribe(Mono.java:4485)
        at reactor.core.publisher.Mono.subscribeWith(Mono.java:4551)
        at reactor.core.publisher.Mono.subscribe(Mono.java:4452)
        at reactor.core.publisher.Mono.subscribe(Mono.java:4388)
        at reactor.core.publisher.Mono.subscribe(Mono.java:4335)
        at tv.phantombot.discord.util.DiscordUtil.addRole(DiscordUtil.java:961)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:206)
        at org.mozilla.javascript.NativeJavaMethod.call(NativeJavaMethod.java:211)
        at org.mozilla.javascript.optimizer.OptRuntime.call2(OptRuntime.java:46)
        at org.mozilla.javascript.gen.misc_js_179._c_setRole_11(misc.js:198)
        at org.mozilla.javascript.gen.misc_js_179.call(misc.js)
        at org.mozilla.javascript.optimizer.OptRuntime.call2(OptRuntime.java:46)
        at org.mozilla.javascript.gen.discord_js_116._c_setrole_9(discord.js:181)
        at org.mozilla.javascript.gen.discord_js_116.call(discord.js)
        at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:35)
        at org.mozilla.javascript.gen.commandTags_js_93._c_tags_7(commandTags.js:243)
        at org.mozilla.javascript.gen.commandTags_js_93.call(commandTags.js)
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:52)
        at org.mozilla.javascript.gen.customCommands_js_184._c_anonymous_4(customCommands.js:71)
        at org.mozilla.javascript.gen.customCommands_js_184.call(customCommands.js)
        at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:35)
        at org.mozilla.javascript.gen.init_js_1._c_callHook_26(init.js:496)
        at org.mozilla.javascript.gen.init_js_1.call(init.js)
        at org.mozilla.javascript.optimizer.OptRuntime.callName(OptRuntime.java:59)
        at org.mozilla.javascript.gen.init_js_1._c_anonymous_32(init.js:836)
        at org.mozilla.javascript.gen.init_js_1.call(init.js)
        at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:380)
        at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3868)
        at org.mozilla.javascript.gen.init_js_1.call(init.js)
        at org.mozilla.javascript.InterfaceAdapter.invokeImpl(InterfaceAdapter.java:166)
        at org.mozilla.javascript.InterfaceAdapter.lambda$invoke$0(InterfaceAdapter.java:116)
        at org.mozilla.javascript.Context.call(Context.java:535)
        at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:472)
        at org.mozilla.javascript.InterfaceAdapter.invoke(InterfaceAdapter.java:116)
        at org.mozilla.javascript.jdk18.VMBridge_jdk18$1.invoke(VMBridge_jdk18.java:126)
        at com.sun.proxy.$Proxy16.handle(Unknown Source)
        at tv.phantombot.script.ScriptEventManager.onEvent(ScriptEventManager.java:77)
        at jdk.internal.reflect.GeneratedMethodAccessor44.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at net.engio.mbassy.dispatch.ReflectiveHandlerInvocation.invoke(ReflectiveHandlerInvocation.java:29)
        at net.engio.mbassy.dispatch.MessageDispatcher.dispatch(MessageDispatcher.java:30)
        at net.engio.mbassy.dispatch.FilteredMessageDispatcher.dispatch(FilteredMessageDispatcher.java:42)
        at net.engio.mbassy.subscription.Subscription.publish(Subscription.java:72)
        at net.engio.mbassy.bus.MessagePublication.execute(MessagePublication.java:49)
        at net.engio.mbassy.bus.AbstractSyncAsyncMessageBus$1.run(AbstractSyncAsyncMessageBus.java:67)
        at java.base/java.lang.Thread.run(Unknown Source)
[06-22-2023 @ 12:25:22.553 GMT] [DEBUG] [onEvent()@ScriptEventManager.java:80] Dispatched event DiscordChannelCommandEvent
```