### PR TITLE
Fix alerts & discord reaction regression

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <dependencies defaultconf="default">
         <!-- General -->
         <dependency org="com.rollbar" name="rollbar-java" rev="2.1.0"/>
-        <dependency org="com.discord4j" name="discord4j-core" rev="3.3.0"/>
+        <dependency org="com.discord4j" name="discord4j-core" rev="3.3.2"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
         <dependency org="com.vdurmont" name="emoji-java" rev="5.1.1" />
         <!-- Networking -->

--- a/javascript-source/core/transformers/alerts.js
+++ b/javascript-source/core/transformers/alerts.js
@@ -119,7 +119,7 @@
     }
 
     let transformers = [
-        new $.transformers.transformer('alert', ['twitch', 'discord', 'noevent', 'alerts'], alerttext),
+        new $.transformers.transformer('alert', ['twitch', 'discord', 'noevent', 'alerts'], alert),
         new $.transformers.transformer('alerttext', ['twitch', 'discord', 'noevent', 'alerts'], alerttext),
         new $.transformers.transformer('playsound', ['twitch', 'discord', 'noevent', 'alerts'], playsound)
     ];

--- a/javascript-source/core/transformers/alerts.js
+++ b/javascript-source/core/transformers/alerts.js
@@ -44,7 +44,7 @@
      * @formula (alerttext -d duration:float, -c css:str, message:str) sends a text alert with the specified CSS to the alerts overlay, fading out after duration seconds
      * @labels twitch discord noevent alerts
      */
-    function alert(args) {
+    function alerttext(args) {
         let alertText = args.args;
         let alertCSS = null;
         let alertDuration = null;
@@ -119,7 +119,8 @@
     }
 
     let transformers = [
-        new $.transformers.transformer('alert', ['twitch', 'discord', 'noevent', 'alerts'], alert),
+        new $.transformers.transformer('alert', ['twitch', 'discord', 'noevent', 'alerts'], alerttext),
+        new $.transformers.transformer('alerttext', ['twitch', 'discord', 'noevent', 'alerts'], alerttext),
         new $.transformers.transformer('playsound', ['twitch', 'discord', 'noevent', 'alerts'], playsound)
     ];
 

--- a/javascript-source/discord/core/misc.js
+++ b/javascript-source/discord/core/misc.js
@@ -436,7 +436,7 @@
         var reactionEvent = event.getEvent(),
                 reactionUser = event.getSenderId();
 
-        if (event.getReactionEmoji().asUnicodeEmoji().equals(Packages.discord4j.core.object.reaction.ReactionEmoji.unicode('❌'))) {
+        if (event.getReactionEmoji().asUnicodeEmoji().equals(Packages.discord4j.core.object.emoji.Emoji.unicode('❌'))) {
             var messageID = reactionEvent.getMessage().block().getId().asString(),
                     messageInArray = messageDeleteArray[messageID];
             if (messageInArray !== undefined) {

--- a/source/tv/phantombot/discord/util/DiscordUtil.java
+++ b/source/tv/phantombot/discord/util/DiscordUtil.java
@@ -33,6 +33,8 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import com.gmt2001.PathValidator;
 import com.gmt2001.ratelimiters.ExponentialBackoff;
 import com.gmt2001.util.concurrent.ExecutorService;
@@ -1559,6 +1561,11 @@ public class DiscordUtil {
                 com.gmt2001.Console.err.printStackTrace(ex);
             }
 
+            return null;
+        }
+
+        @Override
+        public @Nullable String description() {
             return null;
         }
     }


### PR DESCRIPTION
- Fix regression from #3666 causing Reaction Event on discord to not be processed by Phantombot
       - `[ERROR] [init.js:519] Error with Event Handler [discordMessageReaction] Script [./discord/core/misc.js] Stacktrace [misc.js:436 > init.js:511 > init.js:947] Exception [TypeError: unicode is not a function, it is object.]`
- Fixes alerts (video, mp3, gif) showing only the file name#
       - Caused by new `alerttext` tag using the same function name as the `alert` tag