### PR TITLE
Improved design of Emote Cache and related classes

### DIFF
--- a/javascript-source/handlers/emotesBttvHandler.js
+++ b/javascript-source/handlers/emotesBttvHandler.js
@@ -69,7 +69,9 @@
     });
 
     $.bind('emotesCacheUpdated', function (event) {
-        prepareLocalCache(event.getBttvEmotes());
+        if(event.getEmoteSets()[emoteProvider]){
+            prepareLocalCache(event.getEmoteSets()[emoteProvider]);
+        }
     });
 
     $.bind('initReady', function () {

--- a/javascript-source/handlers/emotesFfzHandler.js
+++ b/javascript-source/handlers/emotesFfzHandler.js
@@ -69,7 +69,9 @@
     });
 
     $.bind('emotesCacheUpdated', function (event) {
-        prepareLocalCache(event.getFfzEmotes());
+        if(event.getEmoteSets()[emoteProvider]){
+            prepareLocalCache(event.getEmoteSets()[emoteProvider]);
+        }
     });
 
     $.bind('initReady', function () {

--- a/source/tv/phantombot/event/emotes/EmotesCacheUpdatedEvent.java
+++ b/source/tv/phantombot/event/emotes/EmotesCacheUpdatedEvent.java
@@ -1,5 +1,6 @@
 package tv.phantombot.event.emotes;
 
+import org.apache.commons.lang3.Validate;
 import org.mozilla.javascript.NativeObject;
 
 /**
@@ -10,51 +11,40 @@ import org.mozilla.javascript.NativeObject;
  */
 public class EmotesCacheUpdatedEvent extends EmotesEvent {
     /**
-     * Contents of the bttvEmote Cache
-     * Format: {
-     * global: {
-     * id: String,
-     * code: String,
-     * imageType: String
-     * },
-     * local: {
-     * ...
-     * },
-     * shared: {
-     * ...
-     * }
-     * }
+     * Object with provider as key and an object with keys local, shared and global as value.
+     * <pre>
+     *     {
+     *         "providerName": {
+     *             "local": [
+     *             {
+     *                 "id": "someId",
+     *                 "code": "someCode"
+     *             },
+     *             {
+     *                 "id": "otherId",
+     *                 "code": "otherCode"
+     *             }
+     *             ],
+     *             "shared": [],
+     *             "global": null
+     *         },
+     *         "otherProvider": {
+     *             "local": [],
+     *             "shared": null,
+     *             "global": []
+     *         }
+     *     }
+     * </pre>
      */
-    private final NativeObject bttvEmotes;
+    private final NativeObject emoteSets;
 
-    /**
-     * Contents of the ffzEmote Cache
-     * Format: {
-     * global: {
-     * id: String,
-     * code: String,
-     * },
-     * local: {
-     * ...
-     * },
-     * shared: {
-     * ...
-     * }
-     * }
-     */
-    private final NativeObject ffzEmotes;
-
-    public EmotesCacheUpdatedEvent(NativeObject bttvEmotes, NativeObject ffzEmotes) {
+    public EmotesCacheUpdatedEvent(NativeObject emoteSets) {
         super();
-        this.bttvEmotes = bttvEmotes;
-        this.ffzEmotes = ffzEmotes;
+        Validate.notNull(emoteSets);
+        this.emoteSets = emoteSets;
     }
 
-    public NativeObject getBttvEmotes() {
-        return this.bttvEmotes;
-    }
-
-    public NativeObject getFfzEmotes() {
-        return this.ffzEmotes;
+    public NativeObject getEmoteSets(){
+        return this.emoteSets;
     }
 }

--- a/source/tv/phantombot/event/emotes/EmotesGetEvent.java
+++ b/source/tv/phantombot/event/emotes/EmotesGetEvent.java
@@ -16,75 +16,21 @@
  */
 package tv.phantombot.event.emotes;
 
-import org.json.JSONObject;
+import tv.phantombot.cache.EmotesCache;
+
+import java.util.List;
 
 public class EmotesGetEvent extends EmotesEvent {
+    private final List<EmotesCache.EmotesSet> emotesSet;
 
-    private final JSONObject twitchEmotes;
-    private final JSONObject bttvEmotes;
-    private final JSONObject bttvLocalEmotes;
-    private final JSONObject ffzEmotes;
-    private final JSONObject ffzLocalEmotes;
-
-    /**
-     * Class constructor
-     *
-     * @param twitchEmotes
-     * @param bttvEmotes
-     * @param bttvLocalEmotes
-     * @param ffzEmotes
-     * @param ffzLocalEmotes
-     */
-    public EmotesGetEvent(JSONObject twitchEmotes, JSONObject bttvEmotes, JSONObject bttvLocalEmotes, JSONObject ffzEmotes, JSONObject ffzLocalEmotes) {
-        this.twitchEmotes = twitchEmotes;
-        this.bttvEmotes = bttvEmotes;
-        this.bttvLocalEmotes = bttvLocalEmotes;
-        this.ffzEmotes = ffzEmotes;
-        this.ffzLocalEmotes = ffzLocalEmotes;
+    public EmotesGetEvent(List<EmotesCache.EmotesSet> emotesSet) {
+        if (emotesSet == null) {
+            throw new IllegalArgumentException("EmotesSet cannot be null");
+        }
+        this.emotesSet = emotesSet;
     }
 
-    /**
-     * Method that returns the JSONObject emotes from Twitch.
-     *
-     * @param twitchEmotes
-     */
-    public JSONObject getTwitchEmotes() {
-        return this.twitchEmotes;
-    }
-
-    /**
-     * Method that returns the JSONObject emotes from bttv.
-     *
-     * @param bttvEmotes
-     */
-    public JSONObject getBttvEmotes() {
-        return this.bttvEmotes;
-    }
-
-    /**
-     * Method that returns the JSONObject emotes from bttv local emotes.
-     *
-     * @param bttvLocalEmotes
-     */
-    public JSONObject getBttvLocalEmotes() {
-        return this.bttvLocalEmotes;
-    }
-
-    /**
-     * Method that returns the JSONObject emotes from ffz.
-     *
-     * @param ffzEmotes
-     */
-    public JSONObject getFfzEmotes() {
-        return this.ffzEmotes;
-    }
-
-    /**
-     * Method that returns the JSONObject emotes from ffz local emotes.
-     *
-     * @param ffzLocalEmotes
-     */
-    public JSONObject getFfzLocalEmotes() {
-        return this.ffzLocalEmotes;
+    public List<EmotesCache.EmotesSet> getEmotesSet() {
+        return this.emotesSet;
     }
 }

--- a/source/tv/phantombot/twitch/emotes/BttvApiV3.java
+++ b/source/tv/phantombot/twitch/emotes/BttvApiV3.java
@@ -1,0 +1,113 @@
+/* astyle --style=java --indent=spaces=4 */
+
+/*
+ * Copyright (C) 2016-2023 phantombot.github.io/PhantomBot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package tv.phantombot.twitch.emotes;
+
+import com.gmt2001.httpclient.HttpClient;
+import com.gmt2001.httpclient.HttpClientResponse;
+import com.gmt2001.httpclient.URIUtil;
+import com.gmt2001.twitch.cache.ViewerCache;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/*
+ * Communicates with the BetterTwitchTV v3 API server.
+ *
+ * @author IllusionaryOne
+ * @author Radipiz
+ */
+public class BttvApiV3 implements EmoteProvider {
+
+    public static final String PROVIDER_NAME = "bttv";
+    private static BttvApiV3 instance;
+    private static final String APIURL = "https://api.betterttv.net/3/cached";
+
+    public static synchronized EmoteProvider instance() {
+        if (instance == null) {
+            instance = new BttvApiV3();
+        }
+        return instance;
+    }
+
+    private BttvApiV3() {
+        Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
+    }
+
+    private static HttpClientResponse readJsonFromUrl(String urlAddress) {
+        return HttpClient.get(URIUtil.create(urlAddress));
+    }
+
+    private void checkResponseForError(HttpClientResponse response) throws EmoteApiRequestFailedException {
+        if (response.hasException()) {
+            throw new EmoteApiRequestFailedException(response.exception());
+        } else if (!response.isSuccess()) {
+            throw new EmoteApiRequestFailedException(response.responseBody());
+        }
+    }
+
+    private List<EmoteEntry> mapEmotesFromData(JSONArray jsonArray) {
+        return StreamSupport.stream(jsonArray.spliterator(), false)
+                .map(data -> new EmoteEntry(((JSONObject) data).getString("id"), ((JSONObject) data).getString("code")))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<EmoteEntry> getGlobalEmotes() throws EmoteApiRequestFailedException {
+        HttpClientResponse response = readJsonFromUrl(APIURL + "/emotes/global");
+        checkResponseForError(response);
+        try {
+            // Global Emotes returns a JSON array that cannot be parsed by JSONObject in HttpClientResponse
+            JSONArray responseData = new JSONArray(response.responseBody());
+            return mapEmotesFromData(responseData);
+        } catch (Exception ex) {
+            throw new EmoteApiRequestFailedException("Could not process returned json", ex);
+        }
+    }
+
+
+    @Override
+    public List<EmoteEntry> getSharedEmotes() throws EmoteApiRequestFailedException {
+        HttpClientResponse response = readJsonFromUrl(APIURL + "/users/twitch/" + ViewerCache.instance().broadcaster().id());
+        checkResponseForError(response);
+        try {
+            return mapEmotesFromData(response.json().getJSONArray("sharedEmotes"));
+        } catch (Exception ex) {
+            throw new EmoteApiRequestFailedException("Could not process returned json", ex);
+        }
+    }
+
+    @Override
+    public List<EmoteEntry> getLocalEmotes() throws EmoteApiRequestFailedException {
+        HttpClientResponse response = readJsonFromUrl(APIURL + "/users/twitch/" + ViewerCache.instance().broadcaster().id());
+        checkResponseForError(response);
+        try {
+            return mapEmotesFromData(response.json().getJSONArray("channelEmotes"));
+        } catch (Exception ex) {
+            throw new EmoteApiRequestFailedException("Could not process returned json", ex);
+        }
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+}

--- a/source/tv/phantombot/twitch/emotes/EmoteApiRequestFailedException.java
+++ b/source/tv/phantombot/twitch/emotes/EmoteApiRequestFailedException.java
@@ -1,0 +1,16 @@
+package tv.phantombot.twitch.emotes;
+
+public class EmoteApiRequestFailedException extends Exception {
+    public EmoteApiRequestFailedException(final String message) {
+        this(message, null);
+    }
+
+    public EmoteApiRequestFailedException(final Throwable cause) {
+        this(cause != null ? cause.getMessage() : null, cause);
+    }
+
+    public EmoteApiRequestFailedException(final String message, final Throwable cause) {
+        super(message);
+        if (cause != null) super.initCause(cause);
+    }
+}

--- a/source/tv/phantombot/twitch/emotes/EmoteEntry.java
+++ b/source/tv/phantombot/twitch/emotes/EmoteEntry.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016-2023 phantombot.github.io/PhantomBot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package tv.phantombot.twitch.emotes;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Represents an emote in its most basic form
+ */
+public class EmoteEntry {
+    private final String id;
+    private final String code;
+
+    public EmoteEntry(String id, String code) {
+        Validate.notEmpty(id, "id can't be empty");
+        Validate.notEmpty(id, "code can't be empty");
+        this.id = id;
+        this.code = code;
+    }
+
+    /**
+     * Gets the id that is often used to retrieve the corresponding image
+     *
+     * @return a string containing the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the code that is assigned to the emote and gets replaced by the image
+     *
+     * @return a string containing the code that triggers the emote and gets replaced
+     */
+    public String getCode() {
+        return code;
+    }
+
+    public String toString() {
+        return "EmoteEntry(id=" + this.getId() + ", code=" + this.getCode() + ")";
+    }
+}

--- a/source/tv/phantombot/twitch/emotes/EmoteProvider.java
+++ b/source/tv/phantombot/twitch/emotes/EmoteProvider.java
@@ -1,0 +1,40 @@
+package tv.phantombot.twitch.emotes;
+
+import java.util.List;
+
+public interface EmoteProvider {
+
+    /**
+     * Returns the name of the provider (for code usage, not for human reading)
+     * @return the codename of the provider
+     */
+    String getProviderName();
+
+    /**
+     * Retrieves all emotes which are local to the channel by the emote provider
+     * @return list of all emotes local to the channel of the provider or null if not supported
+     * @throws EmoteApiRequestFailedException when the api request or parsing of the response fails
+     */
+    default List<EmoteEntry> getLocalEmotes() throws EmoteApiRequestFailedException {
+        return null;
+    }
+
+    /**
+     * Retrieves all emotes which are selected from a shared pool of the emote provider and thus
+     * not exclusive to the channel but allowed to use under the terms of the provider
+     * @return list of all the selected shared emotes of the provider or null if not supported
+     * @throws EmoteApiRequestFailedException when the api request or parsing of the response fails
+     */
+    default List<EmoteEntry> getSharedEmotes() throws EmoteApiRequestFailedException {
+        return null;
+    }
+
+    /**
+     * Retrieves all emotes which are globally available to all users of the emote provider
+     * @return list of all globally available emotes of the provider or null if not supported
+     * @throws EmoteApiRequestFailedException when the api request or parsing of the response fails
+     */
+    default List<EmoteEntry> getGlobalEmotes() throws EmoteApiRequestFailedException {
+        return null;
+    }
+}

--- a/source/tv/phantombot/twitch/emotes/FrankerFacezApiV1.java
+++ b/source/tv/phantombot/twitch/emotes/FrankerFacezApiV1.java
@@ -1,0 +1,114 @@
+/* astyle --style=java --indent=spaces=4 */
+
+/*
+ * Copyright (C) 2016-2023 phantombot.github.io/PhantomBot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package tv.phantombot.twitch.emotes;
+
+import com.gmt2001.httpclient.HttpClient;
+import com.gmt2001.httpclient.HttpClientResponse;
+import com.gmt2001.httpclient.URIUtil;
+import com.gmt2001.twitch.cache.ViewerCache;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/*
+ * Communicates with the BetterTwitchTV v3 API server.
+ *
+ * @author IllusionaryOne
+ * @author Radipiz
+ */
+public class FrankerFacezApiV1 implements EmoteProvider {
+
+    public static final String PROVIDER_NAME = "ffz";
+    private static FrankerFacezApiV1 instance;
+    private static final String APIURL = "https://api.frankerfacez.com/v1";
+
+    public static synchronized EmoteProvider instance() {
+        if (instance == null) {
+            instance = new FrankerFacezApiV1();
+        }
+        return instance;
+    }
+
+    private FrankerFacezApiV1() {
+        Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
+    }
+
+    private static HttpClientResponse readJsonFromUrl(String urlAddress) {
+        return HttpClient.get(URIUtil.create(urlAddress));
+    }
+
+    private void checkResponseForError(HttpClientResponse response) throws EmoteApiRequestFailedException {
+        if (response.hasException()) {
+            throw new EmoteApiRequestFailedException(response.exception());
+        } else if (!response.isSuccess()) {
+            throw new EmoteApiRequestFailedException(response.responseBody());
+        }
+    }
+
+    private List<EmoteEntry> mapEmotesFromData(JSONArray jsonArray) {
+        return StreamSupport.stream(jsonArray.spliterator(), false)
+                .map(data -> new EmoteEntry(String.valueOf(((JSONObject) data).get("id")), ((JSONObject) data).getString("name")))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<EmoteEntry> getGlobalEmotes() throws EmoteApiRequestFailedException {
+        HttpClientResponse response = readJsonFromUrl(APIURL + "/set/global");
+        checkResponseForError(response);
+        try {
+            // FrankerFaceZ can return multiple sets of global emotes
+            // It announces the numeric ids in "default_sets". This id is used as key
+            // in the key for the collection in "sets"
+            // The following stream reduces the emotes of multiple sets into a single
+            // List object containing EmoteEntry
+            JSONObject responseData = response.json();
+            return StreamSupport.stream(responseData.getJSONArray("default_sets").spliterator(), false)
+                    .map(setId -> mapEmotesFromData(responseData.getJSONObject("sets")
+                            .getJSONObject(String.valueOf(setId))
+                            .getJSONArray("emoticons")))
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+
+        } catch (Exception ex) {
+            throw new EmoteApiRequestFailedException("Could not process returned json", ex);
+        }
+    }
+
+    @Override
+    public List<EmoteEntry> getSharedEmotes() throws EmoteApiRequestFailedException {
+        HttpClientResponse response = readJsonFromUrl(APIURL + "/room/id/" + ViewerCache.instance().broadcaster().id());
+        checkResponseForError(response);
+        try {
+            String setId = String.valueOf(response.json().getJSONObject("room").get("set"));
+            return mapEmotesFromData(response.json().getJSONObject("sets").getJSONObject(setId).getJSONArray("emoticons"));
+        } catch (Exception ex) {
+            throw new EmoteApiRequestFailedException("Could not process returned json", ex);
+        }
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+}


### PR DESCRIPTION
Hi again,
since 7tv app seems to get adopted more, PhantomBot should support it. But I've noticed the EmoteCache isn't really ready to extend it more. So I wanted to start with some cleanup. The changes are compatible with the current installation. No migration is necessary.

What I've done is basically:
* Defining an Interface `EmoteProvider`
* Let `EmoteCache` retrieve a common format from all providers
* Use loops instead of repeated logic

It ran for quite a while and a few streams. I've noticed commit ec778a3 where a NPE was fixed. Probably happened when EmoteCache started it's work too early. I decided to keep it where it was and protect the emote providers on a single place instead of doing NPE checks everywhere.
