### PR TITLE
Fix socket.getDBTableValues calls querying for every value

### DIFF
--- a/source/tv/phantombot/panel/WsPanelHandler.java
+++ b/source/tv/phantombot/panel/WsPanelHandler.java
@@ -17,6 +17,7 @@
 package tv.phantombot.panel;
 
 import com.gmt2001.TestData;
+import com.gmt2001.datastore.KeyValue;
 import com.gmt2001.httpwsserver.HTTPWSServer;
 import com.gmt2001.httpwsserver.WebSocketFrameHandler;
 import com.gmt2001.httpwsserver.WsFrameHandler;
@@ -707,10 +708,9 @@ public class WsPanelHandler implements WsFrameHandler {
 
         jsonObject.object().key("query_id").value(uniqueID).key("results").array();
 
-        String[] dbKeys = PhantomBot.instance().getDataStore().GetKeyList(table, "");
-        for (String dbKey : dbKeys) {
-            String value = PhantomBot.instance().getDataStore().GetString(table, "", dbKey);
-            jsonObject.object().key("table").value(table).key("key").value(dbKey).key("value").value(value).endObject();
+        KeyValue[] rows = PhantomBot.instance().getDataStore().GetKeyValueList(table, "");
+        for (KeyValue row : rows) {
+            jsonObject.object().key("table").value(table).key("key").value(row.getKey()).key("value").value(row.getValue()).endObject();
         }
 
         jsonObject.endArray().endObject();


### PR DESCRIPTION
Any panel action required to get all table values was first making a query for the keys (variable name), loops through each key and queries the DB for the value.

Changed the method so that keys and values are queried in one shot.