### PR TITLE
[Panel User] GUI improvements & fix

### DIFF
--- a/resources/web/panel/js/pages/settings/panelUsers.js
+++ b/resources/web/panel/js/pages/settings/panelUsers.js
@@ -145,13 +145,24 @@ $(function () {
                 return;
             }
 
-            availableSections.push(section);
-            if (availableSections.length > 0) {
-                $('#userPermissionAdd-button').attr('disabled', false);
+            if (!availableSections.includes(section)) {
+                availableSections.push(section);
+                if (availableSections.length > 0) {
+                    $('#userPermissionAdd-button').attr('disabled', false);
+                }
             }
 
             permissions.splice(idx, 1);
             userPermissionTable.DataTable().row($(this).parents('tr')).remove().draw();
+            if (addRequiredPermissions(permissions, 'dashboard', 'Read Only')) {
+                userPermissionTable.DataTable().row.add(getPermissionTableRow('dashboard', 'Read Only')).draw();
+            }
+
+            if ($('#user-canManageUsers').is(':checked')) {
+                if (addRequiredPermissions(permissions, 'settings', 'Read Only')) {
+                    userPermissionTable.DataTable().row.add(getPermissionTableRow('settings', 'Read Only')).draw();
+                }
+            }
         });
 
         //Add permission
