### PR TITLE
[Adventure] Configurable odds

### DIFF
--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -44,7 +44,8 @@
         enterMessage = $.getIniDbBoolean('adventureSettings', 'enterMessage');
         warningMessage = $.getIniDbBoolean('adventureSettings', 'warningMessage');
         coolDownAnnounce = $.getIniDbBoolean('adventureSettings', 'coolDownAnnounce');
-        startPermission = $.getSetIniDbNumber('adventureSettings', 'startPermission', $.PERMISSION.Viewer);
+        odds = $.getIniDbNumber('adventureSettings', 'odds');
+        startPermission = $.getIniDbNumber('adventureSettings', 'startPermission');
     }
 
     /**

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -106,6 +106,7 @@
             stories.push({
                 game: ($.lang.exists(prefix + '.' + storyId + '.game') ? $.lang.get(prefix + '.' + storyId + '.game') : null),
                 title: $.lang.get(prefix + '.' + storyId + '.title'),
+                odds: $.lang.get(prefix + '.' + storyId + '.odds') ? parseInt($.lang.get(prefix + '.' + storyId + '.odds')) : odds,
                 lines: lines
             });
 
@@ -194,7 +195,7 @@
         _currentAdventureLock.lock();
         try {
             for (let i in currentAdventure.users) {
-                if ($.randRange(1, 100) > odds) {
+                if ($.randRange(1, 100) > currentAdventure.story.odds) {
                     currentAdventure.caught.push(currentAdventure.users[i]);
                 } else {
                     currentAdventure.survivors.push(currentAdventure.users[i]);

--- a/javascript-source/games/adventureSystem.js
+++ b/javascript-source/games/adventureSystem.js
@@ -27,6 +27,7 @@
         warningMessage = $.getSetIniDbBoolean('adventureSettings', 'warningMessage', false),
         coolDownAnnounce = $.getSetIniDbBoolean('adventureSettings', 'coolDownAnnounce', false),
         startPermission = $.getSetIniDbNumber('adventureSettings', 'startPermission', $.PERMISSION.Viewer),
+        odds = $.getSetIniDbNumber('adventureSettings', 'odds', 50),
         currentAdventure = {},
         stories = [],
         lastStory,
@@ -192,10 +193,10 @@
         _currentAdventureLock.lock();
         try {
             for (let i in currentAdventure.users) {
-                if ($.randRange(0, 20) > 5) {
-                    currentAdventure.survivors.push(currentAdventure.users[i]);
-                } else {
+                if ($.randRange(1, 100) > odds) {
                     currentAdventure.caught.push(currentAdventure.users[i]);
+                } else {
+                    currentAdventure.survivors.push(currentAdventure.users[i]);
                 }
             }
         } finally {
@@ -591,6 +592,27 @@
                     }
 
                     $.inidb.set('adventureSettings', 'coolDownAnnounce', coolDownAnnounce);
+                }
+
+                /**
+                 * @commandpath adventure set odds [value] - Set the odds of players surviving adventures
+                 */
+                if ($.equalsIgnoreCase(actionArg1, 'odds')) {
+                    if (isNaN(actionArg2)) {
+                        $.say($.whisperPrefix(sender) + $.lang.get('adventuresystem.set.usage'));
+                        return;
+                    }
+
+                    let tmp = parseInt(actionArg2);
+                    if (tmp < 0 || tmp > 100) {
+                        $.say($.whisperPrefix(sender) + $.lang.get('adventuresystem.set.usage.odds'));
+                        return;
+                    }
+
+                    odds = tmp;
+                    $.setIniDbNumber('adventureSettings', 'odds', odds);
+                    // Pretty up the output
+                    actionArg2 = actionArg2 + '%';
                 }
 
                 $.say($.whisperPrefix(sender) + $.lang.get('adventuresystem.set.success', actionArg1, actionArg2));

