### PR TITLE
Fix bot whisper detection

### DIFF
--- a/javascript-source/core/whisper.js
+++ b/javascript-source/core/whisper.js
@@ -57,7 +57,7 @@
      * @returns {string}
      */
     function whisperPrefix(username, force) {
-        if (username.toLowerCase() === $.botName.toLowerCase()) {
+        if ($.equalsIgnoreCase(username, $.botName)) {
             return '';
         }
         if (whisperMode || force) {


### PR DESCRIPTION
Whisper prefix is not ignored for the bot. Mismatch between java and javascript strings, thus strict comparison fails