### PR TITLE
Alerts bugfixes & Gif/Audio Synchronization

### DIFF
--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -511,7 +511,7 @@ $(function () {
                 audioEl.removeAttribute('src');
                 audioEl.load();
                 audioEl.volume = 1;
-            } catch (e2) {
+            } catch (e) {
                 printDebug('Error: audio stop failed:' + e, true);
             }
         }

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -817,7 +817,7 @@ $(function () {
         printDebug('Playing video, duration: ' + videoEl.duration);
 
         if (duration != null && duration > 0) {
-            setTimeout(() => {
+            playTimeout = setTimeout(() => {
                 printDebug('Video complete (duration), after: ' + (duration/1000) + ' seconds');
                 stopMedia();
             }, duration);

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -488,8 +488,9 @@ $(function () {
 
         if (stopGif) {
             try {
-                if (imgEl.className = 'fade-in') {
-                    imgEl.className = 'fade-out';
+                if (imgEl.classList.contains('fade-in')) {
+                    imgEl.classList.remove('fade-in');
+                    imgEl.classList.add('fade-out');
                     shouldSleep = true;
                 }
                 if (shouldSleep) {
@@ -518,8 +519,9 @@ $(function () {
         
         if (stopVideo) {
             try {
-                if (videoEl.className = 'fade-in') {
-                    videoEl.className = 'fade-out';
+                if (videoEl.classList.contains('fade-in')) {
+                    videoEl.classList.remove('fade-in');
+                    videoEl.classList.add('fade-out');
                     shouldSleep = true;
                 }
                 if (shouldSleep) {

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -19,7 +19,7 @@
 $(function () {
     const webSocket = getWebSocket(),
         queryMap = getQueryMap(),
-        isDebug = localStorage.getItem('phantombot_alerts_debug') === 'true' || false,
+        isDebug = getOptionSetting('enableDebug', localStorage.getItem('phantombot_alerts_debug') === 'true'),
         imgEl = document.getElementById('alert'),
         audioEl = document.getElementById('alertAudio'),
         videoEl = document.getElementById('alertVideo'),

--- a/resources/web/alerts/js/index.js
+++ b/resources/web/alerts/js/index.js
@@ -502,7 +502,7 @@ $(function () {
     }
 
     async function removeAlertText() {
-        $('#alert-text').fadeOut(fadeTime, function () { //Remove the text with a fade out.
+        $('#alert-text').fadeOut((fadeTime - 10), function () { //Remove the text with a fade out slight earlier than the video/gif to prevent a jump during removal.
             let t = $(this);
             // Remove the p tag
             t.find('p').remove();

--- a/resources/web/panel/js/pages/overlay/overlay.js
+++ b/resources/web/panel/js/pages/overlay/overlay.js
@@ -34,6 +34,7 @@ $(function () {
     const videoClipVolume = 'videoClipVolume';
     const enableDebug = 'enableDebug';
     const fadeDuration = 'fadeDuration';
+    const enableAutoStopGifAlerts = 'stopGifWithAudio';
 
     // members
     let inputElements = null;
@@ -47,13 +48,13 @@ $(function () {
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
-                moduleConfigTable
+                moduleConfigTable, moduleConfigTable
             ],
             keys: [
                 enableAudioHooks, audioHookVolume, enableFlyingEmotes,
                 enableGifAlerts, gifAlertVolume, enableDebug,
                 enableVideoClips, videoClipVolume, flyingEmotesSize,
-                fadeDuration
+                fadeDuration, enableAutoStopGifAlerts
             ]
         }, true, function(config) {
             // handle boolean values
@@ -62,7 +63,8 @@ $(function () {
                 enableFlyingEmotes,
                 enableGifAlerts,
                 enableVideoClips,
-                enableDebug
+                enableDebug,
+                enableAutoStopGifAlerts
             ].forEach((key) => {
                 let inputNode = document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1));
                 // only accept 'true' and 'false' as valid
@@ -125,7 +127,7 @@ $(function () {
     function save() {
         // Collect values from the form with special caution to checkbox elements
         let keysStrings = [audioHookVolume, gifAlertVolume, videoClipVolume, flyingEmotesSize, fadeDuration];
-        let keysCheckboxes = [enableAudioHooks, enableFlyingEmotes, enableGifAlerts, enableVideoClips, enableDebug];
+        let keysCheckboxes = [enableAudioHooks, enableFlyingEmotes, enableGifAlerts, enableVideoClips, enableDebug, enableAutoStopGifAlerts];
         let valuesStrings = keysStrings.map(key => document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1)).value );
         let valuesCheckboxes = keysCheckboxes.map(key => document.getElementById(moduleId + key[0].toUpperCase() + key.slice(1)).checked );
         let keys = keysStrings.concat(keysCheckboxes);
@@ -136,7 +138,7 @@ $(function () {
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
                 moduleConfigTable, moduleConfigTable, moduleConfigTable,
-                moduleConfigTable
+                moduleConfigTable, moduleConfigTable
             ],
             keys: keys,
             values: values

--- a/resources/web/panel/pages/overlay/overlay.html
+++ b/resources/web/panel/pages/overlay/overlay.html
@@ -97,6 +97,18 @@
                         <span class="help-block">Sets the volume of Audio Alerts where 1.0 full volume and 0.0 is silent.</span>
                     </div>
                 </div>
+                <!-- Box content -->
+                <div class="box-body">
+                    <div class="form-group">
+                        <label for="overlayStopGifWithAudio">Synchronize Gif Alert & Audio Duration
+                            <label class="switch" data-toggle="tooltip" title="Synchronize Gif Alert & Audio Duration">
+                            <input type="checkbox" class="trigger-update" id="overlayStopGifWithAudio">
+                                <span class="slider round"></span>
+                            </label>
+                        </label>
+                        <span class="help-block">If enabled the Gif is automatically stopped when the audio finished playing and no duration is set in the alert-tag</span>
+                    </div>
+                </div>
             </div>
             <!-- Video clips -->
             <div class="box box-solid">


### PR DESCRIPTION
### Adds:

- Gif to Audio duration synchronization (Disabled by default to reflect previous behavior)
Synchronization is not used when the user sets a specific duration in their [alert command tag ](https://phantombot.dev/guides/#guide=content-stable/commands/command-variables&channel=stable&jumpto=global-command-tags_alerts_alert)

<img width="685" height="84" alt="image" src="https://github.com/user-attachments/assets/8b75c4df-b7d3-4399-aae9-19461a449553" />

### Fixes:

- Debug option from URL parameter not followed
- `Audio.onended()` event handler stopping all media (symptoms reported by IanDLive on Discord)
- Exception for failing to stop audio is empty
- Remove alert text a little bit earlier to prevent it from jumping in the DOM when the Gif/Video is removed faster/earlier

### General changes:

- Switch to a **playback mask** instead of a simple **boolean** to assess which media is being played. This allows discerning between multiple simultaneous playbacks of different types 
- Use proper DOM operations to check, remove and set (style-)classes
- Also save the video playback timeout