--- a/javascript-source/lang/english/games/README-games-adventureSyste.txt
+++ b/javascript-source/lang/english/games/README-games-adventureSyste.txt
@@ -1,0 +1,36 @@
+** Using the stories that come with PhantomBot:
+ - All stories that are bundled with the bot are in the namespace adventuresystem.stories.*
+ - If you do not want to use these stories, set the following in your custom language file:
+     "adventuresystem.stories.default": "false",
+ 
+** Rules on writing your own adventure story:
+ - Stories are automatically loaded from the language file by their sequence number (adventuresystem.stories.custom.[This number]).
+ - It is recommended to use a custom language file for your own stories.
+ - Keep the format of your story as shown above, adding the '.custom' portion of the identifier.
+ - There can be an unlimited number of stories, IF you keep their subsequence numbers 1, 2, 3, 4, 5...
+ - A story must have a title.
+ - A story can have an unlimited number of chapters, IF you keep their subsequence numbers 1, 2, 3, 4, 5...
+ - Stories are picked at random.
+ - Please make sure that your story number also follows along. This means the numbering starts from 1 and keeps increasing. Same with the chapters.
+ 
+** Game specific story how-to. You also need to make sure that you at least have ONE story that doesn't require a specific game.
+ - Add "adventuresystem.stories.NUMBER.game": "GAME NAME IN LOWER CASE",
+ 
+** Winning odds
+ - Add "adventuresystem.stories.custom.1.odds": 85,
+ 
+** A basic template for your first custom story
+ 
+    "adventuresystem.stories.custom.1.title": "",
+    "adventuresystem.stories.custom.1.odds": 50,
+    "adventuresystem.stories.custom.1.chapter.1": "",
+    "adventuresystem.stories.custom.1.chapter.2": "",
+    "adventuresystem.stories.custom.1.chapter.3": "",
+
+** Full example
+    "adventuresystem.stories.custom.1.title": "Talk Shows",
+    "adventuresystem.stories.custom.1.game": "programming",
+    "adventuresystem.stories.custom.1.odds": 85,
+    "adventuresystem.stories.custom.1.chapter.1": "Random story - Part 1...",
+    "adventuresystem.stories.custom.1.chapter.2": "Random story - Part 2...",
+    "adventuresystem.stories.custom.1.chapter.2": "Random story - Part 3...",

--- a/javascript-source/lang/english/games/games-adventureSystem.json
+++ b/javascript-source/lang/english/games/games-adventureSystem.json
@@ -15,7 +15,7 @@
     "adventuresystem.runstory": "Starting adventure \"$1\" with $2 player(s).",
     "adventuresystem.set.success": "Set $1 to $2.",
     "adventuresystem.set.usage": "Usage: !adventure set [settingname] [value].",
-    "adventuresystem.set.usage.odds": "The odds are only configurable from 0 to 100 (0 = users never win; 100 = users always win)",
+    "adventuresystem.set.usage.odds": "The odds are only configurable from 0 to 100 (0 = users never win; 100 = users always win). This setting is overridden by adventure specific odds!",
     "adventuresystem.start.success": "$1 is trying get a team together for some serious adventure business! Use \"!adventure [$2]\" to join in!",
     "adventuresystem.tamagotchijoined": "$1 is also joining the adventure.",
     "adventuresystem.top5": "The top 5 adventurers are: $1.",

--- a/javascript-source/lang/english/games/games-adventureSystem.json
+++ b/javascript-source/lang/english/games/games-adventureSystem.json
@@ -15,6 +15,7 @@
     "adventuresystem.runstory": "Starting adventure \"$1\" with $2 player(s).",
     "adventuresystem.set.success": "Set $1 to $2.",
     "adventuresystem.set.usage": "Usage: !adventure set [settingname] [value].",
+    "adventuresystem.set.usage.odds": "The odds are only configurable from 0 to 100 (0 = users never win; 100 = users always win)",
     "adventuresystem.start.success": "$1 is trying get a team together for some serious adventure business! Use \"!adventure [$2]\" to join in!",
     "adventuresystem.tamagotchijoined": "$1 is also joining the adventure.",
     "adventuresystem.top5": "The top 5 adventurers are: $1.",

