### PR TITLE
[Chore] Update dependencies

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -40,30 +40,31 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </configurations>
     <dependencies defaultconf="default">
         <!-- General -->
-        <dependency org="com.rollbar" name="rollbar-java" rev="1.10.0"/>
+        <dependency org="com.rollbar" name="rollbar-java" rev="1.10.3"/>
         <dependency org="com.discord4j" name="discord4j-core" rev="3.2.6"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
         <dependency org="com.vdurmont" name="emoji-java" rev="5.1.1" />
         <!-- Networking -->
-        <dependency org="io.netty" name="netty-codec-http" rev="4.1.101.Final"/>
-        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.101.Final" />
-        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.101.Final" />
-        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.13"/>
+        <dependency org="io.netty" name="netty-codec-http" rev="4.1.114.Final"/>
+        <dependency org="io.netty" name="netty-transport-native-epoll" rev="4.1.114.Final" />
+        <dependency org="io.netty" name="netty-transport-native-kqueue" rev="4.1.114.Final" />
+        <dependency org="io.projectreactor.netty" name="reactor-netty" rev="1.1.23"/>
         <!-- Database -->
-        <dependency org="com.h2database" name="h2" rev="2.2.224"/>
+        <dependency org="com.h2database" name="h2" rev="2.3.232"/>
+        <dependency org="com.h2database" name="h2" rev="2.2.224" conf="lib.extra->default"/>
         <dependency org="com.h2database" name="h2" rev="2.1.214" conf="lib.extra->default"/>
         <dependency org="com.h2database" name="h2" rev="1.4.200" conf="lib.extra->default"/>
-        <dependency org="org.jooq" name="jooq" rev="3.18.7"/>
-        <dependency org="org.mariadb.jdbc" name="mariadb-java-client" rev="3.3.0"/>
-        <dependency org="com.mysql" name="mysql-connector-j" rev="8.2.0"/>
-        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.44.1.0"/>
+        <dependency org="org.jooq" name="jooq" rev="3.19.13"/>
+        <dependency org="org.mariadb.jdbc" name="mariadb-java-client" rev="3.4.1"/>
+        <dependency org="com.mysql" name="mysql-connector-j" rev="9.1.0"/>
+        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.46.1.3"/>
         <!-- Utility -->
-        <dependency org="commons-codec" name="commons-codec" rev="1.16.0"/>
-        <dependency org="commons-io" name="commons-io" rev="2.15.0"/>
-        <dependency org="org.apache.commons" name="commons-text" rev="1.11.0"/>
-        <dependency org="org.json" name="json" rev="20231013"/>
-        <dependency org="org.mozilla" name="rhino" rev="1.7.14"/>
-        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.9"/>
+        <dependency org="commons-codec" name="commons-codec" rev="1.17.1"/>
+        <dependency org="commons-io" name="commons-io" rev="2.17.0"/>
+        <dependency org="org.apache.commons" name="commons-text" rev="1.12.0"/>
+        <dependency org="org.json" name="json" rev="20240303"/>
+        <dependency org="org.mozilla" name="rhino" rev="1.7.15"/>
+        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.16"/>
         <!-- Conflict Resolvers -->
         <conflict org="com.h2database" manager="all"/>
     </dependencies>

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2023-11-27 21:48:56</div>
+        2024-10-20 11:48:42</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>
@@ -31,21 +31,21 @@
                     <td class="title">Modules</td><td class="value">1</td>
                 </tr>
                 <tr>
-                    <td class="title">Revisions</td><td class="value">2
+                    <td class="title">Revisions</td><td class="value">3
         (0 searched <img src="https://ant.apache.org/ivy/images/searched.gif" alt="searched" title="module revisions which required a search with a dependency resolver to be resolved">,
         0 downloaded <img src="https://ant.apache.org/ivy/images/downloaded.gif" alt="downloaded" title="module revisions for which ivy file was downloaded by dependency resolver">,
         0 evicted <img src="https://ant.apache.org/ivy/images/evicted.gif" alt="evicted" title="module revisions which were evicted by others">,
         0 errors <img src="https://ant.apache.org/ivy/images/error.gif" alt="error" title="module revisions on which error occurred">)</td>
                 </tr>
                 <tr>
-                    <td class="title">Artifacts</td><td class="value">2
+                    <td class="title">Artifacts</td><td class="value">3
         (0 downloaded,
         0 failed)</td>
                 </tr>
                 <tr>
-                    <td class="title">Artifacts size</td><td class="value">4733 kB
+                    <td class="title">Artifacts size</td><td class="value">7287 kB
         (0 kB downloaded,
-        4733 kB in cache)</td>
+        7287 kB in cache)</td>
                 </tr>
             </table>
             <h2>Conflicts</h2>
@@ -59,7 +59,7 @@
                     <tr>
                         <td><a href="#com.h2database-h2">h2
             by
-            com.h2database</a></td><td><a href="#com.h2database-h2-1.4.200">1.4.200</a> <a href="#com.h2database-h2-2.1.214">2.1.214</a> </td><td></td>
+            com.h2database</a></td><td><a href="#com.h2database-h2-1.4.200">1.4.200</a> <a href="#com.h2database-h2-2.1.214">2.1.214</a> <a href="#com.h2database-h2-2.2.224">2.2.224</a> </td><td></td>
                     </tr>
                 </tbody>
             </table>
@@ -81,6 +81,12 @@
                         <td><a href="#com.h2database-h2"> h2
         by
         com.h2database</a></td><td><a href="#com.h2database-h2-2.1.214">2.1.214</a></td><td align="center">release</td><td align="center">public</td><td align="center">false</td><td align="center"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td><td align="center">2483 kB
