### PR TITLE
Fix disabled textboxes and buttons

### DIFF
--- a/resources/web/panel/js/pages/loyalty/channelpoints.js
+++ b/resources/web/panel/js/pages/loyalty/channelpoints.js
@@ -256,6 +256,14 @@ $(function () {
         });
     };
 
+    const disableButtons = function  () {
+        $('#addcpreward-button').attr('disabled', 'disabled');
+        $('#refreshcprewards-button').attr('disabled', 'disabled');
+        $('#addcpredeemable-button').attr('disabled', 'disabled');
+        $('#convertcpredeemable-button').attr('disabled', 'disabled');
+        $('#refreshcpredeemables-button').attr('disabled', 'disabled');
+    };
+
     const loadRedeemables = function (cb, updateTable) {
         socket.query('channelpointslist', 'channelpoints_redeemables', null, function (e1) {
             socket.wsEvent('channelpoints_redeemable_get_managed_ws', './handlers/channelPointsHandler.js', null, ['redeemable-get-managed'], function (e2) {
@@ -273,6 +281,9 @@ $(function () {
                 if (updateTable !== false) {
                     if (e1.hasOwnProperty('error')) {
                         toastr.error('HTTP ' + e1.status + ': ' + e1.message);
+                        if (e1.hasOwnProperty('message') && e1.message.trim().toLowerCase() === 'The broadcaster must have partner or affiliate status.'.toLowerCase()) {
+                            disableButtons();
+                        }
                     } else {
                         let tableData = [];
                         for (const redeemable of redeemables) {
@@ -724,11 +735,7 @@ $(function () {
                 loadRewards();
                 loadRedeemables();
             } else {
-                $('#addcpreward-button').attr('disabled', 'disabled');
-                $('#refreshcprewards-button').attr('disabled', 'disabled');
-                $('#addcpredeemable-button').attr('disabled', 'disabled');
-                $('#convertcpredeemable-button').attr('disabled', 'disabled');
-                $('#refreshcpredeemables-button').attr('disabled', 'disabled');
+                disableButtons();
             }
         });
     };

--- a/resources/web/panel/pages/giveaways/ticketRaffle.html
+++ b/resources/web/panel/pages/giveaways/ticketRaffle.html
@@ -81,7 +81,7 @@
                             <div class="form-group">
                                 <label for="ticket-raffle-cmd">Command</label>
                                 <input id="ticket-raffle-cmd" type="text" class="form-control" value="!tickets"
-                                    data-toggle="tooltip" title="Command used to buy tickets. This cannot be changed." disabled/>
+                                    data-toggle="tooltip" title="Command used to buy tickets. This cannot be changed." readonly/>
                             </div>
 
                             <!-- Eligibility -->


### PR DESCRIPTION
There is one instance where the buttons should be disabled when they are not:
- Channelpoints have working buttons even when the streamer is not a twitch partner and thus returns a `HTTP 403` with the message "The broadcaster must have partner or affiliate status." . We thus disable the buttons instead of enabling them

There is on instance where a (text)-input field should be disabled but the `disabled` keyword is wrong here and it should be `readonly`.
<img width="218" height="59" alt="image" src="https://github.com/user-attachments/assets/15276708-8829-4fde-b86b-85b80631491f" />