--- a/resources/web/panel/js/pages/games/games.js
+++ b/resources/web/panel/js/pages/games/games.js
@@ -90,7 +90,7 @@ $(function () {
                     // Add the box for max bet.
                     .append(helpers.getInputGroup('max-bet', 'number', 'Adventure Maximum Bet', '', e.maxBet, 'The maximum amount of points a user can join an adventure with.'))
                     // Add the box for odds.
-                    .append(helpers.getInputGroup('odds', 'number', 'Adventure odds', '', e.odds, 'The odds a player may win an adventure (0 = users never win; 100 = users always win)'))
+                    .append(helpers.getInputGroup('odds', 'number', 'Adventure odds', '', e.odds, 'The odds a player may win an adventure (0 = users never win; 100 = users always win). This setting is overridden by adventure specific odds!'))
                     // Add the box for set up the permission who can start the adventure.
                     .append(helpers.getDropdownGroup('start-permission', 'Permission to start adventure', helpers.getGroupNameById(e.startPermission ? e.startPermission : 7), helpers.getPermGroupNames())),
                     function () { // Callback once the user clicks save.

--- a/resources/web/panel/js/pages/games/games.js
+++ b/resources/web/panel/js/pages/games/games.js
@@ -92,7 +92,7 @@ $(function () {
                     // Add the box for odds.
                     .append(helpers.getInputGroup('odds', 'number', 'Adventure odds', '', e.odds, 'The odds a player may win an adventure (0 = users never win; 100 = users always win)'))
                     // Add the box for set up the permission who can start the adventure.
-                    .append(helpers.getDropdownGroup('start-permission', 'Permission to start adventure', helpers.getGroupNameById(e.startPermission ?? 7), helpers.getPermGroupNames())),
+                    .append(helpers.getDropdownGroup('start-permission', 'Permission to start adventure', helpers.getGroupNameById(e.startPermission ? e.startPermission : 7), helpers.getPermGroupNames())),
                     function () { // Callback once the user clicks save.
                         let entryMessages = $('#entry-messages').find(':selected').text() === 'Yes',
                                 userMessages = $('#user-messages').find(':selected').text() === 'Yes',

--- a/resources/web/panel/js/pages/games/games.js
+++ b/resources/web/panel/js/pages/games/games.js
@@ -62,8 +62,8 @@ $(function () {
     $('#adventureSystemSettings').on('click', function () {
         socket.getDBValues('get_adventure_settings', {
             tables: ['adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings',
-                'adventureSettings', 'adventureSettings', 'adventureSettings'],
-            keys: ['joinTime', 'coolDown', 'gainPercent', 'minBet', 'maxBet', 'enterMessage', 'warningMessage', 'coolDownAnnounce', 'startPermission']
+                'adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings'],
+            keys: ['joinTime', 'coolDown', 'gainPercent', 'minBet', 'maxBet', 'enterMessage', 'warningMessage', 'coolDownAnnounce', 'startPermission', 'odds']
         }, true, function (e) {
             helpers.getModal('adventure-settings', 'Adventure Settings', 'Save', $('<form/>', {
                 'role': 'form'
@@ -89,6 +89,8 @@ $(function () {
                     .append(helpers.getInputGroup('min-bet', 'number', 'Adventure Minimum Bet', '', e.minBet, 'The minimum amount of points a user can join an adventure with.'))
                     // Add the box for max bet.
                     .append(helpers.getInputGroup('max-bet', 'number', 'Adventure Maximum Bet', '', e.maxBet, 'The maximum amount of points a user can join an adventure with.'))
+                    // Add the box for odds.
+                    .append(helpers.getInputGroup('odds', 'number', 'Adventure odds', '', e.odds, 'The odds a player may win an adventure (0 = users never win; 100 = users always win)'))
                     // Add the box for set up the permission who can start the adventure.
                     .append(helpers.getDropdownGroup('start-permission', 'Permission to start adventure', helpers.getGroupNameById(e.startPermission ?? 7), helpers.getPermGroupNames())),
                     function () { // Callback once the user clicks save.
@@ -100,6 +102,7 @@ $(function () {
                                 gainPercent = $('#gain'),
                                 minBet = $('#min-bet'),
                                 maxBet = $('#max-bet'),
+                                odds = $('#odds'),
                                 startPermission = helpers.getGroupIdByName($('#start-permission').find(':selected').text(), true);
 
                         // Make sure everything has been filled in.
@@ -109,13 +112,14 @@ $(function () {
                             case helpers.handleInputNumber(gainPercent, 1):
                             case helpers.handleInputNumber(minBet, 1):
                             case helpers.handleInputNumber(maxBet, 1):
+                            case helpers.handleInputNumber(odds, 0, 100):
                                 break;
                             default:
                                 socket.updateDBValues('adventure_update_settings', {
                                     tables: ['adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings',
-                                        'adventureSettings', 'adventureSettings', 'adventureSettings'],
-                                    keys: ['joinTime', 'coolDown', 'gainPercent', 'minBet', 'maxBet', 'enterMessage', 'warningMessage', 'coolDownAnnounce', 'startPermission'],
-                                    values: [joinTime.val(), cooldownTime.val(), gainPercent.val(), minBet.val(), maxBet.val(), entryMessages, userMessages, cooldownMessage, startPermission]
+                                        'adventureSettings', 'adventureSettings', 'adventureSettings', 'adventureSettings'],
+                                    keys: ['joinTime', 'coolDown', 'gainPercent', 'minBet', 'maxBet', 'enterMessage', 'warningMessage', 'coolDownAnnounce', 'startPermission', 'odds'],
+                                    values: [joinTime.val(), cooldownTime.val(), gainPercent.val(), minBet.val(), maxBet.val(), entryMessages, userMessages, cooldownMessage, startPermission, odds.val()]
                                 }, function () {
                                     socket.sendCommand('adventure_update_settings_cmd', 'reloadadventure', function () {
                                         // Close the modal.


### PR DESCRIPTION
Closes [#226](https://github.com/gmt2001/PhantomBot-1/issues/226)

- Allow the streamers to set the odds for adventures
- Allow the streamers to set per-adventure odds by adding a new line in their lang-files:
```"adventuresystem.stories.3.odds": 67,```
or
```"adventuresystem.stories.custom.3.odds": 67,``` 