### PR TITLE
Polls api Implementation

### DIFF
--- a/resources/web/oauth/scopes.json
+++ b/resources/web/oauth/scopes.json
@@ -46,6 +46,10 @@
             "desc": "Run commercials on a channel.",
             "tooltip": "Used to run commercials."
         },
+        "channel:manage:polls" : {
+            "desc": "Manage a channel’s polls.",
+            "tooltip": "Used to start or end Twitch native polls."
+        },
         "channel:manage:predictions" : {
             "desc": "Manage of channel's Channel Points Predictions.",
             "tooltip": "Used to start or end predictions."

--- a/source/tv/phantombot/twitch/api/Helix.java
+++ b/source/tv/phantombot/twitch/api/Helix.java
@@ -29,6 +29,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -2563,33 +2564,35 @@ public class Helix {
     /**
      * Gets a list of polls that the broadcaster created.
      * Polls are available for 90 days after they’re created.
+     *
      * @param pollIds A list of IDs that identify the polls to return. You may specify a maximum of 20 IDs.
-     *           Specify this parameter only if you want to filter the list that the request returns.
-     *           The endpoint ignores duplicate IDs and those not owned by this broadcaster.
-     * @param first The maximum number of items to return per page in the response.
-     *              The minimum page size is 1 item per page and the maximum is 20 items per page. The default is 20.
-     * @param after The cursor used to get the next page of results. The Pagination object in the response contains
-     *              the cursor’s value.
+     *                Specify this parameter only if you want to filter the list that the request returns.
+     *                The endpoint ignores duplicate IDs and those not owned by this broadcaster.
+     * @param first   The maximum number of items to return per page in the response.
+     *                The minimum page size is 1 item per page and the maximum is 20 items per page. The default is 20.
+     * @param after   The cursor used to get the next page of results. The Pagination object in the response contains
+     *                the cursor’s value.
      * @return A list of polls. The list is empty if the broadcaster hasn’t created polls.
-     * @throws JSONException when the result object could not be parsed
+     * @throws JSONException            when the result object could not be parsed
      * @throws IllegalArgumentException when more ids are passed than the API allows
      */
-    public JSONObject getPolls(List<String> pollIds, int first, String after){
+    public JSONObject getPolls(List<String> pollIds, int first, String after) {
         return getPollsAsync(pollIds, first, after).block();
     }
 
     /**
      * Gets a list of polls that the broadcaster created.
      * Polls are available for 90 days after they’re created.
+     *
      * @param pollIds A list of IDs that identify the polls to return. You may specify a maximum of 20 IDs.
-     *           Specify this parameter only if you want to filter the list that the request returns.
-     *           The endpoint ignores duplicate IDs and those not owned by this broadcaster.
-     * @param first The maximum number of items to return per page in the response.
-     *              The minimum page size is 1 item per page and the maximum is 20 items per page. The default is 20.
-     * @param after The cursor used to get the next page of results. The Pagination object in the response contains
-     *              the cursor’s value.
+     *                Specify this parameter only if you want to filter the list that the request returns.
+     *                The endpoint ignores duplicate IDs and those not owned by this broadcaster.
+     * @param first   The maximum number of items to return per page in the response.
+     *                The minimum page size is 1 item per page and the maximum is 20 items per page. The default is 20.
+     * @param after   The cursor used to get the next page of results. The Pagination object in the response contains
+     *                the cursor’s value.
      * @return A list of polls. The list is empty if the broadcaster hasn’t created polls.
-     * @throws JSONException when the result object could not be parsed
+     * @throws JSONException            when the result object could not be parsed
      * @throws IllegalArgumentException when more ids are passed than the API allows
      */
     public Mono<JSONObject> getPollsAsync(List<String> pollIds, int first, String after)
@@ -2612,6 +2615,133 @@ public class Helix {
                 + this.qspValid("&after", after);
 
         return this.handleQueryAsync(endpoint, () -> this.handleRequest(HttpMethod.GET, endpoint));
+    }
+
+    /**
+     * Creates a poll that viewers in the broadcaster’s channel can vote on.
+     * The poll begins as soon as it’s created. You may run only one poll at a time.
+     *
+     * @param title                The question that viewers will vote on. For example, What game should I play next? The question
+     *                             may contain a maximum of 60 characters.
+     * @param choices              A list of choices each with a maximum of 25 characters, that viewers may choose from.
+     *                             The list must contain a minimum of 2 choices and up to a maximum of 5 choices.
+     * @param durationSec          The length of time (in seconds) that the poll will run for. The minimum is 15 seconds and
+     *                             the maximum is 1800 seconds (30 minutes).
+     * @param channelPointsPerVote The number of points that the viewer must spend to cast one additional vote.
+     *                             The minimum is 1 and the maximum is 1000000. 0 and smaller disables this option.
+     * @return A list that contains the single poll that you created.
+     * @throws JSONException            when the result object could not be parsed
+     * @throws IllegalArgumentException when more ids are passed than the API allows
+     */
+    public JSONObject createPoll(String title, List<String> choices, int durationSec, int channelPointsPerVote)
+            throws JSONException, IllegalArgumentException {
+        return createPollAsync(title, choices, durationSec, channelPointsPerVote).block();
+    }
+
+    /**
+     * Creates a poll that viewers in the broadcaster’s channel can vote on.
+     * The poll begins as soon as it’s created. You may run only one poll at a time.
+     *
+     * @param title                The question that viewers will vote on. For example, What game should I play next? The question
+     *                             may contain a maximum of 60 characters.
+     * @param choices              A list of choices each with a maximum of 25 characters, that viewers may choose from.
+     *                             The list must contain a minimum of 2 choices and up to a maximum of 5 choices.
+     * @param durationSec          The length of time (in seconds) that the poll will run for. The minimum is 15 seconds and
+     *                             the maximum is 1800 seconds (30 minutes).
+     * @param channelPointsPerVote The number of points that the viewer must spend to cast one additional vote.
+     *                             The minimum is 1 and the maximum is 1000000. 0 and smaller disables this option.
+     * @return A list that contains the single poll that you created.
+     * @throws JSONException            when the result object could not be parsed
+     * @throws IllegalArgumentException when more ids are passed than the API allows
+     */
+    public Mono<JSONObject> createPollAsync(String title, List<String> choices, int durationSec, int channelPointsPerVote)
+            throws JSONException, IllegalArgumentException {
+        final int titleMaxLength = 60;
+        final byte minimumChoices = 2;
+        final byte maximumChoices = 5;
+        final int minimumDurationSec = 15;
+        final int maximumDurationSec = 1800;
+        final int maximumChannelPointsPerVote = 1000000;
+        final int choiceTitleMaxLength = 25;
+
+        if (title.isBlank() || title.length() > titleMaxLength) {
+            throw new IllegalArgumentException("title must be set and cannot be longer than " + titleMaxLength + "characters");
+        }
+        if (choices == null || minimumChoices > choices.size() || choices.size() > maximumChoices) {
+            throw new IllegalArgumentException("choices must contain " + minimumChoices + "-" + maximumChoices + " options");
+        }
+        if (minimumDurationSec > durationSec || durationSec > maximumDurationSec) {
+            throw new IllegalArgumentException("duration must be between " + minimumDurationSec + " and " + maximumDurationSec + " seconds");
+        }
+        if (channelPointsPerVote > maximumChannelPointsPerVote) {
+            throw new IllegalArgumentException("channelPointsPerVote must be between 1 and " + maximumChannelPointsPerVote);
+        }
+
+        // chop too long options
+        List<String> validChoices = choices.stream()
+                .map(s -> s.length() > choiceTitleMaxLength ? s.substring(0, choiceTitleMaxLength) : s)
+                .toList();
+
+        JSONStringer js = new JSONStringer();
+        js.object();
+        js.key("broadcaster_id").value(TwitchValidate.instance().getAPIUserID());
+        js.key("title").value(title);
+        js.key("choices").array();
+        validChoices.forEach(choice -> js.object().key("title").value(choice).endObject());
+        js.endArray();
+        js.key("duration").value(durationSec);
+        if (channelPointsPerVote > 0) {
+            js.key("channel_points_voting_enabled").value(true);
+            js.key("channel_points_per_vote").value(channelPointsPerVote);
+        }
+        js.endObject();
+
+        String endpoint = "/polls";
+        return this.handleMutatorAsync(endpoint + js, () -> this.handleRequest(HttpMethod.POST, endpoint, js.toString()));
+    }
+
+    /**
+     * Ends an active poll. You have the option to end it or end it and archive it.
+     *
+     * @param id     The ID of the poll to update.
+     * @param status The status to set the poll to. Possible case-sensitive values are:
+     *               TERMINATED — Ends the poll before the poll is scheduled to end. The poll remains publicly visible.
+     *               ARCHIVED — Ends the poll before the poll is scheduled to end, and then archives it, so it's no longer publicly visible.
+     * @return A list that contains the poll that you ended.
+     * @throws JSONException            when the result object could not be parsed
+     * @throws IllegalArgumentException when more ids are passed than the API allows
+     */
+    public JSONObject endPoll(String id, String status)
+            throws JSONException, IllegalArgumentException {
+        return endPollAsync(id, status).block();
+    }
+
+    /**
+     * Ends an active poll. You have the option to end it or end it and archive it.
+     *
+     * @param id     The ID of the poll to update.
+     * @param status The status to set the poll to. Possible case-sensitive values are:
+     *               TERMINATED — Ends the poll before the poll is scheduled to end. The poll remains publicly visible.
+     *               ARCHIVED — Ends the poll before the poll is scheduled to end, and then archives it, so it's no longer publicly visible.
+     * @return A list that contains the poll that you ended.
+     * @throws JSONException            when the result object could not be parsed
+     * @throws IllegalArgumentException when more ids are passed than the API allows
+     */
+    public Mono<JSONObject> endPollAsync(String id, String status)
+            throws JSONException, IllegalArgumentException {
+        Set<String> validStatuses = Set.of("TERMINATED", "ARCHIVED");
+        if (!validStatuses.contains(status)) {
+            throw new IllegalArgumentException("Status invalid. Valid options: " + validStatuses);
+        }
+
+        JSONStringer js = new JSONStringer();
+        js.object();
+        js.key("broadcaster_id").value(TwitchValidate.instance().getAPIUserID());
+        js.key("id").value(id);
+        js.key("status").value(status);
+        js.endObject();
+        String endpoint = "/polls";
+        return this.handleMutatorAsync(endpoint + js, () -> this.handleRequest(HttpMethod.PATCH, endpoint, js.toString()));
     }
 
     /**


### PR DESCRIPTION
I've added support for the Twitch Polls API endpoints [get Polls](https://dev.twitch.tv/docs/api/reference/#get-polls), [end Poll](https://dev.twitch.tv/docs/api/reference/#end-poll) and [create Poll](https://dev.twitch.tv/docs/api/reference/#create-poll).
To use the latter ones the `channel:manage:polls` scope must be provided. This is currently not an issue as there is no active use. But it contributes to #2479 and might be the better option to solve #2698 as it uses the native poll feature. I've have seen streams where the results are displayed in the video which is kinda nice for VODs and clips. So it lays the base for a further implementation.