### PR TITLE
Reduce CPU-time during userUpdate

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -946,20 +946,16 @@
                 values = [];
 
         // Process new users list
-        for (let i = 0; i < chatters.size(); i++) {
+        for (let i = 0; i < newUsers.length; i++) {
             let username = $.jsString(chatters.get(i).login().toLowerCase());
             if (isTwitchBot(username)) {
                 continue;
             }
 
-            if (!isOwner(username)) { //Ignore bots and users that are constantly in chat anyway
-                if (chatters.get(i).lastSeen() === Packages.java.time.Instant.MIN) {
-                    keys.push(username);
-                    values.push('true');
-                    restoreSubscriberStatus(username);
-                } else if (chatters.get(i).lastSeen().minusMillis($.systemTime()).toEpochMilli() <= 86.4 * 1e6) { //Only try to restore status if the user has not been seen in a day
-                    restoreSubscriberStatus(username);
-                }
+            if (!isOwner(username) && !$.users.includes(username)) { //Ignore already known users and bots as well as the streamer
+                keys.push(username);
+                values.push('true');
+                restoreSubscriberStatus(username);
             }
 
             newUsers.push(username);

--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -932,35 +932,45 @@
      * @event ircChannelJoinUpdate
      */
     $.bind('ircChannelUsersUpdate', function (event) {
-        setTimeout(function () {
-            // Don't allow other events to add or remove users.
-            isUpdatingUsers = true;
 
-            let chatters = event.chatters(),
-                    newUsers = [],
-                    keys = [],
-                    values = [];
+        if (isUpdatingUsers) {
+            return; //Skip this update run
+        }
 
-            // Handle joins.
-            for (let i = 0; i < chatters.size(); i++) {
-                let username = $.jsString(chatters.get(i).toLowerCase());
-                $.restoreSubscriberStatus(username);
-                keys.push(username);
-                values.push('true');
+        // Don't allow other events to add or remove users.
+        isUpdatingUsers = true;
 
-                if (isTwitchBot(username)) {
-                    continue;
-                }
+        let chatters = event.chatters(),
+                newUsers = [],
+                keys = [],
+                values = [];
 
-                newUsers.push(username);
+        // Process new users list
+        for (let i = 0; i < chatters.size(); i++) {
+            let username = $.jsString(chatters.get(i).login().toLowerCase());
+            if (isTwitchBot(username)) {
+                continue;
             }
 
-            $.users = newUsers;
+            if (!isOwner(username)) { //Ignore bots and users that are constantly in chat anyway
+                if (chatters.get(i).lastSeen() === Packages.java.time.Instant.MIN) {
+                    keys.push(username);
+                    values.push('true');
+                    restoreSubscriberStatus(username);
+                } else if (chatters.get(i).lastSeen().minusMillis($.systemTime()).toEpochMilli() <= 86.4 * 1e6) { //Only try to restore status if the user has not been seen in a day
+                    restoreSubscriberStatus(username);
+                }
+            }
 
+            newUsers.push(username);
+        }
+
+        $.users = newUsers;
+        isUpdatingUsers = false;
+
+        if (keys.length !== 0) {
             $.inidb.SetBatchString('visited', '', keys, values);
-
-            isUpdatingUsers = false;
-        }, 0, 'core::permissions.js::ircChannelUsersUpdate');
+        }
     });
 
     /**

--- a/source/com/gmt2001/twitch/cache/ViewerCache.java
+++ b/source/com/gmt2001/twitch/cache/ViewerCache.java
@@ -168,11 +168,11 @@ public final class ViewerCache implements Listener {
     }
 
     /**
-     * Sends IrcChannelUsersUpdateEvent if a change has ocurred
+     * Sends IrcChannelUsersUpdateEvent if a change has occurred
      */
     private void sendUpdate() {
         if (this.chattersUpdated(false)) {
-            EventBus.instance().postAsync(new IrcChannelUsersUpdateEvent(this.viewers.entrySet().stream().filter(kv -> kv.getValue().inChat()).map(kv -> kv.getValue().login()).collect(Collectors.toList())));
+            EventBus.instance().postAsync(new IrcChannelUsersUpdateEvent(this.viewers.entrySet().stream().filter(kv -> kv.getValue().inChat()).map(kv -> kv.getValue()).collect(Collectors.toList())));
         }
     }
 

--- a/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
+++ b/source/tv/phantombot/event/irc/channel/IrcChannelUsersUpdateEvent.java
@@ -19,6 +19,7 @@ package tv.phantombot.event.irc.channel;
 import java.util.Collections;
 import java.util.List;
 
+import com.gmt2001.twitch.cache.Viewer;
 import tv.phantombot.twitch.irc.TwitchSession;
 
 /**
@@ -26,14 +27,14 @@ import tv.phantombot.twitch.irc.TwitchSession;
  * @author gmt2001
  */
 public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
-    private final List<String> chatters;
+    private final List<Viewer> chatters;
 
     /**
      * Constructor
      *
      * @param chatters A list of login names for users who are currently in chat
      */
-    public IrcChannelUsersUpdateEvent(List<String> chatters) {
+    public IrcChannelUsersUpdateEvent(List<Viewer> chatters) {
         super(null);
         this.chatters = Collections.unmodifiableList(chatters);
     }
@@ -92,7 +93,7 @@ public class IrcChannelUsersUpdateEvent extends IrcChannelEvent {
      *
      * @return A list of login names for users who are currently in chat
      */
-    public List<String> chatters() {
+    public List<Viewer> chatters() {
         return this.chatters;
     }
 }


### PR DESCRIPTION
- Only run `restoreSubscriberStatus()` for users that have recently joined
- Exempt the streamer, the bot and other TwitchBots from invoking `restoreSubscriberStatus()`