### PR TITLE
Rhino interpret mode support & misc

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -64,8 +64,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <dependency org="commons-io" name="commons-io" rev="2.21.0"/>
         <dependency org="org.apache.commons" name="commons-text" rev="1.15.0"/>
         <dependency org="org.json" name="json" rev="20251224"/>
-        <dependency org="org.mozilla" name="rhino" rev="1.9.0"/>
-        <dependency org="org.mozilla" name="rhino-tools" rev="1.9.0"/>
+        <dependency org="org.mozilla" name="rhino" rev="1.9.1"/>
+        <dependency org="org.mozilla" name="rhino-tools" rev="1.9.1"/>
         <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.17"/>
         <!-- Conflict Resolvers -->
         <conflict org="com.h2database" manager="all"/>

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -946,31 +946,31 @@ public final class PhantomBot implements Listener {
          * @botpropertyrestart owner
          */
         com.gmt2001.Console.debug.println("Init globals");
-        Script.GLOBAL.defineProperty("inidb", DataStore.instance(), 0);
-        Script.GLOBAL.defineProperty("datastore", Datastore2.instance(), 0);
-        Script.GLOBAL.defineProperty("username", UsernameCache.instance(), 0);
-        Script.GLOBAL.defineProperty("twitch", TwitchAPIv5.instance(), 0);
-        Script.GLOBAL.defineProperty("helix", Helix.instance(), 0);
-        Script.GLOBAL.defineProperty("botName", this.getBotName(), 0);
-        Script.GLOBAL.defineProperty("channelName", this.getChannelName(), 0);
-        Script.GLOBAL.defineProperty("ownerName", CaselessProperties.instance().getProperty("owner", this.getChannelName()).toLowerCase(), 0);
-        Script.GLOBAL.defineProperty("ytplayer", this.ytHandler, 0);
-        Script.GLOBAL.defineProperty("panelsocketserver", this.panelHandler, 0);
-        Script.GLOBAL.defineProperty("alertspollssocket", this.alertsPollsHandler, 0);
-        Script.GLOBAL.defineProperty("random", this.random, 0);
-        Script.GLOBAL.defineProperty("youtube", YouTubeAPIv3.instance(), 0);
-        Script.GLOBAL.defineProperty("twitchCacheReady", PhantomBot.twitchCacheReady, 0);
-        Script.GLOBAL.defineProperty("isNightly", this.isNightly(), 0);
-        Script.GLOBAL.defineProperty("isPrerelease", this.isPrerelease(), 0);
-        Script.GLOBAL.defineProperty("version", this.botVersion(), 0);
-        Script.GLOBAL.defineProperty("changed", CaselessProperties.instance().getPropertyAsBoolean("newSetup", false), 0);
-        Script.GLOBAL.defineProperty("discordAPI", DiscordAPI.instance(), 0);
-        Script.GLOBAL.defineProperty("hasDiscordToken", hasDiscordToken(), 0);
-        Script.GLOBAL.defineProperty("customAPI", CustomAPI.instance(), 0);
-        Script.GLOBAL.defineProperty("streamLabsAPI", StreamLabsAPI.instance(), 0);
+        RhinoRuntime.ExposePropertyToScripts("inidb", DataStore.instance());
+        RhinoRuntime.ExposePropertyToScripts("datastore", Datastore2.instance());
+        RhinoRuntime.ExposePropertyToScripts("username", UsernameCache.instance());
+        RhinoRuntime.ExposePropertyToScripts("twitch", TwitchAPIv5.instance());
+        RhinoRuntime.ExposePropertyToScripts("helix", Helix.instance());
+        RhinoRuntime.ExposePropertyToScripts("botName", this.getBotName());
+        RhinoRuntime.ExposePropertyToScripts("channelName", this.getChannelName());
+        RhinoRuntime.ExposePropertyToScripts("ownerName", CaselessProperties.instance().getProperty("owner", this.getChannelName()).toLowerCase());
+        RhinoRuntime.ExposePropertyToScripts("ytplayer", this.ytHandler);
+        RhinoRuntime.ExposePropertyToScripts("panelsocketserver", this.panelHandler);
+        RhinoRuntime.ExposePropertyToScripts("alertspollssocket", this.alertsPollsHandler);
+        RhinoRuntime.ExposePropertyToScripts("random", this.random);
+        RhinoRuntime.ExposePropertyToScripts("youtube", YouTubeAPIv3.instance());
+        RhinoRuntime.ExposePropertyToScripts("twitchCacheReady", PhantomBot.twitchCacheReady);
+        RhinoRuntime.ExposePropertyToScripts("isNightly", this.isNightly());
+        RhinoRuntime.ExposePropertyToScripts("isPrerelease", this.isPrerelease());
+        RhinoRuntime.ExposePropertyToScripts("version", this.botVersion());
+        RhinoRuntime.ExposePropertyToScripts("changed", CaselessProperties.instance().getPropertyAsBoolean("newSetup", false));
+        RhinoRuntime.ExposePropertyToScripts("discordAPI", DiscordAPI.instance());
+        RhinoRuntime.ExposePropertyToScripts("hasDiscordToken", hasDiscordToken());
+        RhinoRuntime.ExposePropertyToScripts("customAPI", CustomAPI.instance());
+        RhinoRuntime.ExposePropertyToScripts("streamLabsAPI", StreamLabsAPI.instance());
         this.twitchCache = TwitchCache.instance();
-        Script.GLOBAL.defineProperty("twitchcache", this.twitchCache, 0);
-        Script.GLOBAL.defineProperty("viewer", ViewerCache.instance(), 0);
+        RhinoRuntime.ExposePropertyToScripts("twitchcache", this.twitchCache);
+        RhinoRuntime.ExposePropertyToScripts("viewer", ViewerCache.instance());
 
         /* And finally try to load init, that will then load the scripts */
         try {
@@ -1179,10 +1179,10 @@ public final class PhantomBot implements Listener {
         this.streamElementCache = StreamElementsCache.instance();
 
         /* Export these to the $. api for the sripts to use */
-        Script.GLOBAL.defineProperty("twitchteamscache", this.twitchTeamCache, 0);
-        Script.GLOBAL.defineProperty("emotes", this.emotesCache, 0);
-        Script.GLOBAL.defineProperty("followers", this.followersCache, 0);
-        Script.GLOBAL.defineProperty("usernameCache", this.viewerListCache, 0);
+        RhinoRuntime.ExposePropertyToScripts("twitchteamscache", this.twitchTeamCache);
+        RhinoRuntime.ExposePropertyToScripts("emotes", this.emotesCache);
+        RhinoRuntime.ExposePropertyToScripts("followers", this.followersCache);
+        RhinoRuntime.ExposePropertyToScripts("usernameCache", this.viewerListCache);
 
         com.gmt2001.Console.debug.println("Init EventSub");
         EventSub.instance();
@@ -1474,7 +1474,7 @@ public final class PhantomBot implements Listener {
      */
     public void setTwitchCacheReady(boolean twitchCacheReady) {
         PhantomBot.twitchCacheReady = twitchCacheReady;
-        Script.GLOBAL.defineProperty("twitchCacheReady", PhantomBot.twitchCacheReady, 0);
+        RhinoRuntime.ExposePropertyToScripts("twitchCacheReady", PhantomBot.twitchCacheReady);
     }
 
     /**

--- a/source/tv/phantombot/PhantomBot.java
+++ b/source/tv/phantombot/PhantomBot.java
@@ -946,31 +946,31 @@ public final class PhantomBot implements Listener {
          * @botpropertyrestart owner
          */
         com.gmt2001.Console.debug.println("Init globals");
-        Script.global.defineProperty("inidb", DataStore.instance(), 0);
-        Script.global.defineProperty("datastore", Datastore2.instance(), 0);
-        Script.global.defineProperty("username", UsernameCache.instance(), 0);
-        Script.global.defineProperty("twitch", TwitchAPIv5.instance(), 0);
-        Script.global.defineProperty("helix", Helix.instance(), 0);
-        Script.global.defineProperty("botName", this.getBotName(), 0);
-        Script.global.defineProperty("channelName", this.getChannelName(), 0);
-        Script.global.defineProperty("ownerName", CaselessProperties.instance().getProperty("owner", this.getChannelName()).toLowerCase(), 0);
-        Script.global.defineProperty("ytplayer", this.ytHandler, 0);
-        Script.global.defineProperty("panelsocketserver", this.panelHandler, 0);
-        Script.global.defineProperty("alertspollssocket", this.alertsPollsHandler, 0);
-        Script.global.defineProperty("random", this.random, 0);
-        Script.global.defineProperty("youtube", YouTubeAPIv3.instance(), 0);
-        Script.global.defineProperty("twitchCacheReady", PhantomBot.twitchCacheReady, 0);
-        Script.global.defineProperty("isNightly", this.isNightly(), 0);
-        Script.global.defineProperty("isPrerelease", this.isPrerelease(), 0);
-        Script.global.defineProperty("version", this.botVersion(), 0);
-        Script.global.defineProperty("changed", CaselessProperties.instance().getPropertyAsBoolean("newSetup", false), 0);
-        Script.global.defineProperty("discordAPI", DiscordAPI.instance(), 0);
-        Script.global.defineProperty("hasDiscordToken", hasDiscordToken(), 0);
-        Script.global.defineProperty("customAPI", CustomAPI.instance(), 0);
-        Script.global.defineProperty("streamLabsAPI", StreamLabsAPI.instance(), 0);
+        Script.GLOBAL.defineProperty("inidb", DataStore.instance(), 0);
+        Script.GLOBAL.defineProperty("datastore", Datastore2.instance(), 0);
+        Script.GLOBAL.defineProperty("username", UsernameCache.instance(), 0);
+        Script.GLOBAL.defineProperty("twitch", TwitchAPIv5.instance(), 0);
+        Script.GLOBAL.defineProperty("helix", Helix.instance(), 0);
+        Script.GLOBAL.defineProperty("botName", this.getBotName(), 0);
+        Script.GLOBAL.defineProperty("channelName", this.getChannelName(), 0);
+        Script.GLOBAL.defineProperty("ownerName", CaselessProperties.instance().getProperty("owner", this.getChannelName()).toLowerCase(), 0);
+        Script.GLOBAL.defineProperty("ytplayer", this.ytHandler, 0);
+        Script.GLOBAL.defineProperty("panelsocketserver", this.panelHandler, 0);
+        Script.GLOBAL.defineProperty("alertspollssocket", this.alertsPollsHandler, 0);
+        Script.GLOBAL.defineProperty("random", this.random, 0);
+        Script.GLOBAL.defineProperty("youtube", YouTubeAPIv3.instance(), 0);
+        Script.GLOBAL.defineProperty("twitchCacheReady", PhantomBot.twitchCacheReady, 0);
+        Script.GLOBAL.defineProperty("isNightly", this.isNightly(), 0);
+        Script.GLOBAL.defineProperty("isPrerelease", this.isPrerelease(), 0);
+        Script.GLOBAL.defineProperty("version", this.botVersion(), 0);
+        Script.GLOBAL.defineProperty("changed", CaselessProperties.instance().getPropertyAsBoolean("newSetup", false), 0);
+        Script.GLOBAL.defineProperty("discordAPI", DiscordAPI.instance(), 0);
+        Script.GLOBAL.defineProperty("hasDiscordToken", hasDiscordToken(), 0);
+        Script.GLOBAL.defineProperty("customAPI", CustomAPI.instance(), 0);
+        Script.GLOBAL.defineProperty("streamLabsAPI", StreamLabsAPI.instance(), 0);
         this.twitchCache = TwitchCache.instance();
-        Script.global.defineProperty("twitchcache", this.twitchCache, 0);
-        Script.global.defineProperty("viewer", ViewerCache.instance(), 0);
+        Script.GLOBAL.defineProperty("twitchcache", this.twitchCache, 0);
+        Script.GLOBAL.defineProperty("viewer", ViewerCache.instance(), 0);
 
         /* And finally try to load init, that will then load the scripts */
         try {
@@ -1179,10 +1179,10 @@ public final class PhantomBot implements Listener {
         this.streamElementCache = StreamElementsCache.instance();
 
         /* Export these to the $. api for the sripts to use */
-        Script.global.defineProperty("twitchteamscache", this.twitchTeamCache, 0);
-        Script.global.defineProperty("emotes", this.emotesCache, 0);
-        Script.global.defineProperty("followers", this.followersCache, 0);
-        Script.global.defineProperty("usernameCache", this.viewerListCache, 0);
+        Script.GLOBAL.defineProperty("twitchteamscache", this.twitchTeamCache, 0);
+        Script.GLOBAL.defineProperty("emotes", this.emotesCache, 0);
+        Script.GLOBAL.defineProperty("followers", this.followersCache, 0);
+        Script.GLOBAL.defineProperty("usernameCache", this.viewerListCache, 0);
 
         com.gmt2001.Console.debug.println("Init EventSub");
         EventSub.instance();
@@ -1474,7 +1474,7 @@ public final class PhantomBot implements Listener {
      */
     public void setTwitchCacheReady(boolean twitchCacheReady) {
         PhantomBot.twitchCacheReady = twitchCacheReady;
-        Script.global.defineProperty("twitchCacheReady", PhantomBot.twitchCacheReady, 0);
+        Script.GLOBAL.defineProperty("twitchCacheReady", PhantomBot.twitchCacheReady, 0);
     }
 
     /**

--- a/source/tv/phantombot/console/ConsoleEventHandler.java
+++ b/source/tv/phantombot/console/ConsoleEventHandler.java
@@ -75,7 +75,7 @@ import tv.phantombot.event.twitch.subscriber.TwitchReSubscriberEvent;
 import tv.phantombot.event.twitch.subscriber.TwitchSubscriberEvent;
 import tv.phantombot.event.twitch.subscriber.TwitchSubscriptionGiftEvent;
 import tv.phantombot.panel.PanelUser.PanelUserHandler;
-import tv.phantombot.script.Script;
+import tv.phantombot.script.RhinoRuntime;
 
 public final class ConsoleEventHandler implements Listener {
 
@@ -312,7 +312,7 @@ public final class ConsoleEventHandler implements Listener {
                 str[0] = ("!" + key);
                 str[1] = PhantomBot.instance().getDataStore().get("groups",
                         PhantomBot.instance().getDataStore().get("permcom", key));
-                str[2] = Script.callMethod("getCommandScript",
+                str[2] = RhinoRuntime.callGlobalExposedScriptMethod("getCommandScript",
                         key.contains(" ") ? key.substring(0, key.indexOf(' ')) : key);
                 // If the module is disabled, return.
                 if (str[2].contains("Undefined")) {

--- a/source/tv/phantombot/script/RhinoContextFactory.java
+++ b/source/tv/phantombot/script/RhinoContextFactory.java
@@ -20,6 +20,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 
 import tv.phantombot.CaselessProperties;
+import tv.phantombot.PhantomBot;
 
 /**
  * Custom Rhino ContextFactory
@@ -32,6 +33,9 @@ public final class RhinoContextFactory extends ContextFactory {
         Context cx = super.makeContext();
         if (CaselessProperties.instance().getPropertyAsBoolean("rhinointerpretmode", false)) {
             cx.setInterpretedMode(true);
+        }
+        if (PhantomBot.getEnableRhinoDebugger()) {
+            cx.setGeneratingDebug(true);
         }
         return cx;
     }

--- a/source/tv/phantombot/script/RhinoContextFactory.java
+++ b/source/tv/phantombot/script/RhinoContextFactory.java
@@ -19,6 +19,8 @@ package tv.phantombot.script;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 
+import tv.phantombot.CaselessProperties;
+
 /**
  * Custom Rhino ContextFactory
  * @author sartharon
@@ -28,6 +30,9 @@ public final class RhinoContextFactory extends ContextFactory {
     @Override
     protected Context makeContext() {
         Context cx = super.makeContext();
+        if (CaselessProperties.instance().getPropertyAsBoolean("rhinointerpretmode", false)) {
+            cx.setInterpretedMode(true);
+        }
         return cx;
     }
 

--- a/source/tv/phantombot/script/RhinoRuntime.java
+++ b/source/tv/phantombot/script/RhinoRuntime.java
@@ -95,6 +95,12 @@ public final class RhinoRuntime {
         return BASESCOPE;
     }
 
+
+    public static String callGlobalExposedScriptMethod(String method, String arg) {
+        Object[] obj = new Object[]{arg};
+        return ScriptableObject.callMethod(FACTORY.enterContext(), GLOBAL, method, obj).toString();
+    }
+
     /**
      * Expose a property to all scripts via the {@code $} api. Scripts can later use {@code $.property} and {@code $.property.function()} to access these
      * @param propertyName The name of the property visible to the scripts

--- a/source/tv/phantombot/script/RhinoRuntime.java
+++ b/source/tv/phantombot/script/RhinoRuntime.java
@@ -16,7 +16,9 @@
  */
 package tv.phantombot.script;
 
+import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.StackStyle;
 import org.mozilla.javascript.tools.debugger.Main;
 
@@ -28,6 +30,8 @@ import tv.phantombot.CaselessProperties;
  */
 public final class RhinoRuntime {
     private static final RhinoContextFactory FACTORY = new RhinoContextFactory();
+    private static final NativeObject GLOBAL = new NativeObject(); // $ api used in scripts
+    private static ScriptableObject BASESCOPE;
     private static Main guiDebugger;
 
     private RhinoRuntime() {}
@@ -35,7 +39,7 @@ public final class RhinoRuntime {
     /**
      * Get the Rhino ContextFactory instance.
      */
-    public static RhinoContextFactory factory() {
+    public static RhinoContextFactory getContextFactory() {
         return FACTORY;
     }
 
@@ -50,6 +54,9 @@ public final class RhinoRuntime {
         if (enableGuiDebugger) {
             guiDebugger = new Main("Rhino Debugger");
             guiDebugger.attachTo(FACTORY);
+            guiDebugger.setBreakOnEnter(false);
+            guiDebugger.setSize(640, 480);
+            guiDebugger.setVisible(true);
         }
 
         /**
@@ -62,6 +69,14 @@ public final class RhinoRuntime {
         } else {
             com.gmt2001.Console.debug.println("Initializing Rhino in JIT mode. Producing compiled ByteCode!");
         }
+
+        BASESCOPE = getContextFactory().enterContext().initStandardObjects(new NativeObject(), false); //Holds globally, scopeless defined things like setInterval() etc.
+        BASESCOPE.defineProperty("$", GLOBAL, ScriptableObject.PERMANENT);// Global functions that can only be accessed and replaced with $.
+        BASESCOPE.defineProperty("$api", ScriptApi.instance(), ScriptableObject.PERMANENT);
+
+        if (enableGuiDebugger) {
+            guiDebugger.setScope(BASESCOPE);
+        }
     }
 
 
@@ -69,7 +84,23 @@ public final class RhinoRuntime {
      * Get the Rhino GUI debugger instance
      * @return
      */
-    public static Main debugger() {
+    public static Main getDebugger() {
         return guiDebugger;
+    }
+
+    /**
+     * Get the shared default Phantombot Rhino runtime script scope
+     */
+    public static ScriptableObject getBaseScope() {
+        return BASESCOPE;
+    }
+
+    /**
+     * Expose a property to all scripts via the {@code $} api. Scripts can later use {@code $.property} and {@code $.property.function()} to access these
+     * @param propertyName The name of the property visible to the scripts
+     * @param property The property object to be exposed to the scripts
+     */
+    public static void ExposePropertyToScripts(String propertyName, Object property) {
+        GLOBAL.defineProperty(propertyName, property, ScriptableObject.PERMANENT);
     }
 }

--- a/source/tv/phantombot/script/RhinoRuntime.java
+++ b/source/tv/phantombot/script/RhinoRuntime.java
@@ -21,6 +21,8 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.StackStyle;
 import org.mozilla.javascript.tools.debugger.Main;
 
+import tv.phantombot.CaselessProperties;
+
 /**
  * Rhino runtime environment configuration and management.
  * @author sartharon
@@ -49,6 +51,17 @@ public final class RhinoRuntime {
         if (enableGuiDebugger) {
             guiDebugger = new Main("Rhino Debugger");
             guiDebugger.attachTo(FACTORY);
+        }
+
+        /**
+         * @botproperty rhinointerpretmode - If `true`, Rhino will be running in interpret mode and won't compile ByteCode on the fly. Interpret mode is slower but can lead to reduced memory usage. Default `false`
+         * @botpropertycatsort rhinointerpretmode 10 50 Misc
+         * @botpropertyrestart rhinointerpretmode
+         */
+        if (CaselessProperties.instance().getPropertyAsBoolean("rhinointerpretmode", false)) {
+            com.gmt2001.Console.debug.println("Initializing Rhino in interpret mode. Scripts will not be compiled in to ByteCode!");
+        } else {
+            com.gmt2001.Console.debug.println("Initializing Rhino in JIT mode. Producing compiled ByteCode!");
         }
     }
 

--- a/source/tv/phantombot/script/RhinoRuntime.java
+++ b/source/tv/phantombot/script/RhinoRuntime.java
@@ -16,7 +16,6 @@
  */
 package tv.phantombot.script;
 
-import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.StackStyle;
 import org.mozilla.javascript.tools.debugger.Main;
@@ -36,7 +35,7 @@ public final class RhinoRuntime {
     /**
      * Get the Rhino ContextFactory instance.
      */
-    public static ContextFactory factory() {
+    public static RhinoContextFactory factory() {
         return FACTORY;
     }
 

--- a/source/tv/phantombot/script/RhinoRuntime.java
+++ b/source/tv/phantombot/script/RhinoRuntime.java
@@ -39,10 +39,9 @@ public final class RhinoRuntime {
     /**
      * Get the Rhino ContextFactory instance.
      */
-    public static RhinoContextFactory getContextFactory() {
+    protected static RhinoContextFactory getContextFactory() {
         return FACTORY;
     }
-
     
     /**
      * Initialize the Rhino runtime environment with optional GUI debugger.
@@ -79,22 +78,12 @@ public final class RhinoRuntime {
         }
     }
 
-
-    /**
-     * Get the Rhino GUI debugger instance
-     * @return
-     */
-    public static Main getDebugger() {
-        return guiDebugger;
-    }
-
     /**
      * Get the shared default Phantombot Rhino runtime script scope
      */
-    public static ScriptableObject getBaseScope() {
+    protected static ScriptableObject getBaseScope() {
         return BASESCOPE;
     }
-
 
     public static String callGlobalExposedScriptMethod(String method, String arg) {
         Object[] obj = new Object[]{arg};

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -25,22 +25,17 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.ScriptableObject;
 
 import tv.phantombot.PhantomBot;
 
 public class Script {
-
-    public static final NativeObject GLOBAL = new NativeObject();
-    private static final NativeObject VARS = new NativeObject();
     private final List<ScriptDestroyable<?>> destroyables = new ArrayList<>();
     private final File file;
     private final String fileName;
     private long lastModified;
     private boolean killed = false;
-    private ScriptableObject scope;
 
     public Script(File file, String fileName) {
         this.file = file;
@@ -58,8 +53,7 @@ public class Script {
 
     public static String callMethod(String method, String arg) {
         Object[] obj = new Object[]{arg};
-
-        return ScriptableObject.callMethod(GLOBAL, method, obj).toString();
+        return ScriptableObject.callMethod(RhinoRuntime.GLOBAL, method, obj).toString();
     }
 
     public void reload() throws IOException {
@@ -72,8 +66,8 @@ public class Script {
         }
 
         doDestroyables();
-        scope = null;
         load();
+
         if (silent) {
             if (file.getPath().endsWith("init.js")) {
                 com.gmt2001.Console.out.println("Reloaded module: init.js");
@@ -98,28 +92,12 @@ public class Script {
             return;
         }
 
-        Context context = RhinoRuntime.factory().enterContext();
-
-        if (scope == null) {
-            scope = context.initStandardObjects(VARS, false);//Normal scripting object.
-            scope.defineProperty("$", GLOBAL, ScriptableObject.PERMANENT);// Global functions that can only be accessed and replaced with $.
-            scope.defineProperty("$api", ScriptApi.instance(), ScriptableObject.PERMANENT);
-            scope.defineProperty("$script", this, ScriptableObject.PERMANENT);
-        }
-
-        /* Configure debugger. */
-        if (RhinoRuntime.debugger() != null) {
-            context.setGeneratingDebug(true);
-            if (file.getName().endsWith("init.js") ) {
-                RhinoRuntime.debugger().setBreakOnEnter(false);
-                RhinoRuntime.debugger().setScope(scope);
-                RhinoRuntime.debugger().setSize(640, 480);
-                RhinoRuntime.debugger().setVisible(true);
-            }
-        }
+        Context context = RhinoRuntime.getContextFactory().enterContext();
+        ScriptableObject localscope = RhinoRuntime.getBaseScope();
+        localscope.defineProperty("$script", this, ScriptableObject.PERMANENT);
 
         try {
-            context.evaluateString(scope, Files.readString(file.toPath()), file.getName(), 1, null);
+            context.evaluateString(localscope, Files.readString(file.toPath()), file.getName(), 1, null);
         } catch (IOException | RhinoException ex) {
             com.gmt2001.Console.err.println(ex.getMessage());
             com.gmt2001.Console.err.printStackTrace(ex, Map.of("file", this.getPath()));
@@ -170,8 +148,7 @@ public class Script {
         ObservingDebugger od = null;
         if (PhantomBot.getEnableRhinoDebugger()) {
             od = new ObservingDebugger();
-            com.gmt2001.Console.out.println("Entering exit debugger context for script: " + file.getName());
-            Context context = RhinoRuntime.factory().enterContext();
+            Context context = RhinoRuntime.getContextFactory().enterContext();
             context.setDebugger(od, 0);
             context.setGeneratingDebug(true);
         }
@@ -181,7 +158,7 @@ public class Script {
 
         if (od != null) {
             od.setDisconnected(true);
-        }        
+        }
     }
 
     @Override

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -33,17 +33,15 @@ import tv.phantombot.PhantomBot;
 
 public class Script {
 
-    public static final NativeObject global = new NativeObject();
+    public static final NativeObject GLOBAL = new NativeObject();
+    private static final NativeObject VARS = new NativeObject();
     private final List<ScriptDestroyable<?>> destroyables = new ArrayList<>();
-    private static final NativeObject vars = new NativeObject();
     private final File file;
     private final String fileName;
     private long lastModified;
-    private Context context;
     private boolean killed = false;
     private ScriptableObject scope;
 
-    @SuppressWarnings({"CallToThreadStartDuringObjectConstruction", "LeakingThisInConstructor"})
     public Script(File file, String fileName) {
         this.file = file;
         this.fileName = fileName;
@@ -61,7 +59,7 @@ public class Script {
     public static String callMethod(String method, String arg) {
         Object[] obj = new Object[]{arg};
 
-        return ScriptableObject.callMethod(global, method, obj).toString();
+        return ScriptableObject.callMethod(GLOBAL, method, obj).toString();
     }
 
     public void reload() throws IOException {
@@ -70,6 +68,9 @@ public class Script {
         }
 
         doDestroyables();
+
+        scope = null;
+
         load();
         if (file.getPath().endsWith("init.js")) {
             com.gmt2001.Console.out.println("Reloaded module: init.js");
@@ -110,10 +111,10 @@ public class Script {
             return;
         }
 
-        context = RhinoRuntime.factory().enterContext();
+        Context context = RhinoRuntime.factory().enterContext();
 
-        scope = context.initStandardObjects(vars, false);//Normal scripting object.
-        scope.defineProperty("$", global, 0);// Global functions that can only be accessed and replaced with $.
+        scope = context.initStandardObjects(VARS, false);//Normal scripting object.
+        scope.defineProperty("$", GLOBAL, 0);// Global functions that can only be accessed and replaced with $.
         scope.defineProperty("$api", ScriptApi.instance(), 0);
         scope.defineProperty("$script", this, 0);
 
@@ -172,24 +173,26 @@ public class Script {
         return fileName;
     }
 
-    public Context getContext() {
-        return context;
-    }
-
     public boolean isKilled() {
         return killed;
     }
 
     public void kill() {
-        if (context == null) {
-            return;
+        ObservingDebugger od = null;
+        if (PhantomBot.getEnableRhinoDebugger()) {
+            od = new ObservingDebugger();
+            com.gmt2001.Console.out.println("Entering exit debugger context for script: " + file.getName());
+            Context context = RhinoRuntime.factory().enterContext();
+            context.setDebugger(od, 0);
+            context.setGeneratingDebug(true);
         }
-        ObservingDebugger od = new ObservingDebugger();
-        context.setDebugger(od, 0);
-        context.setGeneratingDebug(true);
+
         doDestroyables();
-        od.setDisconnected(true);
         killed = true;
+
+        if (od != null) {
+            od.setDisconnected(true);
+        }        
     }
 
     @Override

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -63,21 +63,7 @@ public class Script {
     }
 
     public void reload() throws IOException {
-        if (killed) {
-            return;
-        }
-
-        doDestroyables();
-
-        scope = null;
-
-        load();
-        if (file.getPath().endsWith("init.js")) {
-            com.gmt2001.Console.out.println("Reloaded module: init.js");
-        } else {
-            String path = file.getPath().replace("\056\134", "").replace("\134", "/").replace("scripts/", "");
-            com.gmt2001.Console.out.println("Reloaded module: " + path);
-        }
+        reload(true);
     }
 
     public void reload(boolean silent) throws IOException {
@@ -86,6 +72,7 @@ public class Script {
         }
 
         doDestroyables();
+        scope = null;
         load();
         if (silent) {
             if (file.getPath().endsWith("init.js")) {

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -113,10 +113,12 @@ public class Script {
 
         Context context = RhinoRuntime.factory().enterContext();
 
-        scope = context.initStandardObjects(VARS, false);//Normal scripting object.
-        scope.defineProperty("$", GLOBAL, 0);// Global functions that can only be accessed and replaced with $.
-        scope.defineProperty("$api", ScriptApi.instance(), 0);
-        scope.defineProperty("$script", this, 0);
+        if (scope == null) {
+            scope = context.initStandardObjects(VARS, false);//Normal scripting object.
+            scope.defineProperty("$", GLOBAL, ScriptableObject.PERMANENT);// Global functions that can only be accessed and replaced with $.
+            scope.defineProperty("$api", ScriptApi.instance(), ScriptableObject.PERMANENT);
+            scope.defineProperty("$script", this, ScriptableObject.PERMANENT);
+        }
 
         /* Configure debugger. */
         if (RhinoRuntime.debugger() != null) {

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -51,11 +51,6 @@ public class Script {
         }
     }
 
-    public static String callMethod(String method, String arg) {
-        Object[] obj = new Object[]{arg};
-        return ScriptableObject.callMethod(RhinoRuntime.GLOBAL, method, obj).toString();
-    }
-
     public void reload() throws IOException {
         reload(true);
     }


### PR DESCRIPTION
- Update Rhino to [1.9.1](https://github.com/mozilla/rhino/releases/tag/Rhino1_9_1_Release)
- Add _botlogin.txt_ property `rhinointerpretmode` to enable Rhino's interpret mode avoiding ByteCode compilation. This allows the user to either choose
     - `true`: the **memory efficiency** of JIT interpreted scripts
     - `false`: the compiled bytecode's **performance**
         - `rhinointerpretmode` defaults to `false`
- Strip the Script class of any unneeded variables and code.
    - Global variables and base scope is build in the RhinoRuntime upon initialisation
    - `Context` is not worth saving as it's volatile and thread-local. `enterContext()` handles proper context attaching