@@ -169,7 +180,7 @@ $(function () {
 
                 if (allSections) { //Add all available sections
                     for (let section in availableSections) {
-                        let idx = findSectionIndex(permissions, section);
+                        let idx = findSectionIndex(permissions, availableSections[section]);
                         if (idx >= 0) {
                             permissions[idx].permission = selectedPerm;
                             $('button[data-section="' + availableSections[section] + '"]').parents('td').siblings('.section-permission').text(selectedPerm);
@@ -194,8 +205,9 @@ $(function () {
                             permission: selectedPerm
                         });
                         userPermissionTable.DataTable().row.add(getPermissionTableRow(selectedSection, selectedPerm));
-                        availableSections.splice(availableSections.indexOf(selectedSection), 1);
                     }
+
+                    availableSections.splice(availableSections.indexOf(selectedSection), 1);
                 }
 
                 if (availableSections.length === 0) {

--- a/resources/web/panel/js/pages/settings/panelUsers.js
+++ b/resources/web/panel/js/pages/settings/panelUsers.js
@@ -119,7 +119,7 @@ $(function () {
                 'columnDefs': [
                     {'className': 'default-table', 'orderable': true, 'targets': [0, 1]},
                     {'width': '40%', 'targets': 0},
-                    {'width': '20%', 'targets': 1},
+                    {'className': 'section-permission', 'width': '20%', 'targets': 1},
                     {'className': 'text-center', 'width': '10%', 'targets': 2, 'orderable': false}
                 ],
                 'columns': [
@@ -169,22 +169,33 @@ $(function () {
 
                 if (allSections) { //Add all available sections
                     for (let section in availableSections) {
-                        permissions.push({
-                            section: availableSections[section],
-                            permission: selectedPerm
-                        });
-
-                        userPermissionTable.DataTable().row.add(getPermissionTableRow(availableSections[section], selectedPerm));
+                        let idx = findSectionIndex(permissions, section);
+                        if (idx >= 0) {
+                            permissions[idx].permission = selectedPerm;
+                            $('button[data-section="' + availableSections[section] + '"]').parents('td').siblings('.section-permission').text(selectedPerm);
+                        } else {
+                            permissions.push({
+                                section: availableSections[section],
+                                permission: selectedPerm
+                            });
+                            userPermissionTable.DataTable().row.add(getPermissionTableRow(availableSections[section], selectedPerm));
+                        }
                     }
 
                     availableSections = [];
                 } else { //Add single section
-                    permissions.push({
-                        section: selectedSection,
-                        permission: selectedPerm
-                    });
-                    userPermissionTable.DataTable().row.add(getPermissionTableRow(selectedSection, selectedPerm));
-                    availableSections.splice(availableSections.indexOf(selectedSection), 1);
+                    let idx = findSectionIndex(permissions, selectedSection);
+                    if (idx >= 0) { //Handle present required permissions (only Read-Only)
+                        permissions[idx].permission = selectedPerm;
+                        $('button[data-section="' + selectedSection + '"]').parents('td').siblings('.section-permission').text(selectedPerm);
+                    } else {
+                        permissions.push({
+                            section: selectedSection,
+                            permission: selectedPerm
+                        });
+                        userPermissionTable.DataTable().row.add(getPermissionTableRow(selectedSection, selectedPerm));
+                        availableSections.splice(availableSections.indexOf(selectedSection), 1);
+                    }
                 }
 
                 if (availableSections.length === 0) {
@@ -421,7 +432,11 @@ $(function () {
                         let userPermissionTable = $('#user-permissions-table'),
                                 canManageUsersCheckBox = $('#user-canManageUsers');
 
-                        addRequiredPermissions(permissions, 'dashboard', 'Read Only');
+                        getPermissionTable(userPermissionTable, permissions);
+                        if (addRequiredPermissions(permissions, 'dashboard', 'Read Only')) {
+                            userPermissionTable.DataTable().row.add(getPermissionTableRow('dashboard', 'Read Only')).draw();
+                        }
+
                         canManageUsersCheckBox.on('change', function (e) {
                             if (e.target.checked) {
                                 if (addRequiredPermissions(permissions, 'settings', 'Read Only')) {
@@ -429,7 +444,6 @@ $(function () {
                                 }
                             }
                         });
-                        getPermissionTable(userPermissionTable, permissions);
                     }).modal('toggle');
                 });
             });
@@ -483,7 +497,11 @@ $(function () {
             let userPermissionTable = $('#user-permissions-table'),
                     canManageUsersCheckBox = $('#user-canManageUsers');
 
-            addRequiredPermissions(permissions, 'dashboard', 'Read Only');
+            getPermissionTable(userPermissionTable, permissions);
+            if (addRequiredPermissions(permissions, 'dashboard', 'Read Only')) {
+                userPermissionTable.DataTable().row.add(getPermissionTableRow('dashboard', 'Read Only')).draw();
+            }
+
             canManageUsersCheckBox.on('change', function (e) {
                 if (e.target.checked) {
                     if (addRequiredPermissions(permissions, 'settings', 'Read Only')) {
@@ -491,7 +509,6 @@ $(function () {
                     }
                 }
             });
-            getPermissionTable(userPermissionTable, permissions);
         }).modal('toggle');
     });
 });

--- a/source/tv/phantombot/panel/WsPanelHandler.java
+++ b/source/tv/phantombot/panel/WsPanelHandler.java
@@ -432,8 +432,8 @@ public class WsPanelHandler implements WsFrameHandler {
             String username = jso.getJSONObject("add").getString("username");
             JSONArray permission = new JSONArray(jso.getJSONObject("add").getString("permission"));
             boolean enabled = jso.getJSONObject("add").getBoolean("enabled");
-            boolean canManageUsers = jso.getJSONObject("edit").getBoolean("canManageUsers");
-            boolean canRestartBot = jso.getJSONObject("edit").getBoolean("canRestartBot");
+            boolean canManageUsers = jso.getJSONObject("add").getBoolean("canManageUsers");
+            boolean canRestartBot = jso.getJSONObject("add").getBoolean("canRestartBot");
             PanelUserHandler.PanelMessage response = PanelUserHandler.createNewUser(username, permission, enabled, canManageUsers, canRestartBot);
             jsonObject.object().key(response.getJSONkey()).value(response.getMessage()).endObject();
         } else if (jso.has("edit")) {


### PR DESCRIPTION
- Fix: cannot add new users on current nightlies caused by a copy and paste mistake in #3309 
- Fix: cannot add `Full Access` permission to sections which have been added as part of a requirement (i.e `Dashboard - Read Only` & `Settings - Read Only`)
- Improve permission management flow: Ensure required permissions are always shown and cannot be removed