### PR TITLE
Change order to allow panel to open

### DIFF
--- a/docs/panel/js/utils/helpers.js
+++ b/docs/panel/js/utils/helpers.js
@@ -1606,12 +1606,6 @@ $(function () {
 
     const ipRegex = /(?<ip>(?<ipv4>(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[0-9])\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[0-9])\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[0-9])\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[0-9]))|(?<ipv6>(?:::)?(?:[0-9a-fA-F]{1,4}(?:::|:)){2,7}(?:[0-9a-fA-F]{1,4}|)|(?:::[0-9a-fA-F]{1,4})|(?:[0-9a-fA-F]{1,4}::(?:[0-9a-fA-F]{1,4})?)))/;
 
-    helpers.canEmbedTwitch = function() {
-        return location.protocol.toLowerCase().startsWith('https') && location.hostname.includes('.') && !ipRegex.test(location.hostname) && (location.port === '' || location.port === 443);
-    };
-
-    helpers.CANT_EMBED_TWITCH_TEXT = 'Due to changes by Twitch, the live feed panel can no longer be displayed unless you enable SSL on the PhantomBot Panel and change the baseport to 443 or setup a reverse proxy. This may not work without root privileges.<br /><br />Alternatively, you can login using the GitHub version of the panel at <a href="https://phantombot.dev/">PhantomBot</a> which gets around this issue.<br /><br />For help setting up SSL, please see <a href="https://phantombot.dev/guides/#guide=content/integrations/twitchembeds&channel=' + helpers.getBranch() + '">this guide</a>.';
-
     /** Takes an object {} and an array [] of keys.
     * Foreach key in keys:
     *   If obj has the key, and its value is typeof string that starts with '{',
@@ -1643,6 +1637,12 @@ $(function () {
     helpers.getBranch = function () {
         return helpers.isNightly() ? 'nightly' : 'stable';
     };
+
+    helpers.canEmbedTwitch = function() {
+        return location.protocol.toLowerCase().startsWith('https') && location.hostname.includes('.') && !ipRegex.test(location.hostname) && (location.port === '' || location.port === 443);
+    };
+
+    helpers.CANT_EMBED_TWITCH_TEXT = 'Due to changes by Twitch, the live feed panel can no longer be displayed unless you enable SSL on the PhantomBot Panel and change the baseport to 443 or setup a reverse proxy. This may not work without root privileges.<br /><br />Alternatively, you can login using the GitHub version of the panel at <a href="https://phantombot.dev/">PhantomBot</a> which gets around this issue.<br /><br />For help setting up SSL, please see <a href="https://phantombot.dev/guides/#guide=content/integrations/twitchembeds&channel=' + helpers.getBranch() + '">this guide</a>.';
 
     // Export.
     window.helpers = helpers;


### PR DESCRIPTION
Per this thread:
https://discord.com/channels/107910097937682432/1132292565551566858 Panel would not load, claiming 
`helpers.getBranch is not a function`
I assume because it was not yet a function in the order of declarations. I moved helpers.canEmbedTwitch and helpers.CANT... down below where it was declared and it works now.

Disclaimer:  I am using http, not https.  It is possible that someone with https would get past this error, though I doubt it, because it's in the initial declarations.  Maybe those who aren't seeing this error are lucky enough to have the older js cached.