### PR TITLE
Fix welcome system for first time chatters

### DIFF
--- a/javascript-source/systems/welcomeSystem.js
+++ b/javascript-source/systems/welcomeSystem.js
@@ -54,8 +54,8 @@
                 return;
             }
 
-            var lastUserMessage = $.getIniDbNumber('greetingCoolDown', sender),
-                    firstTimeChatter = lastUserMessage === undefined,
+            var lastUserMessage = $.optIniDbNumber('greetingCoolDown', sender).get(),
+                    firstTimeChatter = lastUserMessage === null,
                     queue = firstTimeChatter ? welcomeQueueFirst : welcomeQueue;
 
             lastUserMessage = firstTimeChatter ? 0 : lastUserMessage;


### PR DESCRIPTION
The system treated everyone like a returning chatter.

It seems like the db number getter was changed at some point to return `0` instead of `undefined` if the entry is missing.