### PR TITLE
[Points/Time] Ensure tables exist

### DIFF
--- a/javascript-source/core/coreCommands.js
+++ b/javascript-source/core/coreCommands.js
@@ -57,7 +57,7 @@
             /*
              * @commandpath shoutoutapitoggle - Toggles if the /shoutout API is also sent along with the normal !shoutout response
              */
-        } else if ($.equalsIgnoreCase(command, 'shoutoutapi')) {
+        } else if ($.equalsIgnoreCase(command, 'shoutoutapitoggle')) {
             shoutoutApi = !shoutoutApi;
             $.setIniDbBoolean('settings', 'shoutoutapi', shoutoutApi);
             $.say($.whisperPrefix(sender) + $.lang.get('corecommands.shoutoutapi.' + (shoutoutApi ? 'enable' : 'disable')));

--- a/source/com/gmt2001/datastore/DataStore.java
+++ b/source/com/gmt2001/datastore/DataStore.java
@@ -663,7 +663,7 @@ public sealed class DataStore permits H2Store, MySQLStore, MariaDBStore, SqliteS
      * @return an {@link Optional} that may contain a {@link SectionVariableValueRecord} if the row exists
      */
     public Optional<SectionVariableValueRecord> OptRecord(String fName, String section, String key) {
-        SectionVariableValueTable table = SectionVariableValueTable.instance("phantombot_" + fName, false);
+        SectionVariableValueTable table = SectionVariableValueTable.instance("phantombot_" + fName);
 
         if (table == null) {
             return Optional.empty();
@@ -836,7 +836,7 @@ public sealed class DataStore permits H2Store, MySQLStore, MariaDBStore, SqliteS
      * @param values the new values to set the {@code value} column to
      */
     public void SetBatchString(String fName, String section, String[] keys, String[] values) {
-        SectionVariableValueTable table = SectionVariableValueTable.instance("phantombot_" + fName, false);
+        SectionVariableValueTable table = SectionVariableValueTable.instance("phantombot_" + fName);
 
         if (table != null) {
             dsl().batched(c -> {


### PR DESCRIPTION
Ensures tables are present when batch increases or sets are called. Otherwise, the time and points system will not complete their interval runs as expected (increase in time and points) on a fresh database.

No negative effects as there is no other usage for those functions besides from the permissions "visited" tracker and VIP/Sub swap