### PR TITLE
Add hashCode() & equals() to PB Classes

### DIFF
--- a/source/com/gmt2001/JSTimers.java
+++ b/source/com/gmt2001/JSTimers.java
@@ -17,6 +17,7 @@
 package com.gmt2001;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -167,6 +168,34 @@ public class JSTimers {
                     }
                 }
             }
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getEnclosingInstance().hashCode();
+            result = prime * result + Objects.hash(name, callback, isInterval);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            JSTimer other = (JSTimer) obj;
+            if (!getEnclosingInstance().equals(other.getEnclosingInstance()))
+                return false;
+            return Objects.equals(name, other.name) && Objects.equals(callback, other.callback)
+                    && isInterval == other.isInterval;
+        }
+
+        private JSTimers getEnclosingInstance() {
+            return JSTimers.this;
         }
     }
 }

--- a/source/com/gmt2001/datastore/SectionVariableValueTable.java
+++ b/source/com/gmt2001/datastore/SectionVariableValueTable.java
@@ -17,6 +17,7 @@
 package com.gmt2001.datastore;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -260,5 +261,26 @@ public final class SectionVariableValueTable extends TableImpl<SectionVariableVa
         } catch (Exception ex) {
             com.gmt2001.Console.err.printStackTrace(ex);
         }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(tableName, SECTION, VARIABLE);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SectionVariableValueTable other = (SectionVariableValueTable) obj;
+        return Objects.equals(tableName, other.tableName) && Objects.equals(SECTION, other.SECTION)
+                && Objects.equals(VARIABLE, other.VARIABLE);
     }
 }

--- a/source/com/gmt2001/httpwsserver/auth/HttpBasicAuthenticationHandler.java
+++ b/source/com/gmt2001/httpwsserver/auth/HttpBasicAuthenticationHandler.java
@@ -20,6 +20,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Objects;
 
 import com.gmt2001.httpwsserver.HttpServerPageHandler;
 import com.gmt2001.security.Digest;
@@ -200,5 +201,24 @@ public class HttpBasicAuthenticationHandler implements HttpAuthenticationHandler
         }
 
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(realm, user, pass, allowPaneluser, loginUri);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HttpBasicAuthenticationHandler other = (HttpBasicAuthenticationHandler) obj;
+        return Objects.equals(realm, other.realm) && Objects.equals(user, other.user)
+                && Objects.equals(pass, other.pass) && allowPaneluser == other.allowPaneluser
+                && Objects.equals(loginUri, other.loginUri);
     }
 }

--- a/source/com/gmt2001/httpwsserver/auth/HttpSharedTokenOrPasswordAuthenticationHandler.java
+++ b/source/com/gmt2001/httpwsserver/auth/HttpSharedTokenOrPasswordAuthenticationHandler.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import tv.phantombot.PhantomBot;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Provides a {@link HttpAuthenticationHandler} that implements password and token-based authentication
@@ -123,5 +124,22 @@ public class HttpSharedTokenOrPasswordAuthenticationHandler implements HttpAuthe
         String auth2 = headers.get("webauth");
 
         return (auth1 != null && (auth1.equals(password) || auth1.equals("oauth:" + password))) || (auth2 != null && auth2.equals(token));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token, password);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HttpSharedTokenOrPasswordAuthenticationHandler other = (HttpSharedTokenOrPasswordAuthenticationHandler) obj;
+        return Objects.equals(token, other.token) && Objects.equals(password, other.password);
     }
 }

--- a/source/com/gmt2001/httpwsserver/auth/WsSharedRWTokenAuthenticationHandler.java
+++ b/source/com/gmt2001/httpwsserver/auth/WsSharedRWTokenAuthenticationHandler.java
@@ -27,6 +27,8 @@ import tv.phantombot.PhantomBot;
 import tv.phantombot.panel.PanelUser.PanelUser;
 import tv.phantombot.panel.PanelUser.PanelUserHandler;
 
+import java.util.Objects;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONStringer;
@@ -256,5 +258,25 @@ public class WsSharedRWTokenAuthenticationHandler implements WsAuthenticationHan
         }
 
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(readOnlyToken, readWriteToken, maxAttempts, authenticatedCallback, allowPaneluser);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        WsSharedRWTokenAuthenticationHandler other = (WsSharedRWTokenAuthenticationHandler) obj;
+        return Objects.equals(readOnlyToken, other.readOnlyToken)
+                && Objects.equals(readWriteToken, other.readWriteToken) && maxAttempts == other.maxAttempts
+                && Objects.equals(authenticatedCallback, other.authenticatedCallback)
+                && allowPaneluser == other.allowPaneluser;
     }
 }

--- a/source/com/gmt2001/twitch/cache/Viewer.java
+++ b/source/com/gmt2001/twitch/cache/Viewer.java
@@ -18,6 +18,7 @@
 package com.gmt2001.twitch.cache;
 
 import java.time.Instant;
