### PR TITLE
[PointSystem] Prevent erroneously printed errormessage

### DIFF
--- a/javascript-source/systems/pointSystem.js
+++ b/javascript-source/systems/pointSystem.js
@@ -423,6 +423,7 @@
                     $.inidb.incr('points', actionArg1, actionArg2);
                     $.say($.lang.get('pointsystem.add.success',
                             $.getPointsString(actionArg2), $.viewer.getByLogin(actionArg1).name(), getPointsString(getUserPoints(actionArg1))));
+                    return;
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('pointsystem.usage.invalid', '!' + command));


### PR DESCRIPTION
Do not tell the user that some of the passed options are invalid, even if giving or adding points to a user has been successful.