### PR TITLE
Feature Suggestion - add parameter "lastquote" for !quote command

### DIFF
--- a/javascript-source/systems/quoteSystem.js
+++ b/javascript-source/systems/quoteSystem.js
@@ -106,6 +106,8 @@
 
         if (!quoteId) {
             quoteId = $.rand($.inidb.GetKeyList('quotes', '').length);
+        } else if (String(quoteId).toLowerCase() == 'lastquote') {
+            quoteId = $.inidb.GetKeyList('quotes', '').length - 1;
         } else if (isNaN(quoteId)) {
             quoteId = String(quoteId).toLowerCase();
             var quotes = $.inidb.GetKeyValueList('quotes', '');


### PR DESCRIPTION
We had a `!lastquote` command in a bot we have been using aeons ago and are missing this feature in PhantomBot.

I figured that - instead of adding a whole new function - we could simply use the already existing feature of non numerical input to add a `lastquote` parameter. 
We can now simply add an alias `!lastquote` pointing to `!quote lastquote`

This simply checks the parameter given to the !quote command if it matches "lastquote" and returns the ID of the last quote added, instead of searching for this (very unlikely) text.

This has been tested and works without any issues even on an empty table, though it might be considered cleaner to not return -1 if the quotes table is empty?