+import java.util.Objects;
 
 /**
  * Contains information about a specific viewer in a {@link ViewerCache}
@@ -356,5 +357,22 @@ public final class Viewer {
      */
     public boolean vip() {
         return this.vip;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Viewer other = (Viewer) obj;
+        return Objects.equals(id, other.id);
     }
 }

--- a/source/com/gmt2001/twitch/eventsub/EventSubSubscription.java
+++ b/source/com/gmt2001/twitch/eventsub/EventSubSubscription.java
@@ -19,6 +19,8 @@ package com.gmt2001.twitch.eventsub;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.json.JSONObject;
 
 /**
@@ -294,5 +296,23 @@ public final class EventSubSubscription {
      */
     public EventSubTransport transport() {
         return this.transport;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, status, type, created_at);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EventSubSubscription other = (EventSubSubscription) obj;
+        return Objects.equals(id, other.id) && status == other.status && Objects.equals(type, other.type)
+                && Objects.equals(created_at, other.created_at);
     }
 }

--- a/source/com/gmt2001/twitch/tmi/TMIMessage.java
+++ b/source/com/gmt2001/twitch/tmi/TMIMessage.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An IRCv3 formatted message from TMI
@@ -444,6 +445,33 @@ public final class TMIMessage {
          */
         public int length() {
             return (this.end - this.start) + 1;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getEnclosingInstance().hashCode();
+            result = prime * result + Objects.hash(start, end);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            EmoteLocation other = (EmoteLocation) obj;
+            if (!getEnclosingInstance().equals(other.getEnclosingInstance()))
+                return false;
+            return start == other.start && end == other.end;
+        }
+
+        private TMIMessage getEnclosingInstance() {
+            return TMIMessage.this;
         }
     }
 }

--- a/source/tv/phantombot/cache/SteamCache.java
+++ b/source/tv/phantombot/cache/SteamCache.java
@@ -19,6 +19,8 @@ package tv.phantombot.cache;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import tv.phantombot.PhantomBot;
@@ -139,5 +141,22 @@ public class SteamCache implements Runnable {
      */
     public void kill() {
         runThread.interrupt();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runThread);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SteamCache other = (SteamCache) obj;
+        return Objects.equals(runThread, other.runThread);
     }
 }

--- a/source/tv/phantombot/cache/TwitchTeamsCache.java
+++ b/source/tv/phantombot/cache/TwitchTeamsCache.java
@@ -19,6 +19,7 @@ package tv.phantombot.cache;
 import com.gmt2001.TwitchAPIv5;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -231,6 +232,33 @@ public class TwitchTeamsCache implements Runnable {
          */
         public JSONObject getObject() {
             return obj;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getEnclosingInstance().hashCode();
+            result = prime * result + Objects.hash(obj);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Team other = (Team) obj;
+            if (!getEnclosingInstance().equals(other.getEnclosingInstance()))
+                return false;
+            return Objects.equals(this.obj, other.obj);
+        }
+
+        private TwitchTeamsCache getEnclosingInstance() {
+            return TwitchTeamsCache.this;
         }
     }
 }

--- a/source/tv/phantombot/httpserver/HTTPAuthenticatedHandler.java
+++ b/source/tv/phantombot/httpserver/HTTPAuthenticatedHandler.java
@@ -33,6 +33,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONStringer;
@@ -404,6 +406,23 @@ public class HTTPAuthenticatedHandler implements HttpRequestHandler {
             com.gmt2001.Console.debug.println("500" + req.method().asciiName() + ": lang " + req.headers().get("lang-path"));
             HttpServerPageHandler.sendHttpResponse(ctx, req, HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR, j.getJSONArray("errors").getJSONObject(0).getString("detail").getBytes(Charset.forName("UTF-8")), "plain"));
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HTTPAuthenticatedHandler other = (HTTPAuthenticatedHandler) obj;
+        return Objects.equals(authHandler, other.authHandler);
     }
 
 }

--- a/source/tv/phantombot/httpserver/HTTPOAuthHandler.java
+++ b/source/tv/phantombot/httpserver/HTTPOAuthHandler.java
@@ -35,6 +35,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
+
 import tv.phantombot.CaselessProperties;
 import tv.phantombot.PhantomBot;
 
@@ -139,6 +141,25 @@ public class HTTPOAuthHandler implements HttpRequestHandler {
 
     public boolean validateBroadcasterToken(String token) {
         return this.token.equals(token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler, authHandlerBroadcaster, token);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HTTPOAuthHandler other = (HTTPOAuthHandler) obj;
+        return Objects.equals(authHandler, other.authHandler)
+                && Objects.equals(authHandlerBroadcaster, other.authHandlerBroadcaster)
+                && Objects.equals(token, other.token);
     }
 
 }

