### PR TITLE
Fix #3323

### DIFF
--- a/resources/web/panel/js/pages/dashboard/dashboard.js
+++ b/resources/web/panel/js/pages/dashboard/dashboard.js
@@ -141,7 +141,7 @@ $(function () {
                 // Set stream title.
                 $('#stream-title').val(e.title);
                 // Set stream game.
-                if ($('#stream-game').find("option[value='" + e.game + "']").length) {
+                if ($('#stream-game').find('option[value="' + e.game + '"]').length) {
                     $('#stream-game').val(e.game).trigger('change');
                 } else {
                     // Create a DOM Option and pre-select by default


### PR DESCRIPTION
Instead of escaping ... reorder the single and double quotes. Confirmed working as well:

![image](https://github.com/PhantomBot/PhantomBot/assets/572591/97ce4624-6f2a-4c49-b516-98f50ed94c2f)
