### PR TITLE
Overlay fixes & configurable fade-in/out duration

### DIFF
--- a/resources/web/alerts/index.html
+++ b/resources/web/alerts/index.html
@@ -75,6 +75,7 @@
             left: 0;
             height: 100%;
             width: 100%;
+            opacity: 1 !important;
         }
 
         .animatedEmote {

--- a/resources/web/alerts/index.html
+++ b/resources/web/alerts/index.html
@@ -27,6 +27,9 @@
     <link rel="stylesheet" href="/alerts/css/animate.min.css"/>
     <!-- Main styles. -->
     <style>
+        :root {
+            --fadeTime: 200ms;
+        }
         body {
             background-color: transparent;
         }
@@ -80,11 +83,11 @@
         
         .fade-in {
           opacity: 1 !important;
-          transition: opacity 200ms ease-in;
+          transition: opacity var(--fadeTime) ease-in;
         }
         .fade-out {
           opacity: 0 !important;
-          transition: opacity 200ms ease-out;
+          transition: opacity var(--fadeTime) ease-out;
         }
     </style>
 

--- a/resources/web/alerts/index.html
+++ b/resources/web/alerts/index.html
@@ -111,7 +111,7 @@
     </div>
     <div class="main-text-alert">
         <!-- Where the custom gif text is displayed. -->
-        <div id="alert-text"></div>
+        <div id="alert-text" style="display:none"></div>
     </div>
 
     <!-- jQuery -->

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -754,13 +754,13 @@ $(function () {
             videoEl.className = 'fullscreen';
         } else {
             videoEl.className = 'fade-in';
+            if (additionalText) {
+                addAlertText(additionalText, additionalCSS)
+            }
             duration -= fadeTime;
         }
 
-        if (additionalText) {
-            addAlertText(additionalText, additionalCSS)
-            duration -= fadeTime;
-        }
+        
 
         printDebug('Loading video: ' + videoEl.src);
         printDebug('Playing video, duration: ' + videoEl.duration);

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -25,15 +25,15 @@ $(function () {
         videoEl = document.getElementById('alertVideo'),
         SILENT_WAV =
             'data:audio/wav;base64,' +
-            'UklGRmQGAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YUAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        fadeTime = 4e2; // 400ms
+            'UklGRmQGAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YUAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
     let isPlaying = false,
         audioUnlocked = false,
         unlocking = false,
         queue = [],
         queueProcessing = false,
-        playTimeout;
+        playTimeout,
+        fadeTime;
 
     imgEl.onload = () => printDebug('GIF loaded');
     imgEl.onerror = (e) => printDebug('Error: GIF failed to load: ' + e, true);
@@ -59,6 +59,7 @@ $(function () {
     const CONF_ENABLE_VIDEO_CLIPS = 'enableVideoClips';
     const CONF_VIDEO_CLIP_VOLUME = 'videoClipVolume';
     const CONF_GIF_ALERT_VOLUME = 'gifAlertVolume';
+    const CONF_FADE_DURTAION = 'fadeDuration';
 
     const PROVIDER_TWITCH = 'twitch';
     const PROVIDER_LOCAL = 'local';
@@ -423,10 +424,10 @@ $(function () {
 
         imgEl.setAttribute('style', gifCss);
         imgEl.src = gifUrl;
+        imgEl.className = 'fade-in';
         if (gifText) {
             addAlertText(gifText, gifCss);
         }
-        imgEl.className = 'fade-in';
 
         gifDuration = gifDuration === null ? 3000 : gifDuration
         gifDuration -= fadeTime;
@@ -885,6 +886,7 @@ $(function () {
         }
     };
 
+    fadeTime = getOptionSetting(CONF_FADE_DURTAION, 3e2);
     document.querySelector(':root').style.setProperty('--fadeTime', fadeTime + 'ms');
 
     // Handle processing the queue.

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -779,23 +779,6 @@ $(function () {
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
-    //https://stackoverflow.com/a/57380742
-    promisePoll = (promiseFunction, { pollIntervalMs = 2000 } = {}) => {
-        const startPoll = async resolve => {
-            const startTime = new Date();
-            const result = await promiseFunction();
-
-            if (result) {
-                return resolve();
-            }
-
-            const timeUntilNext = Math.max(pollIntervalMs - (new Date() - startTime), 0);
-            setTimeout(() => startPoll(resolve), timeUntilNext);
-        };
-
-        return new Promise(startPoll);
-    };
-
     async function handleMacro(json) {
         printDebug('Playing Macro: ' + json.macroName);
         for (let i = 0; i < json.script.length; i++) {

--- a/resources/web/panel/js/pages/overlay/overlay.js
+++ b/resources/web/panel/js/pages/overlay/overlay.js
@@ -33,6 +33,7 @@ $(function () {
     const enableVideoClips = 'enableVideoClips';
     const videoClipVolume = 'videoClipVolume';
     const enableDebug = 'enableDebug';
+    const fadeDuration = 'fadeDuration';
 
     // members
     let inputElements = null;
@@ -45,14 +46,16 @@ $(function () {
             tables: [
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
-                moduleConfigTable, moduleConfigTable, moduleConfigTable
+                moduleConfigTable, moduleConfigTable, moduleConfigTable,
+                moduleConfigTable
             ],
             keys: [
                 enableAudioHooks, audioHookVolume, enableFlyingEmotes,
                 enableGifAlerts, gifAlertVolume, enableDebug,
-                enableVideoClips, videoClipVolume, flyingEmotesSize
+                enableVideoClips, videoClipVolume, flyingEmotesSize,
+                fadeDuration
             ]
-        }, true, function (config) {
+        }, true, function(config) {
             // handle boolean values
             [
                 enableAudioHooks,
@@ -71,7 +74,7 @@ $(function () {
                 }
             });
             // handle decimals
-            [audioHookVolume, gifAlertVolume, videoClipVolume, flyingEmotesSize].forEach((key) => {
+            [audioHookVolume, gifAlertVolume, videoClipVolume, flyingEmotesSize, fadeDuration].forEach((key) => {
                 let inputNode = document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1));
                 // Convert the value to a String and then to number to validate it
                 // and use the default value, if it's invalid
@@ -121,10 +124,10 @@ $(function () {
 
     function save() {
         // Collect values from the form with special caution to checkbox elements
-        let keysStrings = [audioHookVolume, gifAlertVolume, videoClipVolume, flyingEmotesSize];
+        let keysStrings = [audioHookVolume, gifAlertVolume, videoClipVolume, flyingEmotesSize, fadeDuration];
         let keysCheckboxes = [enableAudioHooks, enableFlyingEmotes, enableGifAlerts, enableVideoClips, enableDebug];
-        let valuesStrings = keysStrings.map(key => inputElements[moduleId + key[0].toUpperCase() + key.slice(1)].value);
-        let valuesCheckboxes = keysCheckboxes.map(key => inputElements[moduleId + key[0].toUpperCase() + key.slice(1)].checked);
+        let valuesStrings = keysStrings.map(key => document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1)).value );
+        let valuesCheckboxes = keysCheckboxes.map(key => document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1)).checked );
         let keys = keysStrings.concat(keysCheckboxes);
         let values = valuesStrings.concat(valuesCheckboxes);
         // Save the values in the database omitting the success callback because value changes can happen often and fast
@@ -132,11 +135,13 @@ $(function () {
             tables: [
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
-                moduleConfigTable, moduleConfigTable, moduleConfigTable
+                moduleConfigTable, moduleConfigTable, moduleConfigTable,
+                moduleConfigTable
             ],
             keys: keys,
             values: values
         }, () => {
+            toastr.success('Successfully saved settings!');
         });
     }
 

--- a/resources/web/panel/pages/overlay/overlay.html
+++ b/resources/web/panel/pages/overlay/overlay.html
@@ -69,8 +69,8 @@
                 <!-- Box content -->
                 <div class="box-body">
                     <div class="form-group">
-                        <label for="overlayflyingEmoteSize">Flying emotes size</label>
-                        <input type="number" class="form-control trigger-update" id="overlayflyingEmoteSize" placeholder="112"
+                        <label for="overlayFlyingEmotesSize">Flying emotes size</label>
+                        <input type="number" class="form-control trigger-update" id="overlayFlyingEmotesSize" placeholder="112"
                                value="112" min="10"
                                step="1" max="1000"/>
                         <span class="help-block">Defines the flying emote's size in pixel (The default is 112).</span>
@@ -116,6 +116,22 @@
                                value="0.8" min="0.0"
                                step=".05" max="1.0"/>
                         <span class="help-block">Sets the volume of video clips where 1.0 full volume and 0.0 is silent.</span>
+                    </div>
+                </div>
+            </div>
+            <!-- Fade duration -->
+            <div class="box box-solid">
+                <div class="box-header with-border">
+                    <h3 class="box-title">Element fade in/out control</h3>
+                </div>
+                <!-- Box content -->
+                <div class="box-body">
+                    <div class="form-group">
+                        <label for="overlayFadeDuration">Fade duration in ms</label>
+                        <input type="number" class="form-control trigger-update" id="overlayFadeDuration" placeholder="300"
+                               value="300" min="0"
+                               step="1" max="1000"/>
+                        <span class="help-block">Set the duration in milliseconds it takes GIFs, alert text and video to fade in and out of the view</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Addition:
- Configurable fade-in/out duration for gif, image, video and alert text

Fixes:
- Set playback duration not always followed (regression from #3662)
- Fix fullscreen playback being fully transparent after any faded-out playback (regression from #3662)
- Alert text and image/video not fully in sync
- Alert running for `fadeDuration` longer than expected
- `overlayFlyingEmotesSize` typo preventing proper load of overlay values
- Overlay configuration `save()`-function not saving actual values after modifying (`undefined` was saved)
- Add toast notification when values were saved