+    </td><td align="center"></td>
+                    </tr>
+                    <tr>
+                        <td><a href="#com.h2database-h2"> h2
+        by
+        com.h2database</a></td><td><a href="#com.h2database-h2-2.2.224">2.2.224</a></td><td align="center">release</td><td align="center">public</td><td align="center">false</td><td align="center"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td><td align="center">2554 kB
     </td><td align="center"></td>
                     </tr>
                 </tbody>
@@ -212,6 +218,69 @@
                 <tbody>
                     <tr>
                         <td>h2</td><td>jar</td><td>jar</td><td align="center">no</td><td align="center">2483 kB</td>
+                    </tr>
+                </tbody>
+            </table>
+            <h4>
+                <a name="com.h2database-h2-2.2.224"></a>
+           Revision: 2.2.224<span style="padding-left:15px;"></span>
+            </h4>
+            <table class="header">
+                <tr>
+                    <td class="title">Home Page</td><td class="value"><a href="https://h2database.com">https://h2database.com</a></td>
+                </tr>
+                <tr>
+                    <td class="title">Status</td><td class="value">release</td>
+                </tr>
+                <tr>
+                    <td class="title">Publication</td><td class="value">20230918085906</td>
+                </tr>
+                <tr>
+                    <td class="title">Resolver</td><td class="value">public</td>
+                </tr>
+                <tr>
+                    <td class="title">Configurations</td><td class="value">default, compile, runtime, master</td>
+                </tr>
+                <tr>
+                    <td class="title">Artifacts size</td><td class="value">2554 kB
+          (0 kB downloaded,
+          2554 kB in cache)</td>
+                </tr>
+                <tr>
+                    <td class="title">Licenses</td><td class="value"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td>
+                </tr>
+            </table>
+            <h5>Required by</h5>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Organisation</th><th>Name</th><th>Revision</th><th>In Configurations</th><th>Asked Revision</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>tv.phantombot</td><td><a href="#tv.phantombot-phantombot">phantombot</a></td><td>custom</td><td>lib.extra</td><td>2.2.224</td>
+                    </tr>
+                </tbody>
+            </table>
+            <h5>Dependencies</h5>
+            <table>
+                <tr>
+                    <td>
+    No dependency
+    </td>
+                </tr>
+            </table>
+            <h5>Artifacts</h5>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th><th>Type</th><th>Ext</th><th>Download</th><th>Size</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>h2</td><td>jar</td><td>jar</td><td align="center">no</td><td align="center">2554 kB</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
- No breaking changes reported (some removed Java 8 support, irrelevant for PhantomBot)
- Building (Java 17) successful (clean lib folders and full retrieve)
- **h2** `2.2.224` kept in extras. Can be removed (up to you, I'll just force-push if requested). Similarly we might use the newer **h2** `2.3.232` as well for the upgrade process which allows us to remove the `2.1.214` version in `lib/extra` as well (up to you, I'll just force-push required changes if requested)
- Basic testing (startup + basic twitch chat commands + panel + discord) with MariaDB, SQLite3, h2

Should resolve some memory leaks from dependencies. Especially `netty`
## Vulnerabilities fixed
### netty-code-http
- [CVE-2024-29025](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-29025)
- [CVE-2024-47554]([CVE-2024-47554](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554)) (Dependency **commos-io** `2.8.0`)

## Changes

| Dependency| From    | To    | Full Changelog   |
| :---:   | :---: | :---: |:---: |
| rollbar-java | 1.10.0   | 1.10.3   | [Changelog](https://github.com/rollbar/rollbar-java/releases/tag/v1.10.3)  |
| h2 | 2.2.224   | 2.3.232   | [Changelog](https://h2database.com/html/changelog.html)  |
| jooq | 3.18.7   | 3.19.13   | [Changelog](https://www.jooq.org/notes)  |
| mariadb-java-client | 3.3.0   | 3.4.1   | [Changelog](https://mariadb.com/kb/en/about-mariadb-connector-j/)  |
| mysql-connector-j | 8.2.0   | 9.1.0   | [Changelog](https://dev.mysql.com/doc/relnotes/connector-j/en/)  |
| sqlite-jdbc | 3.44.1.0   | 3.46.1.3   | [Changelog](https://github.com/xerial/sqlite-jdbc/releases/tag/3.46.1.3)  |
| commons-codec | 2.16.0   | 2.17.1   | [Changelog](https://commons.apache.org/proper/commons-codec/changes-report.html)  |
| commons-io | 2.15.0   | 2.17.0   | [Changelog](https://commons.apache.org/proper/commons-io/changes-report.html)  |
| commons-text | 1.11.0   | 1.12.0   | [Changelog](https://commons.apache.org/proper/commons-text/changes-report.html)  |
| json | 20231013   | 20240303   | [Changelog](https://github.com/stleary/JSON-java/releases)  |
| rhino | 1.7.14   | 1.7.15   | [Changelog](https://github.com/mozilla/rhino/blob/master/RELEASE-NOTES.md)  |
| slf4j-nop | 2.0.9   | 2.0.16   | [Changelog](https://www.slf4j.org/news.html)  |
| netty-codec-http | 4.1.101.Final   | 4.1.114.Final   | [Changelog](https://netty.io/news/index.html)  |
| netty-transport-native-epoll | 4.1.101.Final   | 4.1.114.Final   | [Changelog](https://netty.io/news/index.html)  |
| netty-transport-native-kqueue | 4.1.101.Final   | 4.1.114.Final   | [Changelog](https://netty.io/news/index.html)  |
| reactor-netty | 1.1.13   | 1.1.23   | [Changelog](https://github.com/reactor/reactor-netty/releases)  |