### PR TITLE
Issue 3709: In isMod check ensure that user-type does not contain staff.

### DIFF
--- a/javascript-source/core/permissions.js
+++ b/javascript-source/core/permissions.js
@@ -238,7 +238,7 @@
     function isMod(username, tags) {
         $.consoleDebug('');
         if (checkTags(tags)) {
-            if ($.strlen(tags.getOrDefault('user-type', '')) > 0 || tags.getOrDefault('mod', '0').equals('1')) {
+            if (($.strlen(tags.getOrDefault('user-type', '')) > 0 && !tags.getOrDefault('user-type', '').equals('staff')) || tags.getOrDefault('mod', '0').equals('1')) {
                 return true;
             }
         }


### PR DESCRIPTION
Modified isMod() function to ensure that staff is not in the user-type tags when determining to promote user to Moderator permission.