### PR TITLE
Fix (readfilerand) Umlaut

### DIFF
--- a/source/com/gmt2001/JSFileSystem.java
+++ b/source/com/gmt2001/JSFileSystem.java
@@ -126,7 +126,7 @@ public final class JSFileSystem {
                 line = rFile.readLine();
             }
 
-            return line;
+            return new String(line.getBytes("ISO-8859-1"), "UTF-8");
         }
     }
 


### PR DESCRIPTION
Enforce charsets where possible to ensure we can read the same set of files as with `java.NIO.file` and the default `UTF-8` charset


Before / After comparison
![image](https://github.com/user-attachments/assets/95108a63-e09c-41ce-aff0-628891ab5d28)

Test file (UTF-8 encoded) contents:
`öä ß ẞ +# test normal text / Привет из Украины 	Œ  Ŀ ý`