### PR TITLE
ConsoleInput overhead and a little threading

### DIFF
--- a/source/com/gmt2001/Console/in.java
+++ b/source/com/gmt2001/Console/in.java
@@ -44,12 +44,9 @@ public final class in {
 
             return s;
         } catch (IOException ex) {
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException ex2) {
-            }
+            com.gmt2001.Console.err.printStackTrace(ex);
         }
 
-        return "";
+        return null;
     }
 }

--- a/source/com/gmt2001/util/concurrent/ExecutorService.java
+++ b/source/com/gmt2001/util/concurrent/ExecutorService.java
@@ -22,7 +22,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Provides an interface to a shared {@link ScheduledExecutorService}
@@ -31,7 +33,19 @@ import java.util.concurrent.TimeUnit;
  */
 public final class ExecutorService {
 
-    private static final ScheduledExecutorService SCHEDULEDEXECUTOR = Executors.newScheduledThreadPool(4);
+    private static final AtomicInteger POOL_THREAD_ID = new AtomicInteger(1);
+    private static final ThreadFactory NAMED_THREAD_FACTORY = r -> {
+        Thread t = new Thread(r);
+        t.setName("Phantombot-Executor-Thread-" + POOL_THREAD_ID.getAndIncrement());
+        t.setUncaughtExceptionHandler((thread, ex) -> {
+                com.gmt2001.Console.err.println("Uncaught exception in " + thread.getName());
+                com.gmt2001.Console.err.printStackTrace(ex);
+            }
+        );
+        return t;
+    };
+
+    private static final ScheduledExecutorService SCHEDULEDEXECUTOR = Executors.newScheduledThreadPool(4, NAMED_THREAD_FACTORY);
     private static boolean shutdown = false;
 
     private ExecutorService() {

--- a/source/tv/phantombot/console/ConsoleInputListener.java
+++ b/source/tv/phantombot/console/ConsoleInputListener.java
@@ -22,18 +22,16 @@ import tv.phantombot.event.console.ConsoleInputEvent;
 public class ConsoleInputListener extends Thread {
 
     @Override
-    @SuppressWarnings("SleepWhileInLoop")
     public void run() {
         Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
+        Thread.currentThread().setName("ConsoleInputListener::runner");
 
         while (true) {
-            try {
-                String msg = com.gmt2001.Console.in.readLine();
-                EventBus.instance().postAsync(new ConsoleInputEvent(msg));
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                com.gmt2001.Console.err.printStackTrace(e);
+            String msg = com.gmt2001.Console.in.readLine();
+            if (msg == null || msg.isEmpty()) {
+                continue;
             }
+            EventBus.instance().postAsync(new ConsoleInputEvent(msg));
         }
     }
 }


### PR DESCRIPTION
### ConsoleInput
The `ConsolInputHandler` was constantly creating empty Strings thus imposing unnecessary activity on the heap. A 1,5 hour run showed **7%** of all the bytes allocated on the heap were coming from Thread-5 (in this case running the static `ConsoleInputHandler::run`)
<img width="533" height="53" alt="image" src="https://github.com/user-attachments/assets/74135387-4156-4800-b065-1d0f6417653e" />
<img width="677" height="127" alt="image" src="https://github.com/user-attachments/assets/92857d9c-66ac-4223-ae2b-d8bd3ffb69aa" />

While a static runner for this is fine I've give it a proper thread name as well now.
As are reading the console with `readlLine()` we are not required to sleep the thread as `readLine()` is already blocking until the line has completed either via `\n` or `\r` or by `EOF` there is no explicit need to sleep again.

One could think about move the ConsoleInputHandler as well on the ExecutorService. (I'm happy to follow up on this either via this PR or a new one if you'd like)

As I was already investigating the ConsoleInput I've taken the liberty to rearrange some of the InputEventHandlers flow allowing for earlier returns thus saving some branch checks

### About Threading in PhantomBot

As I've been looking at profilers and dumps over the last weeks and I noticed the thread naming scheme is a little hit or miss in PB. Thus this PR already starts by defining a default name for the ExecutionService's Threads

In general one can see some tasks/runners using the `ExecutionService` **and** setting a thread name. Setting a thread name is rather pointless as the thread will also run a plethora of other tasks.
As named threads only makes sense for static threads, my recommendation here is to remove this thread naming in itself for tasks running on the `ExecutionService` or at the very least revert it once the task has completed (mind you this comes with an overhead). The same is true for `JSTimer` which set thread names only valid briefly.

Let me know what you prever and I am happy to implement it

**Some minor thing**
I've also added some additional threadsafety for `JSTimer`