--- a/source/tv/phantombot/httpserver/HTTPPanelAndYTHandler.java
+++ b/source/tv/phantombot/httpserver/HTTPPanelAndYTHandler.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
+
 import tv.phantombot.CaselessProperties;
 
 /**
@@ -114,6 +116,23 @@ public class HTTPPanelAndYTHandler implements HttpRequestHandler {
             com.gmt2001.Console.debug.printStackTrace(ex);
             HttpServerPageHandler.sendHttpResponse(ctx, req, HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR));
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HTTPPanelAndYTHandler other = (HTTPPanelAndYTHandler) obj;
+        return Objects.equals(authHandler, other.authHandler);
     }
 
 }

--- a/source/tv/phantombot/httpserver/HttpSetupHandler.java
+++ b/source/tv/phantombot/httpserver/HttpSetupHandler.java
@@ -34,6 +34,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONStringer;
@@ -186,5 +188,23 @@ public class HttpSetupHandler implements HttpRequestHandler {
             com.gmt2001.Console.debug.println("405");
             HttpServerPageHandler.sendHttpResponse(ctx, req, HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.METHOD_NOT_ALLOWED, js.toString(), "json"));
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler, authHandlerToken, token);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        HttpSetupHandler other = (HttpSetupHandler) obj;
+        return Objects.equals(authHandler, other.authHandler)
+                && Objects.equals(authHandlerToken, other.authHandlerToken) && Objects.equals(token, other.token);
     }
 }

--- a/source/tv/phantombot/panel/WsAlertsPollsHandler.java
+++ b/source/tv/phantombot/panel/WsAlertsPollsHandler.java
@@ -18,6 +18,7 @@ package tv.phantombot.panel;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.json.JSONException;
@@ -264,5 +265,22 @@ public class WsAlertsPollsHandler implements WsFrameHandler {
      */
     public void sendMacro(String macroJson) {
         sendJSONToAll(macroJson);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        WsAlertsPollsHandler other = (WsAlertsPollsHandler) obj;
+        return Objects.equals(authHandler, other.authHandler);
     }
 }

--- a/source/tv/phantombot/panel/WsPanelHandler.java
+++ b/source/tv/phantombot/panel/WsPanelHandler.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1020,5 +1022,22 @@ public class WsPanelHandler implements WsFrameHandler {
         jsonObject.endArray();
         jsonObject.endObject().endObject();
         WebSocketFrameHandler.broadcastWsFrame("/ws/panel", WebSocketFrameHandler.prepareTextWebSocketResponse(jsonObject.toString()));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        WsPanelHandler other = (WsPanelHandler) obj;
+        return Objects.equals(authHandler, other.authHandler);
     }
 }

--- a/source/tv/phantombot/panel/WsPanelRemoteLoginHandler.java
+++ b/source/tv/phantombot/panel/WsPanelRemoteLoginHandler.java
@@ -24,6 +24,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+
+import java.util.Objects;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONStringer;
@@ -131,5 +134,22 @@ public class WsPanelRemoteLoginHandler implements WsFrameHandler {
             WebSocketFrameHandler.sendWsFrame(ctx, frame, WebSocketFrameHandler.prepareCloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE));
         }
         ctx.close();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        WsPanelRemoteLoginHandler other = (WsPanelRemoteLoginHandler) obj;
+        return Objects.equals(authHandler, other.authHandler);
     }
 }

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
@@ -212,5 +213,22 @@ public class Script {
         doDestroyables();
         od.setDisconnected(true);
         killed = true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(file);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Script other = (Script) obj;
+        return Objects.equals(file, other.file);
     }
 }

--- a/source/tv/phantombot/twitch/api/Helix.java
+++ b/source/tv/phantombot/twitch/api/Helix.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -3110,6 +3111,33 @@ public class Helix {
         private CallRequest(Instant expires, Mono<JSONObject> processor) {
             this.expires = expires;
             this.processor = processor;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getEnclosingInstance().hashCode();
+            result = prime * result + Objects.hash(expires, processor);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            CallRequest other = (CallRequest) obj;
+            if (!getEnclosingInstance().equals(other.getEnclosingInstance()))
+                return false;
+            return Objects.equals(expires, other.expires) && Objects.equals(processor, other.processor);
+        }
+
+        private Helix getEnclosingInstance() {
+            return Helix.this;
         }
     }
 }

--- a/source/tv/phantombot/ytplayer/WsYTHandler.java
+++ b/source/tv/phantombot/ytplayer/WsYTHandler.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.util.AttributeKey;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONException;
@@ -394,5 +395,23 @@ public class WsYTHandler implements WsFrameHandler {
 
     public void sendJSONToAll(String jsonString) {
         WebSocketFrameHandler.broadcastWsFrame("/ws/ytplayer", WebSocketFrameHandler.prepareTextWebSocketResponse(jsonString));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authHandler, currentState, clientConnected, bufferCounter);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        WsYTHandler other = (WsYTHandler) obj;
+        return Objects.equals(authHandler, other.authHandler) && currentState == other.currentState
+                && clientConnected == other.clientConnected && bufferCounter == other.bufferCounter;
     }
 }


### PR DESCRIPTION
Define basic generated equals() and hashCode() functions for PhantomBot classes which may be added to an HashMap possibly improving the HashMaps efficiency

