### PR TITLE
ZeroCopy, Chunked Transfer & More

### DIFF
--- a/resources/web/alerts/index.html
+++ b/resources/web/alerts/index.html
@@ -77,6 +77,15 @@
         .animatedEmote {
             position: fixed;
         }
+        
+        .fade-in {
+          opacity: 1 !important;
+          transition: opacity 200ms ease-in;
+        }
+        .fade-out {
+          opacity: 0 !important;
+          transition: opacity 200ms ease-out;
+        }
     </style>
 
     <!-- Load our favicon -->
@@ -86,6 +95,7 @@
 <!-- Main body -->
 <body>
     <div id="main-video-clips">
+        <video id="alertVideo" autoplay="false"></video>
         <!-- Where the video clips are played. -->
     </div>
     <div id="main-emotes">
@@ -93,7 +103,8 @@
     </div>
     <div class="main-alert">
         <!-- Where the gif gets played. -->
-        <div id="alert"></div>
+        <img id="alert" class="fade-out"></img>
+        <audio id="alertAudio" autoplay="false"></audio>
     </div>
     <div class="main-text-alert">
         <!-- Where the custom gif text is displayed. -->

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -544,9 +544,10 @@ $(function () {
         if (getOptionSetting('enableAudioHooks', getOptionSetting('allow-audio-hooks', 'false')) === 'false') {
             return;
         }
+        const MEDIA_URL_BASE = '/config/audio-hooks/';
 
         // Create a new audio file.
-        audioEl.src = chooseBestCandidate(json.audio_panel_hook);
+        audioEl.src = MEDIA_URL_BASE + encodeURIComponent(chooseBestCandidate(json.audio_panel_hook));
         // Set the volume.
         audioEl.volume = getOptionSetting('audioHookVolume', getOptionSetting('audio-hook-volume', '1'));
 

--- a/source/com/gmt2001/httpwsserver/HTTPWSServer.java
+++ b/source/com/gmt2001/httpwsserver/HTTPWSServer.java
@@ -51,6 +51,7 @@ import com.gmt2001.util.concurrent.ExecutorService;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -197,6 +198,7 @@ public final class HTTPWSServer {
             ServerBootstrap b = new ServerBootstrap();
             b.group(this.group)
                     .channel(EventLoopDetector.getServerChannelClass())
+                    .childOption(ChannelOption.TCP_NODELAY, true)
                     .childHandler(new HTTPWSServerInitializer());
 
             if (ipOrHostname.isBlank()) {

--- a/source/com/gmt2001/httpwsserver/HTTPWSServerInitializer.java
+++ b/source/com/gmt2001/httpwsserver/HTTPWSServerInitializer.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.stream.ChunkedWriteHandler;
 
 /**
  * Initializes {@link SocketChannel} objects for a {@link HTTPWSServer}
@@ -59,11 +60,12 @@ class HTTPWSServerInitializer extends ChannelInitializer<SocketChannel> {
         }
 
         pipeline.addLast(new HttpServerCodec());
-        pipeline.addLast(new HttpContentCompressor());
         pipeline.addLast(new HttpObjectAggregator(65536));
+        pipeline.addLast(new WebSocketFrameAggregator(65536));
         pipeline.addLast(new WebSocketServerCompressionHandler());
         pipeline.addLast(new WebSocketServerProtocolHandler("/ws", null, true, 65536, false, true));
-        pipeline.addLast(new WebSocketFrameAggregator(65536));
+        pipeline.addLast(new HttpContentCompressor());
+        pipeline.addLast(new ChunkedWriteHandler());   
         pipeline.addLast("pagehandler", new HttpServerPageHandler());
         pipeline.addLast("wshandler", new WebSocketFrameHandler());
     }

--- a/source/tv/phantombot/httpserver/HTTPNoAuthHandler.java
+++ b/source/tv/phantombot/httpserver/HTTPNoAuthHandler.java
@@ -183,8 +183,7 @@ public class HTTPNoAuthHandler implements HttpRequestHandler {
                 } else {
                     com.gmt2001.Console.debug.println("200 " + req.method().asciiName() + ": " + p.toString() + " (" + p.getFileName().toString() + " = "
                             + HttpServerPageHandler.detectContentType(p.getFileName().toString()) + ")");
-                    HttpServerPageHandler.sendHttpResponse(ctx, req, HttpServerPageHandler.prepareHttpResponse(HttpResponseStatus.OK,
-                            req.method().equals(HttpMethod.HEAD) ? null : Files.readAllBytes(p), p.getFileName().toString()));
+                    HttpServerPageHandler.sendFile(ctx, req, p);
                 }
             }
         } catch (IOException ex) {


### PR DESCRIPTION
As nowadays files especially video and lossless audio is getting rather larger in size one can observe rather drastic memory allocation when an alert is triggered pointing to such files. The extraordinary memory allocation can be explained by two front sanding factors:

- Only sending `FullHTTPRequests` thus needing to copy the full file into the heap all at once (reading the file) and then from the heap into Netty's own buffers `ByteBuffer`. Thus we hold the file twice in RAM
- `index.js` (for alerts) having some logic issues due to browsers pre-loading already thus 2x the required heap will be allocated for a short while until GC can clean the residues of the interrupted first load

My believe is that Phantombot should be using minimal amount of resources which I try to achieve with the following PR.

This PR in short does the following on the alerts side of things:

- Find available audio files to a gif file on the server side. Saving CPU cycles for dealing with the otherwise upcoming `HEAD` requests. Available files will be transmitted from the backend to the frontend. The front end will only need to choose what file it will play.
- Similar to the above, for `audiohooks` the server compiles an array of available files and the client will choose which one to load and play
- `GifAlerts` allows to also play video. Now video playback will be handled in the proper `handleVideoClip` function instead of bloating `handleGifAlerts`
- Removed dynamic HTML element creation and deletion as it is error prone and all can be achieved with static HTML elements
- Let the browser deal with the loading of the file (possible to backend changes below)


On the HTTPServer side I did the following:
- Add support for byte ranges opening up modern streaming for files
- Include proper **caching headers** enabling the browser to use it's cached file instead of constantly hammering Phantombot's backend for the same file over and over (happens often with alerts)
- Add support for **chunked file transfers** easing some pressure of the memory for larger files.
- Add support for **zero-copy** (aka. `FileRegion`) using the underlying OS to send the file. This reduces CPU cycles and memory to near zero as the OS is instructed to provide the file to the interface buffer for sending. There is absolutely no more userspace copying ongoing (This has plenty of requirements to work. We will revert to Chunked transfers if not all are met)
- Only compress files which are worth compressing (Currently only `gzip` and deflate but I am happy to add `Brotli` and/or `Zstd`)