### PR TITLE
Fix point usage being printed when it shouldn't

### DIFF
--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -429,6 +429,7 @@
                             $.getPointsString(actionArg2), $.viewer.getByLogin(actionArg1).name(), getPointsString(getUserPoints(actionArg1))));
                 }
 
+                $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.usage.invalid', '!' + command));
                 return;
             }
 
@@ -705,8 +706,6 @@
                 $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.active.bonus.set', getPointsString(activeBonus)));
                 return;
             }
-
-            $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.usage.invalid', '!' + command));
         }
 
 

--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -389,7 +389,7 @@
 
             // Replace everything that is not \w
             action = $.user.sanitize(action);
-            if ($.user.isKnown(action)) {
+            if ($.user.isKnown(action) && (actionArg1 === null || actionArg1 === undefined || actionArg1 === '')) {
                 $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.user.success', $.viewer.getByLogin(action).name(), getPointsString(getUserPoints(action))));
                 return;
             }

--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -389,7 +389,7 @@
 
             // Replace everything that is not \w
             action = $.user.sanitize(action);
-            if ($.user.isKnown(action) && (actionArg1 === null || actionArg1 === undefined || actionArg1 === '')) {
+            if ((actionArg1 === null || actionArg1 === undefined || actionArg1 === '') && $.user.isKnown(action)) {
                 $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.user.success', $.viewer.getByLogin(action).name(), getPointsString(getUserPoints(action))));
                 return;
             }


### PR DESCRIPTION
- Do not print the usage message if it's not needed
- Only assume `!points (user)` is meant if there are no further arguments