### PR TITLE
Drastically speed up readfilerand transformer for large files

### DIFF
--- a/javascript-source/core/bootstrap/100fileSystem.js
+++ b/javascript-source/core/bootstrap/100fileSystem.js
@@ -51,6 +51,30 @@
         }
         return lines;
     }
+
+    /**
+     * @function readFileRandLine
+     * @export $
+     * @param {string} path
+     * @returns {String}
+     */
+    function readFileRandLine(path) {
+        if (!fileExists(path)) {
+            return '';
+        }
+
+        if (invalidLocation(path)) {
+            $.consoleLn('[' + $.findCaller() + '] Blocked readFileRandLine() target outside of validPaths: ' + path);
+            return '';
+        }
+
+        try {
+            return Packages.com.gmt2001.JSFileSystem.ReadFileRandLine($.javaString(path));
+        } catch (e) {
+            $.log.error('[' + $.findCaller() + '] Failed to open \'' + path + '\': ' + e);
+        }
+    }
+
     /**
      * @function readFileString
      * @export $
@@ -300,6 +324,7 @@
     $.moveFile = moveFile;
     $.moveRenameFile = moveRenameFile;
     $.readFile = readFile;
+    $.readFileRandLine = readFileRandLine;
     $.readFileString = readFileString;
     $.saveArray = saveArray;
     $.touchFile = touchFile;

--- a/javascript-source/core/transformers/file.js
+++ b/javascript-source/core/transformers/file.js
@@ -84,7 +84,7 @@
      * @formula (readfilerand filename:str) random line of the specified file
      * @labels twitch discord noevent file
      * @notes files will be read from the addons folder, or a subfolder therein specified by the filename parameter
-     * @notes file contents are returned with parenthasis `( )` escaped, preventing command tags in the files from being processed.
+     * @notes file contents are returned with parenthesis `( )` escaped, preventing command tags in the files from being processed.
      * Use `(unescape (readfilerand filename))` to enable processing the returned tags
      */
     function readfilerand(args) {
@@ -94,9 +94,8 @@
             if (!$.fileExists(fileName)) {
                 return {result: $.lang.get('customcommands.file.404', fileName)};
             }
-            let temp = $.readFile(fileName);
             return {
-                result: $.randElement(temp) || '',
+                result: $.readFileRandLine(fileName),
                 cache: false
             };
         }

--- a/source/com/gmt2001/JSFileSystem.java
+++ b/source/com/gmt2001/JSFileSystem.java
@@ -16,7 +16,9 @@
  */
 package com.gmt2001;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
@@ -27,6 +29,7 @@ import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Stream;
 
 /**
@@ -90,6 +93,41 @@ public final class JSFileSystem {
         }
 
         return Files.readString(Paths.get(path));
+    }
+
+    /**
+     * Reads a single randomly chosen line from an file into a string
+     *
+     * @param path The path to the file to read
+     * @return A randomly chosen line from the file; {@code null} if not an allowed location
+     * @throws IOException If an I/O error occurs reading from the file or a malformed or unmappable byte sequence is read
+     */
+    public static String ReadFileRandLine(String path) throws IOException {
+        if (!PathValidator.isValidPathScript(path)) {
+            return null;
+        }
+
+        final File file = new File(path);
+        String line = "";
+        if (file.length() == 0L) {
+            return line;
+        }
+
+        try (RandomAccessFile rFile = new RandomAccessFile(file, "r")) { 
+            final Random random = new Random();
+            final long rndPos = random.nextLong(file.length());
+            rFile.seek(rndPos);
+            rFile.readLine(); //Disregard this partial line to ensure we start reading at a line beginning
+            line = rFile.readLine();
+
+            // EoF reached seek to start of file, read first line fully
+            if (line == null) {
+                rFile.seek(0);
+                line = rFile.readLine();
+            }
+
+            return line;
+        }
     }
 
     /**


### PR DESCRIPTION
As indicated on discord, the `readfilerand` transformer is rather inefficient as it relies on reading the whole file and passes it multiple times (as arguments) between multiple functions before finally returning a selected line.

This PR aims to speed up the selection by utilizing `RandomAccessFile` allowing a file to be randomly accessed

Example with test file with 1000000 lines (7.52MB) jumping throughout the whole range as expected

![image](https://github.com/user-attachments/assets/98adc6ec-54a7-4f73-b2e2-25a2a9d92bf1)

## Very rudimentary speed test

-  **Old Version:** +/- 5.8 s
![image](https://github.com/user-attachments/assets/ca4b4020-21e1-4784-90f5-9920dc2e2623)
- **New Version:** +/- 7 ns
![image](https://github.com/user-attachments/assets/d4b25baf-3f0e-4e98-bc76-8ce21a5b100b)
