### PR TITLE
[Chore] Deps upgrade

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -41,29 +41,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <dependencies defaultconf="default">
         <!-- General -->
         <dependency org="com.rollbar" name="rollbar-java" rev="1.10.0"/>
-        <dependency org="com.discord4j" name="discord4j-core" rev="3.2.5"/>
+        <dependency org="com.discord4j" name="discord4j-core" rev="3.2.6"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
         <dependency org="com.vdurmont" name="emoji-java" rev="5.1.1" />
         <!-- Networking -->
-        <dependency org="io.netty" name="netty-codec-http" rev="4.1.93.Final"/>
-        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.93.Final" />
-        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.93.Final" />
-        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.7"/>
+        <dependency org="io.netty" name="netty-codec-http" rev="4.1.101.Final"/>
+        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.101.Final" />
+        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.101.Final" />
+        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.13"/>
         <!-- Database -->
-        <dependency org="com.h2database" name="h2" rev="2.2.220"/>
+        <dependency org="com.h2database" name="h2" rev="2.2.224"/>
         <dependency org="com.h2database" name="h2" rev="2.1.214" conf="lib.extra->default"/>
         <dependency org="com.h2database" name="h2" rev="1.4.200" conf="lib.extra->default"/>
-        <dependency org="org.jooq" name="jooq" rev="3.18.4"/>
-        <dependency org="org.mariadb.jdbc" name="mariadb-java-client" rev="3.1.4"/>
-        <dependency org="com.mysql" name="mysql-connector-j" rev="8.0.33"/>
-        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.42.0.0"/>
+        <dependency org="org.jooq" name="jooq" rev="3.18.7"/>
+        <dependency org="org.mariadb.jdbc" name="mariadb-java-client" rev="3.3.0"/>
+        <dependency org="com.mysql" name="mysql-connector-j" rev="8.2.0"/>
+        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.44.1.0"/>
         <!-- Utility -->
-        <dependency org="commons-codec" name="commons-codec" rev="1.15"/>
-        <dependency org="commons-io" name="commons-io" rev="2.12.0"/>
-        <dependency org="org.apache.commons" name="commons-text" rev="1.10.0"/>
-        <dependency org="org.json" name="json" rev="20230227"/>
+        <dependency org="commons-codec" name="commons-codec" rev="1.16.0"/>
+        <dependency org="commons-io" name="commons-io" rev="2.15.0"/>
+        <dependency org="org.apache.commons" name="commons-text" rev="1.11.0"/>
+        <dependency org="org.json" name="json" rev="20231013"/>
         <dependency org="org.mozilla" name="rhino" rev="1.7.14"/>
-        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.7"/>
+        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.9"/>
         <!-- Conflict Resolvers -->
         <conflict org="com.h2database" manager="all"/>
     </dependencies>

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2023-07-05 22:41:40</div>
+        2023-11-27 21:48:56</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>
@@ -101,7 +101,7 @@
                     <td class="title">Status</td><td class="value">release</td>
                 </tr>
                 <tr>
-                    <td class="title">Publication</td><td class="value">20191014032514</td>
+                    <td class="title">Publication</td><td class="value">20191014092514</td>
                 </tr>
                 <tr>
                     <td class="title">Resolver</td><td class="value">public</td>
@@ -164,7 +164,7 @@
                     <td class="title">Status</td><td class="value">release</td>
                 </tr>
                 <tr>
-                    <td class="title">Publication</td><td class="value">20220614145020</td>
+                    <td class="title">Publication</td><td class="value">20220614205020</td>
                 </tr>
                 <tr>
                     <td class="title">Resolver</td><td class="value">public</td>


### PR DESCRIPTION
Upgrade (mostly) minor versions of deps. No major changes mentioned in any changelogs. A couple of CVEs plugged and 1 DDoS vector closed in netty

`reactor-netty` is inline with the version of `netty`

tested and confirmed working after proper libs cleaning:

- Twitch Commands / Chat
- Panel
- Discord Commands / Chat
- SQLite
- H2
- MySQL