### PR TITLE
Fix Dashboard and Settings section permission not editable for existing users

### DIFF
--- a/resources/web/panel/js/pages/settings/panelUsers.js
+++ b/resources/web/panel/js/pages/settings/panelUsers.js
@@ -99,9 +99,12 @@ $(function () {
 
         for (let i in permissions) {
             userPermissionTable.DataTable().row.add(getPermissionTableRow(permissions[i].section, permissions[i].permission));
-            let index = availableSections.indexOf(permissions[i].section.toLowerCase());
-            if (index >= 0) {
-                availableSections.splice(index, 1);
+            if (!(permissions[i].section === 'dashboard' && permissions[i].permission === 'Read Only') //Do not remove the dashboard from the available sections if the default ("Read Only") is currently assinged
+                && !($('#user-canManageUsers').is(':checked') && permissions[i].section === 'settings' && permissions[i].permission === 'Read Only')) { //Do not remove settings from the available sections if it's set to "Read Only" and the user should manage panel users
+                let index = availableSections.indexOf(permissions[i].section.toLowerCase());
+                if (index >= 0) {
+                    availableSections.splice(index, 1);
+                }
             }
         }
 

--- a/resources/web/panel/js/pages/settings/panelUsers.js
+++ b/resources/web/panel/js/pages/settings/panelUsers.js
@@ -118,6 +118,7 @@ $(function () {
                 'autoWidth': false,
                 'lengthChange': false,
                 'bPaginate': true,
+                'pageLength': 6,
                 'data': [],
                 'columnDefs': [
                     {'className': 'default-table', 'orderable': true, 'targets': [0, 1]},

--- a/resources/web/panel/js/pages/settings/panelUsers.js
+++ b/resources/web/panel/js/pages/settings/panelUsers.js
@@ -115,7 +115,6 @@ $(function () {
                 'autoWidth': false,
                 'lengthChange': false,
                 'bPaginate': true,
-                'pageLength': 6,
                 'data': [],
                 'columnDefs': [
                     {'className': 'default-table', 'orderable': true, 'targets': [0, 1]},
@@ -155,6 +154,15 @@ $(function () {
 
             permissions.splice(idx, 1);
             userPermissionTable.DataTable().row($(this).parents('tr')).remove().draw();
+            if (addRequiredPermissions(permissions, 'dashboard', 'Read Only')) {
+                userPermissionTable.DataTable().row.add(getPermissionTableRow('dashboard', 'Read Only')).draw();
+            }
+
+            if ($('#user-canManageUsers').is(':checked')) {
+                if (addRequiredPermissions(permissions, 'settings', 'Read Only')) {
+                    userPermissionTable.DataTable().row.add(getPermissionTableRow('settings', 'Read Only')).draw();
+                }
+            }
         });
 
         //Add permission


### PR DESCRIPTION
- Fixes the "dashboard"-section not immediately being shown as a valid option for adding "Full Access" permissions when editing an existing user. Before this change, this the "Read Only" dashboard permission had to be deleted before it could be upgraded to full access.
- Fixes the "settings"-section not immediately being shown as a valid option when adding permission when editing an existing user's permissions. This is no possible if the "Manages panel users" checkbox is checked and the "settings"-section permission are set to "Read Only"