### PR TITLE
[Panel User] Add restart and manage_user permissions

### DIFF
--- a/resources/web/panel/js/index.js
+++ b/resources/web/panel/js/index.js
@@ -518,7 +518,7 @@ $(function () {
      * @param {Boolean}      enabled
      * @param {Function}     callback
      */
-    socket.addPanelUser = function (callback_id, username, permission, enabled, callback) {
+    socket.addPanelUser = function (callback_id, username, permission, enabled, canRestartBot, canManageUsers, callback) {
         // Genetate a callback.
         generateCallBack(callback_id, [], false, true, callback);
 
@@ -528,7 +528,9 @@ $(function () {
             add: {
                 username: String(username),
                 permission: String(permission),
-                enabled: enabled
+                enabled: enabled,
+                canRestartBot: canRestartBot,
+                canManageUsers: canManageUsers
             }
         });
     };
@@ -561,7 +563,7 @@ $(function () {
      * @param {Boolean}      enabled
      * @param {Function}     callback
      */
-    socket.editPanelUser = function (callback_id, currentUsername, newUsername, permission, enabled, callback) {
+    socket.editPanelUser = function (callback_id, currentUsername, newUsername, permission, enabled, canRestartBot, canManageUsers, callback) {
         // Genetate a callback.
         generateCallBack(callback_id, [], false, true, callback);
 
@@ -572,7 +574,9 @@ $(function () {
                 currentUsername: String(currentUsername),
                 newUsername: String(newUsername),
                 permission: String(permission),
-                enabled: enabled
+                enabled: enabled,
+                canRestartBot: canRestartBot,
+                canManageUsers: canManageUsers
             }
         });
     };

--- a/resources/web/panel/js/pages/global.js
+++ b/resources/web/panel/js/pages/global.js
@@ -107,7 +107,9 @@ $(function () {
         }
     });
 
-    socket.wsEvent('restart-bot-check', 'RestartRunner', '', [], function (e) {});
+    if (!helpers.currentPanelUserData.canRestartBot) {
+        socket.wsEvent('restart-bot-check', 'RestartRunner', '', [], function (e) {});
+    }
 
     // the button that signs out.
     $('#sign-out-btn').on('click', function () {
@@ -185,8 +187,11 @@ $(function () {
         if (helpers.currentPanelUserData.userType === 'CONFIG') {
             $('[data-removeForConfigUser="true"]').remove();//Panel user is defined in the config
         } else {
-            $('[data-removeForCantRestart="true"]').remove();
             $('[data-removeForNonConfigUser="true"]').remove();
+        }
+
+        if (!helpers.currentPanelUserData.canRestartBot) {
+            $('[data-removeForCantRestart="true"]').remove();
         }
 
         if (!helpers.currentPanelUserData.canManageUsers) { //Remove panel user manager

--- a/resources/web/panel/js/pages/global.js
+++ b/resources/web/panel/js/pages/global.js
@@ -107,7 +107,7 @@ $(function () {
         }
     });
 
-    if (!helpers.currentPanelUserData.canRestartBot) {
+    if (helpers.currentPanelUserData.canRestartBot) {
         socket.wsEvent('restart-bot-check', 'RestartRunner', '', [], function (e) {});
     }
 

--- a/source/com/gmt2001/httpwsserver/auth/WsSharedRWTokenAuthenticationHandler.java
+++ b/source/com/gmt2001/httpwsserver/auth/WsSharedRWTokenAuthenticationHandler.java
@@ -171,7 +171,7 @@ public class WsSharedRWTokenAuthenticationHandler implements WsAuthenticationHan
                         astr = jso.getString("readauth");
                     }
 
-                    if (ctx.channel().attr(ATTR_AUTH_USER).get() != null) {
+                    if (this.allowPaneluser && ctx.channel().attr(ATTR_AUTH_USER).get() != null) {
                         ctx.channel().attr(ATTR_AUTHENTICATED).set(Boolean.TRUE);
                         ctx.channel().attr(ATTR_SENT_AUTH_REPLY).set(Boolean.TRUE);
                         ctx.channel().attr(ATTR_IS_READ_ONLY).set(Boolean.TRUE);
@@ -186,7 +186,9 @@ public class WsSharedRWTokenAuthenticationHandler implements WsAuthenticationHan
                         ctx.channel().attr(ATTR_IS_READ_ONLY).set(Boolean.TRUE);
                         ctx.channel().attr(ATTR_SENT_AUTH_REPLY).set(Boolean.TRUE);
                         com.gmt2001.Console.debug.println("ROToken");
-                    } else {
+                    }
+
+                    if (this.allowPaneluser && ctx.channel().attr(ATTR_AUTH_USER).get() == null) {
                         PanelUser user = PanelUserHandler.checkAuthTokenAndGetUser(astr);
                         com.gmt2001.Console.debug.println("user=" + (user == null ? "null" : user.getUsername() + (user.isConfigUser() ? " (config)" : "")));
                         if (user != null) {
@@ -249,7 +251,7 @@ public class WsSharedRWTokenAuthenticationHandler implements WsAuthenticationHan
             if (user != null) {
                 ctx.channel().attr(ATTR_AUTHENTICATED).set(Boolean.TRUE);
                 ctx.channel().attr(ATTR_AUTH_USER).set(user);
-                //return true;
+                return true;
             }
         }
 

--- a/source/tv/phantombot/console/ConsoleEventHandler.java
+++ b/source/tv/phantombot/console/ConsoleEventHandler.java
@@ -817,7 +817,7 @@ public final class ConsoleEventHandler implements Listener {
                 /**
                  * @consolecommand paneluser resetpermission username - Gives a panel user full access to all panel sections if the user exists
                  */
-                else if (argument[0].equalsIgnoreCase("resetpassword")) {
+                else if (argument[0].equalsIgnoreCase("resetpermission")) {
                     PanelUserHandler.PanelMessage response =PanelUserHandler.editUser(argument[1], null, PanelUserHandler.getFullAccessPermissions(), false);
                     com.gmt2001.Console.out.println("New password for user " + argument[1] + " is:");
                     com.gmt2001.Console.out.println(response.getMessage());

--- a/source/tv/phantombot/panel/PanelUser/PanelUser.java
+++ b/source/tv/phantombot/panel/PanelUser/PanelUser.java
@@ -59,15 +59,15 @@ public final class PanelUser {
     /**
      * Constructor used for new user creations
      */
-    private PanelUser(String username, Map<String, Permission> permissions, boolean enabled) {
-        this(username, permissions, Type.NEW, enabled, false);
+    private PanelUser(String username, Map<String, Permission> permissions, boolean enabled, boolean canManageUsers, boolean canRestartBot) {
+        this(username, permissions, Type.NEW, enabled, false, canManageUsers, canRestartBot);
     }
 
     /**
      * Constructor used for the user defined in botlogin.txt
      */
     private PanelUser(String username, String password) {
-        this(username, PanelUserHandler.getFullAccessPermissions(), Type.CONFIG, true, true);
+        this(username, PanelUserHandler.getFullAccessPermissions(), Type.CONFIG, true, true, true, true);
         this.password = password;
         this.generateNewAuthToken();
     }
@@ -75,12 +75,14 @@ public final class PanelUser {
     /**
      * Internal constructor
      */
-    private PanelUser(String username, Map<String, Permission> permissions, Type userType, boolean enabled, boolean hasSetPassword) {
+    private PanelUser(String username, Map<String, Permission> permissions, Type userType, boolean enabled, boolean hasSetPassword, boolean canManageUsers, boolean canRestartBot) {
         this.username = username;
         this.setPermission(permissions);
         this.userType = userType;
         this.enabled = enabled;
         this.hasSetPassword = hasSetPassword;
+        this.setManageUserPermission(canManageUsers);
+        this.setRestartPermission(canRestartBot);
     }
 
     /**
@@ -121,12 +123,12 @@ public final class PanelUser {
      * The user's current websocket authentication token
      * <br /><br />
      * A new token will automatically be generated and the user saved if there is no current token
-     * @param recurse prevents recursion if {@code true}
+     * @param blockRecursion prevents recursion if {@code true}
      * @return The user's current websocket authentication token
      * @see WsPanelHandler#handleFrame() token usage
      */
-    String getAuthToken(boolean recurse) {
-        if (!recurse && (this.token == null || this.token.isEmpty())) {
+    String getAuthToken(boolean blockRecursion) {
+        if (!blockRecursion && (this.token == null || this.token.isEmpty())) {
             generateNewAuthToken();
             if(this.userType == Type.DATABASE) {
                 this.save();
@@ -201,7 +203,38 @@ public final class PanelUser {
      * @return {@code true} if allowed
      */
     public boolean canManageUsers() {
-        return this.isConfigUser();
+        return this.isConfigUser() || (permissions.containsKey("canManageUsers") && permissions.get("canManageUsers").equals(Permission.READ_WRITE));
+    }
+
+    /**
+     * Allows or disallows the user to mange other user
+     * @param permission {@code true} allows the user to manage users; {@code false} prohibits it
+     */
+    void setManageUserPermission(boolean permission) {
+        this.permissions.put("canManageUsers", permission ? Permission.READ_WRITE : Permission.READ_ONLY);
+        if (permission && !this.permissions.containsKey("settings")) {
+            this.permissions.put("settings", Permission.READ_ONLY);
+        }
+    }
+
+    /**
+     * Indicates if this user is allowed to restart the bot
+     *
+     * @return {@code true} if allowed
+     */
+    public boolean canRestartBot() {
+        return this.isConfigUser() || (permissions.containsKey("canRestartBot") && permissions.get("canRestartBot").equals(Permission.READ_WRITE));
+    }
+
+    /**
+     * Allows or disallows the user to restart the bot
+     * @param permission {@code true} allows the user to restart the bot; {@code false} prohibits it
+     */
+    void setRestartPermission(boolean permission) {
+        this.permissions.put("canRestartBot", permission ? Permission.READ_WRITE : Permission.READ_ONLY);
+        if (permission && !this.permissions.containsKey("settings")) {
+            this.permissions.put("settings", Permission.READ_ONLY);
+        }
     }
 
     private void setCreationDateNOW(){
@@ -230,7 +263,7 @@ public final class PanelUser {
      */
     void setPermission(Map<String, Permission> permissions) {
         if (!permissions.containsKey("dashboard")) {
-            permissions.put("dashboard", PanelUserHandler.Permission.READ_ONLY);
+            permissions.put("dashboard", Permission.READ_ONLY);
         }
         this.permissions = permissions;
     }
@@ -280,7 +313,7 @@ public final class PanelUser {
         JSONObject userJO = new JSONObject();
         userJO.put("pass", this.password);
         userJO.put("token", this.token);
-        userJO.put("permissions", this.getPermissionsToJSON(false));
+        userJO.put("permissions", this.getPermissionsToJSON(false, true));
         userJO.put("enabled", this.enabled);
         userJO.put("hasSetPassword", this.hasSetPassword);
         userJO.put("lastLogin", this.lastLogin);
@@ -294,9 +327,22 @@ public final class PanelUser {
      * @return A {@link JSONArray} with the users permissions
      */
     JSONArray getPermissionsToJSON(boolean asDisplayName) {
+        return getPermissionsToJSON(asDisplayName, false);
+    }
+
+    /**
+     * Gets the users {@link PanelUserHandler.Permission permissions} as a {@link JSONArray}
+     * @param asDisplayName Indicates if the {@link PanelUserHandler.Permission permissions} should be included with their display name
+     * @param isSave Indicates if the {@link JSONArray} will be used to save the user; If {@code true}, special permissions will be included as well
+     * @return A {@link JSONArray} with the users permissions
+     */
+    private JSONArray getPermissionsToJSON(boolean asDisplayName, boolean isSave) {
         JSONArray permissionsJSON = new JSONArray();
         int counter = 0;
         for (Map.Entry<String, Permission> entry : this.permissions.entrySet()) {
+            if (!isSave && (entry.getKey().equalsIgnoreCase("canRestartBot") || entry.getKey().equalsIgnoreCase("canManageUsers"))) {
+                continue;
+            }
             JSONObject permissionJSON = new JSONObject();
             permissionJSON.put("section", entry.getKey());
             permissionJSON.put("permission", (asDisplayName ? entry.getValue().getDisplayName() : entry.getValue().getValue()));
@@ -365,11 +411,22 @@ public final class PanelUser {
      * @return The password generated for the new user
      */
     public static String create(String username, Map<String, Permission> permissions, boolean enabled) {
+        return create(username, permissions, enabled, false, false);
+    }
+
+    /**
+     * Creates a new panel user and saves the user in the database
+     * @param username The username of the new panel user
+     * @param permission The user's {@link PanelUserHandler.Permission permissions}; {@code null} to assign no permissions}
+     * @param enabled {@code true} to enable the user; {@code false} to disable the user
+     * @return The password generated for the new user
+     */
+    public static String create(String username, Map<String, Permission> permissions, boolean enabled, boolean canManageUsers, boolean canRestartBot) {
         if (permissions == null) {
             permissions = new HashMap<>();
         }
 
-        PanelUser user = new PanelUser(username, permissions, enabled);
+        PanelUser user = new PanelUser(username, permissions, enabled, canManageUsers, canRestartBot);
         user.setCreationDateNOW();
         user.generateNewAuthToken();
         String password = user.generateNewPassword();
@@ -405,11 +462,18 @@ public final class PanelUser {
         return LookupByAuthToken(token, false);
     }
 
-    private static PanelUser LookupByAuthToken(String token, boolean recurse) {
+    /**
+     * Looks up a panel user by their websocket token
+     * @param token the websocket token to lookup
+     * @param blockRecursion prevents recursion if {@code true}
+     * @return The user if a user with the queried token has been found; {@code null} otherwise
+     * @see PanelUser#LookupByUsername(String)
+     */
+    private static PanelUser LookupByAuthToken(String token, boolean blockRecursion) {
         String username = null;
         if (token.equals(CaselessProperties.instance().getProperty("webauth")) || token.equals(CaselessProperties.instance().getProperty("webauthro"))) {
             username = CaselessProperties.instance().getProperty("paneluser", "panel");
-        } else if (PROPUSER != null && token.equals(PROPUSER.getAuthToken(recurse))) {
+        } else if (PROPUSER != null && token.equals(PROPUSER.getAuthToken(blockRecursion))) {
             return PROPUSER;
         } else {
             DataStore dataStore = PhantomBot.instance().getDataStore();

--- a/source/tv/phantombot/panel/WsPanelHandler.java
+++ b/source/tv/phantombot/panel/WsPanelHandler.java
@@ -313,7 +313,7 @@ public class WsPanelHandler implements WsFrameHandler {
         }
 
         PanelUser user = ctx.channel().attr(WsSharedRWTokenAuthenticationHandler.ATTR_AUTH_USER).get();
-        if (user != null && !PanelUserHandler.checkPanelUserScriptAccess(user, script, args, (jso.has("section") ? jso.getString("section") : ""))) {
+        if (user != null && !uniqueID.equalsIgnoreCase("restart-bot-check") && !PanelUserHandler.checkPanelUserScriptAccess(user, script, args, (jso.has("section") ? jso.getString("section") : ""))) {
             this.panelNotification(ctx, "permission", PanelUserHandler.PanelMessage.InsufficientPermissions.getMessage(), "Permissions error");
             return;
         }
@@ -410,15 +410,19 @@ public class WsPanelHandler implements WsFrameHandler {
         } else if (jso.has("add")) {
             String username = jso.getJSONObject("add").getString("username");
             JSONArray permission = new JSONArray(jso.getJSONObject("add").getString("permission"));
-            Boolean enabled = jso.getJSONObject("add").getBoolean("enabled");
-            PanelUserHandler.PanelMessage response = PanelUserHandler.createNewUser(username, permission, enabled);
+            boolean enabled = jso.getJSONObject("add").getBoolean("enabled");
+            boolean canManageUsers = jso.getJSONObject("edit").getBoolean("canManageUsers");
+            boolean canRestartBot = jso.getJSONObject("edit").getBoolean("canRestartBot");
+            PanelUserHandler.PanelMessage response = PanelUserHandler.createNewUser(username, permission, enabled, canManageUsers, canRestartBot);
             jsonObject.object().key(response.getJSONkey()).value(response.getMessage()).endObject();
         } else if (jso.has("edit")) {
             String currentUsername = jso.getJSONObject("edit").getString("currentUsername");
             String newUsername = jso.getJSONObject("edit").getString("newUsername");
             JSONArray permission = new JSONArray(jso.getJSONObject("edit").getString("permission"));
-            Boolean enabled = jso.getJSONObject("edit").getBoolean("enabled");
-            PanelUserHandler.PanelMessage response = PanelUserHandler.editUser(currentUsername, newUsername, permission, enabled);
+            boolean enabled = jso.getJSONObject("edit").getBoolean("enabled");
+            boolean canManageUsers = jso.getJSONObject("edit").getBoolean("canManageUsers");
+            boolean canRestartBot = jso.getJSONObject("edit").getBoolean("canRestartBot");
+            PanelUserHandler.PanelMessage response = PanelUserHandler.editUser(currentUsername, newUsername, permission, enabled, canManageUsers, canRestartBot);
             jsonObject.object().key(response.getJSONkey()).value(response.getMessage()).endObject();
         } else if (jso.has("resetPassword")) {
             String username = jso.getString("resetPassword");


### PR DESCRIPTION
Adds checkboxes which enable bot owners to allow panel users to:
- Restart the bot (via the panel) [closes #3304]
- Mange other panel users

Reverts some changes from the [GH-login hotfix](https://github.com/PhantomBot/PhantomBot/pull/3300/commits/c17f932b178657ebf0b04341f21c02bddd0d7f66) due to the config user generating a random token even though `webauth` is already the config user's token. No infinite recursion can occur anymore. Login has been tested locally and on the remote panel for the config user and database users