### PR TITLE
Feature: Integrate panel user permissions by section for custom modules

### DIFF
--- a/docs/guides/content/developerdocs/custommodules.md
+++ b/docs/guides/content/developerdocs/custommodules.md
@@ -111,6 +111,49 @@ Illustrates **`nav`** plus one **Games** **`cards`** entry with **`detailsModal`
 
 The bot reads every **`web/panel/custom/<moduleId>/manifest.json`**, merges valid entries, and serves **`GET /panel/custom-manifests.json`** (authenticated). Responses are cacheable like other panel static assets (strong **ETag**, **304** when unchanged). Invalid entries are skipped with a **`warn`** log line that names the manifest path—check the bot console if UI is missing.
 
+### Panel user permissions (section-based)
+
+Custom modules use the same **Settings → Panel Users** sections as stock panel areas—**not** per-module ACL. Grant **Extra** for a typical `nav.section: "extra"` page, or **Games** for `cards.section: "games"`.
+
+| Panel Users access on the section | Custom `nav` / `cards` in that section |
+| --- | --- |
+| **Full Access** | Visible; settings, toggles, saves, and custom page writes allowed. Websocket checks use the manifest **`section`** (e.g. `extra` or `games`) on each panel message. |
+| **Read Only** | Visible; viewing and read-only details allowed. Writes are blocked on the server. In the UI, **Games** card toggles/settings are disabled; clicks show the stock **Permissions error** toast. **Custom nav pages** must implement the same pattern in their own page JS (see below)—the manifest does not wire your buttons. |
+| **No access** (section not granted) | Omitted from **`custom-manifests.json`** for that user; sidebar block is hidden like stock pages. |
+
+Set **`nav.section`** to `extra`, `alerts`, `giveaways`, or `audio`. Set **`cards.section`** to `games` (only supported card section today).
+
+The bot rebuilds an internal index whenever manifests change: every **`settingsModal`** field **`table`** (and **`cards.scriptPath`**) is mapped to that entry’s **`section`** for Panel User websocket checks—no module-specific names are compiled into PhantomBot.
+
+**Websocket `section`:** `socket.getDBValues`, `socket.updateDBValues`, `socket.sendCommand`, and related panel APIs attach **`message.section`** from the active page. For manifest nav, that value comes from **`nav.section`** (`data-panel-section` on the sidebar link). Users should open your page through that link so section checks match **Settings → Panel Users**.
+
+#### Declarative Games cards (built-in UI)
+
+When `cards` are rendered, the panel applies read-only styling automatically: module toggle and settings cog are non-interactive for write, with tooltip text from **`window.__pbCustomPanel__.READ_ONLY_PANEL_TITLE`**. Clicks call **`requirePanelSectionWrite('games')`** and show the permission toast. Declarative **`settingsModal`** saves are blocked the same way.
+
+#### Custom nav pages (your page JS)
+
+Manifest **`nav`** only adds the sidebar link and sets **`section`** on websocket traffic. Buttons, tables, and modals in **`web/panel/pages/custom/<moduleId>/`** are **your** responsibility.
+
+Use the shared namespace **`window.__pbCustomPanel__`** (from `customPanelManifestLoader.js`, loaded in `index.html` before your page script):
+
+| Helper | Purpose |
+| --- | --- |
+| `panelSectionCanWrite(section)` | `true` when the user has **Full Access** on that section. |
+| `requirePanelSectionWrite(section)` | Returns `false` and shows the **Permissions error** toast when read-only; use at the start of click/save handlers. |
+| `READ_ONLY_PANEL_TITLE` | Tooltip for disabled write controls. |
+
+Recommended pattern for read-only users:
+
+- Keep write controls **visible** but styled disabled (`cursor: not-allowed`, reduced opacity, `aria-disabled="true"`).
+- Do **not** use Bootstrap’s `disabled` class on buttons you still want to accept clicks— it sets `pointer-events: none` and blocks the toast.
+- Call **`requirePanelSectionWrite`** (or check **`panelSectionCanWrite`**) before opening modals, confirming deletes, or sending commands.
+- Re-apply read-only styling after AJAX table refreshes if you rebuild row buttons.
+
+Use the same **`section`** string as in your manifest (`extra`, etc.). You can read the active value with **`$.currentPage().panelSection`** after the user navigates via the manifest link.
+
+Optional: declare a minimal **`settingsModal`** on a **Games** card (or any card) listing your INIDB **`table`** names so the server indexes them to a section even when the primary UI is a **nav** page.
+
 ### `nav` entries (sidebar links)
 
 | Field | Required | Rules |
@@ -171,6 +214,8 @@ When manifest content actually renders, the panel inserts a small separator: a *
 - **No card:** `section` must be `games`; `id` safe and unique; console may show **`skipped card`** with a reason (`invalid id`, `invalid scriptPath`, modal validation, etc.).
 - **Toggle no-op:** `scriptPath` must match what the `module` command expects (e.g. `./games/foo.js`). Bare `./foo.js` is rejected.
 - **Commands missing after drop:** Run **`!reloadcustom`** (caster); register commands inside **`$.bind('initReady', ...)`** so the reload fan-out can re-run them.
+- **Read-only user can still “succeed” in UI:** Use **`requirePanelSectionWrite`** before showing success dialogs; avoid **`helpers.getConfirmDeleteModal`** success text on async websocket actions (it runs before the server responds). Prefer **`toastr`** on command callback for deletes.
+- **Wrong section / denied writes:** Open the page from the manifest sidebar link so **`$.currentPage().panelSection`** matches **`nav.section`**. Index INIDB tables in **`settingsModal`** if you rely on table-based checks.
 - **Docker:** Put files under the **host** path you bind to **`/opt/PhantomBot_data`**; symlinks from the image point `./web/panel/.../custom` (and related paths) at that volume.
 
 ### Compatibility with older custom modules
@@ -191,6 +236,7 @@ If you still maintain a **legacy** panel module, **consider migrating to manifes
 2. For each **`nav`** link, add **`web/panel/pages/custom/<moduleId>/<page>.html`** and optional matching JS under **`web/panel/js/pages/custom/<moduleId>/`**. Manifest fields `folder` and `page` must match: `folder` is always `custom/<moduleId>`, `page` is a single filename like `mypage.html`.
 3. For **Games** **`cards`**, set **`scriptPath`** to a path PhantomBot’s `module` command understands, e.g. **`./games/myGame.js`**. For a working settings cog, add a valid **`settingsModal`** (`title` plus `fields` or `sections`).
 4. After a declarative **settings** save, the panel sends **`panel-settings-saved`** to that script over the panel websocket—handle it in **`webPanelSocketUpdate`** to refresh in-memory settings (see [Full manifest specification](#full-manifest-specification)).
+5. For **nav-only** pages with Panel Users: implement read-only UI in your page JS using **`window.__pbCustomPanel__`** (see [Panel user permissions](#panel-user-permissions-section-based)).
 
 ## Docker and data volumes
 

--- a/resources/web/panel/js/index.js
+++ b/resources/web/panel/js/index.js
@@ -50,7 +50,8 @@ $(function () {
      */
     var sendToSocket = function (message) {
         try {
-            message.section = $.currentPage().folder;
+            const cp = $.currentPage();
+            message.section = (cp && cp.panelSection) ? cp.panelSection : (cp ? cp.folder : '');
             let json = JSON.stringify(message);
 
             webSocket.send(json);

--- a/resources/web/panel/js/utils/ajaxLoader.js
+++ b/resources/web/panel/js/utils/ajaxLoader.js
@@ -21,7 +21,8 @@ $(function () {
     let currentPageInfo = {
         folder: '',
         page: '',
-        href: ''
+        href: '',
+        panelSection: ''
     };
     /*
      * @function removes the page loader.
@@ -56,7 +57,7 @@ $(function () {
      * @param {String} folder
      * @param {String} page
      */
-    function loadPage(folder, page, href) {
+    function loadPage(folder, page, href, panelSection) {
         // Make sure the href isn't blank, then load the page.
         if (page !== '') {
             helpers.log('Starting ajax request for page: ' + folder + '/' + page, helpers.LOG_TYPE.DEBUG);
@@ -91,7 +92,8 @@ $(function () {
                     currentPageInfo = {
                         folder: folder,
                         page: page,
-                        href: href === undefined ? '' : href
+                        href: href === undefined ? '' : href,
+                        panelSection: panelSection || ''
                     };
                 },
                 error: function (err) {
@@ -105,13 +107,12 @@ $(function () {
         return currentPageInfo;
     }
 
-    // Delegated so manifest-injected nav links work; data-page avoids parsing href fragments.
+    // Delegated so manifest-injected nav links work. data-page = filename; data-panel-section = Panel Users section.
     $(document).on('click', '[data-folder]', function (e) {
         e.preventDefault();
         const $link = $(this);
         const page = $link.data('page') || String($link.attr('href') || '').substring(1);
-        // Load the page.
-        loadPage($link.data('folder'), page, this.href);
+        loadPage($link.data('folder'), page, this.href, $link.data('panelSection'));
     });
 
     // Export to API.

--- a/resources/web/panel/js/utils/customPanelCards.js
+++ b/resources/web/panel/js/utils/customPanelCards.js
@@ -30,6 +30,10 @@
  * the canonical {@code #pb-panel-<id>-custom-cards} shape and silently drop anything else
  * to keep card injection from being abused as a generic DOM-replace primitive.</p>
  *
+ * <p>Honors {@code ns.panelSectionCanWrite} for the injected section: read-only Panel Users
+ * get disabled toggles/settings, a tooltip, and the stock permission toast on click;
+ * info/details remain available.</p>
+ *
  * @author mcawful
  */
 (function () {
@@ -100,13 +104,16 @@
      * @param {object} card canonical manifest card
      * @returns {jQuery}
      */
-    function buildCardTools(card) {
+    function buildCardTools(card, canWrite) {
         const $tools = $('<div/>', {'class': 'box-tools pull-right'});
         const hasSettings = ns.cardHasSettings(card);
         const hasDetails = ns.cardHasDetailsModal(card);
-
         if (card.scriptPath) {
-            const $label = $('<label/>', {'class': 'switch', 'data-toggle': 'tooltip', 'title': 'Module toggle.'});
+            const $label = $('<label/>', {
+                'class': 'switch',
+                'data-toggle': 'tooltip',
+                title: canWrite ? 'Module toggle.' : ns.READ_ONLY_PANEL_TITLE
+            });
             const $input = $('<input/>', {
                 type: 'checkbox',
                 id: cardChildId(card.id, 'toggle'),
@@ -114,6 +121,10 @@
                 'data-pb-custom-card-id': card.id
             });
             $input.prop('checked', true);
+            if (!canWrite) {
+                $input.prop('disabled', true);
+                $label.addClass('pb-custom-card-readonly-toggle');
+            }
             $label.append($input).append($('<span/>', {'class': 'slider round'}));
             $tools.append($label);
         }
@@ -135,8 +146,12 @@
             const $btn = $('<button/>', {
                 type: 'button',
                 id: settingsBtnId,
-                'class': 'btn btn-md btn-box-tool pb-custom-card-open-settings pb-custom-card-tool-btn',
-                'data-pb-custom-card-id': card.id
+                'class': 'btn btn-md btn-box-tool pb-custom-card-open-settings pb-custom-card-tool-btn'
+                    + (canWrite ? '' : ' pb-custom-card-readonly-settings'),
+                'data-pb-custom-card-id': card.id,
+                'data-toggle': canWrite ? undefined : 'tooltip',
+                title: canWrite ? undefined : ns.READ_ONLY_PANEL_TITLE,
+                'aria-disabled': canWrite ? undefined : 'true'
             });
             $btn.append($('<i/>', {'class': 'fa fa-cog fa-lg'}));
             $tools.append($btn);
@@ -159,9 +174,9 @@
      * @param {object} card canonical manifest card
      * @returns {jQuery}
      */
-    function buildCardHeader(card) {
+    function buildCardHeader(card, canWrite) {
         return $('<div/>', {'class': 'box-header with-border'})
-            .append(buildCardTools(card))
+            .append(buildCardTools(card, canWrite))
             .append($('<h3/>', {'class': 'box-title'}).text(card.title));
     }
 
@@ -184,10 +199,10 @@
      * @param {object} card canonical manifest card
      * @returns {jQuery}
      */
-    function buildCardElement(card) {
+    function buildCardElement(card, canWrite) {
         const $form = $('<form/>', {'role': 'form'}).append(buildCardBody(card));
         const $box = $('<div/>', {'class': 'box box-solid', 'id': 'pb-custom-card-' + card.id})
-            .append(buildCardHeader(card))
+            .append(buildCardHeader(card, canWrite))
             .append($form);
         return $('<div/>', {'class': 'col-md-4'}).append($box);
     }
@@ -222,6 +237,20 @@
     }
 
     /**
+     * Read-only Panel Users: toggle labels and settings cogs stay clickable; show the stock
+     * permission toast ({@link customPanelManifestLoader#requirePanelSectionWrite}).
+     *
+     * @param {jQuery} $mount container holding the freshly injected card elements
+     * @param {string} sectionKey manifest section for this mount
+     */
+    function wireReadOnlyDenials($mount, sectionKey) {
+        $mount.on('click.pbCustomReadonly', '.pb-custom-card-readonly-toggle, .pb-custom-card-readonly-settings', function (e) {
+            e.preventDefault();
+            ns.requirePanelSectionWrite(sectionKey);
+        });
+    }
+
+    /**
      * Binds the settings cog (elements with {@code .pb-custom-card-open-settings}):
      * opens {@code ns.openSettingsModal(card)} from {@code customPanelSettingsModal.js}.
      *
@@ -230,8 +259,7 @@
     function wireCardSettings($mount) {
         $mount.find('.pb-custom-card-open-settings').on('click', function (e) {
             e.preventDefault();
-            const $btn = $(this);
-            const id = $btn.data('pb-custom-card-id');
+            const id = $(this).data('pb-custom-card-id');
             const card = ns.cardsById[id];
 
             if (card && card.settingsModal && typeof ns.openSettingsModal === 'function') {
@@ -328,6 +356,7 @@
 
         const sectionKey = String(section || '').toLowerCase();
         const cards = ns.cardsBySection[sectionKey] || [];
+        const canWrite = typeof ns.panelSectionCanWrite !== 'function' || ns.panelSectionCanWrite(sectionKey);
 
         if (cards.length === 0) {
             return;
@@ -349,13 +378,19 @@
         $mount.append($divider);
 
         cards.forEach(function (card) {
-            $mount.append(buildCardElement(card));
+            $mount.append(buildCardElement(card, canWrite));
         });
 
-        wireCardToggles($mount);
-        wireCardSettings($mount);
+        if (canWrite) {
+            wireCardToggles($mount);
+            wireCardSettings($mount);
+        } else {
+            wireReadOnlyDenials($mount, sectionKey);
+        }
         wireCardDetails($mount);
-        loadInitialCardStates($mount, cards);
+        if (canWrite) {
+            loadInitialCardStates($mount, cards);
+        }
         if (typeof $.fn.tooltip === 'function') {
             $mount.find('[data-toggle="tooltip"]').tooltip({container: 'body'});
         }

--- a/resources/web/panel/js/utils/customPanelManifestLoader.js
+++ b/resources/web/panel/js/utils/customPanelManifestLoader.js
@@ -34,6 +34,10 @@
  * <p>Public API: {@code window.initCustomPanelNav()} — call once after panel websocket auth
  * completes (from {@code js/index.js}). Idempotent; repeat calls after the first are ignored.</p>
  *
+ * <p>Panel Users: {@code ns.panelSectionAccess} / {@code panelSectionCanWrite} /
+ * {@code requirePanelSectionWrite} mirror Settings → Panel Users
+ * section permissions for manifest {@code nav.section} and {@code cards.section}.</p>
+ *
  * @author mcawful
  */
 (function () {
@@ -51,6 +55,107 @@
     ns.MANIFEST_FETCH_TIMEOUT_MS = ns.MANIFEST_FETCH_TIMEOUT_MS || 15000;
     ns.TEXTAREA_DEFAULT_MAX_LEN = ns.TEXTAREA_DEFAULT_MAX_LEN || 480;
     ns.DEFAULT_PERMISSION_GROUP_ID = ns.DEFAULT_PERMISSION_GROUP_ID != null ? ns.DEFAULT_PERMISSION_GROUP_ID : 7;
+    ns.DEFAULT_CARD_SECTION = ns.DEFAULT_CARD_SECTION || 'games';
+    ns.READ_ONLY_PANEL_TITLE = ns.READ_ONLY_PANEL_TITLE || 'Read-only panel user (no changes allowed).';
+
+    const PANEL_SECTION_ALIASES = {
+        'keywords': 'keywords & emotes',
+        'overlay': 'stream overlay'
+    };
+
+    /**
+     * Maps manifest {@code nav.section} / {@code cards.section} keys to Panel Users section names.
+     *
+     * @param {string} section manifest section (e.g. {@code "extra"}, {@code "games"})
+     * @returns {string} normalized section name for permission lookup
+     */
+    function normalizePanelSectionName(section) {
+        const key = String(section || 'extra').toLowerCase();
+        return PANEL_SECTION_ALIASES[key] || key;
+    }
+
+    /**
+     * Panel-user access for a stock sidebar section (matches Settings → Panel Users).
+     *
+     * @param {string} section manifest section key
+     * @returns {'write'|'read'|'none'}
+     */
+    ns.panelSectionAccess = function (section) {
+        if (typeof helpers === 'undefined' || !helpers.currentPanelUserData) {
+            return 'write';
+        }
+        if (helpers.currentPanelUserData.userType === 'CONFIG') {
+            return 'write';
+        }
+        const permKey = normalizePanelSectionName(section);
+        const rows = helpers.currentPanelUserData.permission;
+        if (!Array.isArray(rows)) {
+            return 'none';
+        }
+        const row = rows.find(function (p) {
+            return p && p.section === permKey;
+        });
+        if (!row) {
+            return 'none';
+        }
+        if (row.permission === 'Full Access') {
+            return 'write';
+        }
+        if (row.permission === 'Read Only') {
+            return 'read';
+        }
+        return 'none';
+    };
+
+    /**
+     * @param {string} section manifest section key
+     * @returns {boolean} whether the user may change settings, toggles, or other writes
+     */
+    ns.panelSectionCanWrite = function (section) {
+        return ns.panelSectionAccess(section) === 'write';
+    };
+
+    /**
+     * @param {object} card manifest card entry
+     * @returns {string} normalized {@code cards.section} (defaults to {@code games})
+     */
+    ns.cardManifestSection = function (card) {
+        const s = card && card.section;
+        return s ? String(s).toLowerCase() : ns.DEFAULT_CARD_SECTION;
+    };
+
+    /**
+     * Same toast as stock {@code global.js} / websocket {@code permission} notifications when a
+     * read-only Panel User attempts a write (throttled via {@code helpers.isPermissionErrorRunning}).
+     */
+    ns.notifyPanelWriteDenied = function () {
+        if (typeof helpers === 'undefined' || typeof toastr === 'undefined') {
+            return;
+        }
+        if (helpers.isPermissionErrorRunning) {
+            return;
+        }
+        helpers.isPermissionErrorRunning = true;
+        toastr.error(
+            'You are missing the required permissions to complete this operation!',
+            'Permissions error'
+        );
+        setTimeout(function () {
+            helpers.isPermissionErrorRunning = false;
+        }, 5000);
+    };
+
+    /**
+     * @param {string} section manifest section key
+     * @returns {boolean} {@code true} when the user may write; otherwise shows the permission toast
+     */
+    ns.requirePanelSectionWrite = function (section) {
+        if (!ns.panelSectionCanWrite(section)) {
+            ns.notifyPanelWriteDenied();
+            return false;
+        }
+        return true;
+    };
 
     let stylesInjected = false;
     let ran = false;
@@ -139,6 +244,13 @@
             '}',
             '.pb-custom-card-tool-btn {',
             '    margin-bottom: 7px;',
+            '}',
+            '.pb-custom-card-readonly-toggle,',
+            '.pb-custom-card-readonly-settings {',
+            '    cursor: not-allowed;',
+            '}',
+            '.pb-custom-card-readonly-toggle .slider {',
+            '    opacity: 0.75;',
             '}',
             '/* Equal-height community cards: BS3 float rows stagger when card bodies differ in height. */',
             '.pb-custom-cards-mount.row {',

--- a/resources/web/panel/js/utils/customPanelManifestLoader.js
+++ b/resources/web/panel/js/utils/customPanelManifestLoader.js
@@ -140,9 +140,9 @@
             'You are missing the required permissions to complete this operation!',
             'Permissions error'
         );
-        setTimeout(function () {
+        helpers.sleep(5000).then(function () {
             helpers.isPermissionErrorRunning = false;
-        }, 5000);
+        });
     };
 
     /**

--- a/resources/web/panel/js/utils/customPanelNav.js
+++ b/resources/web/panel/js/utils/customPanelNav.js
@@ -101,7 +101,8 @@
         const $a = $('<a/>', {
             href: href,
             'data-folder': folder,
-            'data-page': page
+            'data-page': page,
+            'data-panel-section': section
         });
         $a.append($('<i/>', {'class': 'fa fa-circle-o'}));
         $a.append(document.createTextNode(' '));

--- a/resources/web/panel/js/utils/customPanelSettingsModal.js
+++ b/resources/web/panel/js/utils/customPanelSettingsModal.js
@@ -514,6 +514,10 @@
     ns.openSettingsModal = function (card) {
         let sm = card && card.settingsModal;
         let fieldsFlat = collectSettingsModalFields(sm);
+        if (card && typeof ns.requirePanelSectionWrite === 'function'
+                && !ns.requirePanelSectionWrite(ns.cardManifestSection(card))) {
+            return;
+        }
 
         if (!sm || fieldsFlat.length === 0 || typeof helpers === 'undefined' || typeof helpers.getModal !== 'function') {
             return;
@@ -543,6 +547,10 @@
             let $form = buildSettingsForm(card, sm, fieldsFlat, results || {});
 
             helpers.getModal(modalId, sm.title || 'Settings', 'Save', $form, function () {
+                if (typeof ns.requirePanelSectionWrite === 'function'
+                        && !ns.requirePanelSectionWrite(ns.cardManifestSection(card))) {
+                    return;
+                }
                 let payload = collectSaveData(card.id, fieldsFlat);
                 if (payload === null) {
                     return;

--- a/source/com/mcawful/CustomPanelManifestCache.java
+++ b/source/com/mcawful/CustomPanelManifestCache.java
@@ -167,6 +167,14 @@ public final class CustomPanelManifestCache {
      * @return quoted ETag value ready to drop into the {@code ETag} header
      */
     private static String computeEtag(byte[] bytes) {
+        return computeStrongEtag(bytes);
+    }
+
+    /**
+     * @param bytes response body to fingerprint
+     * @return strong ETag header value for those bytes
+     */
+    public static String computeStrongEtag(byte[] bytes) {
         return "\"sha256-" + sha256Base64(bytes) + "\"";
     }
 }

--- a/source/com/mcawful/CustomPanelManifestCollector.java
+++ b/source/com/mcawful/CustomPanelManifestCollector.java
@@ -36,6 +36,8 @@ import com.gmt2001.PathValidator;
 import com.gmt2001.util.Reflect;
 
 import tv.phantombot.RepoVersion;
+import tv.phantombot.panel.PanelUser.PanelUser;
+import tv.phantombot.panel.PanelUser.PanelUserHandler;
 
 /**
  * Discovers {@code manifest.json} files under {@code web/panel/custom/&lt;moduleId&gt;/} (bot install
@@ -78,6 +80,10 @@ public final class CustomPanelManifestCollector {
      * {@link #ALLOWED_CARD_SECTIONS}.
      */
     private static final String DEFAULT_CARD_SECTION = "games";
+
+    /** Fail-closed filter fallback: valid empty merge shape for non-config panel users. */
+    private static final byte[] EMPTY_FILTERED_MANIFEST_UTF8 =
+            "{\"nav\":[],\"cards\":[]}".getBytes(StandardCharsets.UTF_8);
 
     /**
      * Maximum fields in a card {@code settingsModal} block (DoS guardrail), counting all fields
@@ -187,6 +193,69 @@ public final class CustomPanelManifestCollector {
     }
 
     /**
+     * Returns merged manifest bytes filtered for the logged-in {@link PanelUser}: entries whose
+     * {@code nav.section} / {@code cards.section} fail {@link PanelUserHandler#checkPanelUserSectionAccess}
+     * with read access are omitted. Config users and {@code null} (legacy panel login) receive the
+     * unfiltered merge. On filter failure for a non-config user, returns an empty {@code nav} /
+     * {@code cards} payload (fail-closed) rather than the unfiltered merge.
+     *
+     * @param mergedUtf8 full merged JSON from {@link #getCachedResponse()}
+     * @param user       authenticated panel user, or {@code null} for unfiltered output
+     * @return UTF-8 JSON bytes, never {@code null}
+     */
+    public static byte[] filterManifestBytesForPanelUser(byte[] mergedUtf8, PanelUser user) {
+        if (mergedUtf8 == null || mergedUtf8.length == 0) {
+            return user == null || user.isConfigUser() ? new byte[0] : EMPTY_FILTERED_MANIFEST_UTF8;
+        }
+        if (user == null || user.isConfigUser()) {
+            return mergedUtf8;
+        }
+
+        try {
+            JSONObject root = new JSONObject(new String(mergedUtf8, StandardCharsets.UTF_8));
+            JSONArray navIn = root.optJSONArray("nav");
+            JSONArray cardsIn = root.optJSONArray("cards");
+
+            JSONObject filtered = new JSONObject();
+            filtered.put("nav", filterManifestArrayForPanelUser(navIn, user, DEFAULT_NAV_SECTION));
+            filtered.put("cards", filterManifestArrayForPanelUser(cardsIn, user, DEFAULT_CARD_SECTION));
+            return filtered.toString().getBytes(StandardCharsets.UTF_8);
+        } catch (Exception ex) {
+            com.gmt2001.Console.warn.println("Custom panel manifest: filter for panel user failed (fail-closed): "
+                    + ex.getMessage());
+            return EMPTY_FILTERED_MANIFEST_UTF8;
+        }
+    }
+
+    private static JSONArray filterManifestArrayForPanelUser(JSONArray entriesIn, PanelUser user, String defaultSection) {
+        JSONArray out = new JSONArray();
+        if (entriesIn == null) {
+            return out;
+        }
+
+        for (int i = 0; i < entriesIn.length(); i++) {
+            JSONObject entry = entriesIn.optJSONObject(i);
+            if (entry == null) {
+                continue;
+            }
+            String section = entry.optString("section", defaultSection).trim().toLowerCase(Locale.ROOT);
+            if (panelUserCanReadSection(user, section)) {
+                out.put(entry);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * @param user            panel user (non-config)
+     * @param manifestSection {@code nav.section} or {@code cards.section} from the manifest
+     * @return {@code true} when the user may see the entry (read or write)
+     */
+    private static boolean panelUserCanReadSection(PanelUser user, String manifestSection) {
+        return PanelUserHandler.checkPanelUserSectionAccess(user, manifestSection, false);
+    }
+
+    /**
      * Returns the {@code web/panel/custom/} directories the collector should scan, in priority
      * order: bot execution directory first, Docker {@code _data} second (if applicable). Either
      * may be missing — callers must handle the empty list and individual missing roots.
@@ -220,6 +289,8 @@ public final class CustomPanelManifestCollector {
         for (Path root : roots) {
             appendFromCustomRoot(root, nav, cards, seenNav, seenCards);
         }
+
+        CustomPanelManifestRegistry.rebuildFromMergedCards(cards);
 
         JSONObject root = new JSONObject();
         root.put("nav", nav);

--- a/source/com/mcawful/CustomPanelManifestRegistry.java
+++ b/source/com/mcawful/CustomPanelManifestRegistry.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2016-2026 phantombot.github.io/PhantomBot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mcawful;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Runtime index built from merged custom-panel manifests so {@link tv.phantombot.panel.PanelUser.PanelUserHandler}
+ * can resolve INIDB tables and Rhino {@code scriptPath} values to a stock panel section ({@code games},
+ * {@code extra}, etc.) without hard-coding community module names.
+ *
+ * <p>Rebuilt whenever {@link CustomPanelManifestCollector} produces a new merged manifest. Nav-only
+ * modules that keep settings in bespoke panel JS (no manifest {@code settingsModal}) rely on the
+ * panel sending {@code section} from {@code nav.section} on websocket messages.</p>
+ *
+ * @author mcawful
+ */
+public final class CustomPanelManifestRegistry {
+
+    private static volatile Map<String, String> tableToPanelSection = Map.of();
+    private static volatile Map<String, String> scriptToPanelSection = Map.of();
+
+    private CustomPanelManifestRegistry() {
+    }
+
+    /**
+     * Clears and repopulates the registry from the canonical merged {@code cards} array.
+     *
+     * @param cards merged {@code cards} array (may be empty)
+     */
+    static void rebuildFromMergedCards(JSONArray cards) {
+        Map<String, String> tables = new HashMap<>();
+        Map<String, String> scripts = new HashMap<>();
+
+        if (cards != null) {
+            for (int i = 0; i < cards.length(); i++) {
+                JSONObject card = cards.optJSONObject(i);
+                if (card == null) {
+                    continue;
+                }
+                String panelSection = card.optString("section", "games").trim().toLowerCase(Locale.ROOT);
+                String scriptPath = card.optString("scriptPath", "").trim();
+                if (!scriptPath.isEmpty()) {
+                    scripts.put(normalizeScriptPath(scriptPath), panelSection);
+                }
+                indexSettingsModalTables(card.optJSONObject("settingsModal"), panelSection, tables);
+            }
+        }
+
+        tableToPanelSection = Collections.unmodifiableMap(tables);
+        scriptToPanelSection = Collections.unmodifiableMap(scripts);
+    }
+
+    /**
+     * @param table INIDB table name from a panel DB request
+     * @return panel section to check, or {@code null} if unknown to custom manifests
+     */
+    public static String panelSectionForTable(String table) {
+        if (table == null || table.isEmpty()) {
+            return null;
+        }
+        return tableToPanelSection.get(table.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * @param scriptPath Rhino script path from a panel command or socket event
+     * @return panel section to check, or {@code null} if unknown to custom manifests
+     */
+    public static String panelSectionForScript(String scriptPath) {
+        if (scriptPath == null || scriptPath.isEmpty()) {
+            return null;
+        }
+        return scriptToPanelSection.get(normalizeScriptPath(scriptPath));
+    }
+
+    private static void indexSettingsModalTables(JSONObject settingsModal, String panelSection, Map<String, String> tables) {
+        if (settingsModal == null) {
+            return;
+        }
+
+        JSONArray fields = settingsModal.optJSONArray("fields");
+        if (fields != null) {
+            indexFieldTables(fields, panelSection, tables);
+        }
+
+        JSONArray sections = settingsModal.optJSONArray("sections");
+        if (sections != null) {
+            for (int i = 0; i < sections.length(); i++) {
+                JSONObject sec = sections.optJSONObject(i);
+                if (sec != null) {
+                    indexFieldTables(sec.optJSONArray("fields"), panelSection, tables);
+                }
+            }
+        }
+    }
+
+    private static void indexFieldTables(JSONArray fields, String panelSection, Map<String, String> tables) {
+        if (fields == null) {
+            return;
+        }
+
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (field == null) {
+                continue;
+            }
+            String table = field.optString("table", "").trim();
+            if (!table.isEmpty()) {
+                tables.putIfAbsent(table.toLowerCase(Locale.ROOT), panelSection);
+            }
+        }
+    }
+
+    private static String normalizeScriptPath(String scriptPath) {
+        return scriptPath.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/source/tv/phantombot/httpserver/HTTPPanelAndYTHandler.java
+++ b/source/tv/phantombot/httpserver/HTTPPanelAndYTHandler.java
@@ -24,6 +24,9 @@ import com.gmt2001.httpwsserver.auth.HttpBasicAuthenticationHandler;
 import com.mcawful.CustomPanelManifestCache;
 import com.mcawful.CustomPanelManifestCollector;
 
+import tv.phantombot.panel.PanelUser.PanelUser;
+import tv.phantombot.panel.PanelUser.PanelUserHandler;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -95,7 +98,11 @@ public class HTTPPanelAndYTHandler implements HttpRequestHandler {
         if (req.method().equals(HttpMethod.GET) && CUSTOM_MANIFESTS_PATH.equals(qsd.path())) {
             try {
                 CustomPanelManifestCache.CachedResponse cached = CustomPanelManifestCollector.getCachedResponse();
-                boolean notModified = HttpServerPageHandler.sendCachedBytes(ctx, req, cached.bytes(), "custom-manifests.json", cached.etag());
+                PanelUser panelUser = PanelUserHandler.checkLoginAndGetUserB64(
+                        HttpBasicAuthenticationHandler.getAuthorizationString(req.headers()), CUSTOM_MANIFESTS_PATH);
+                byte[] body = CustomPanelManifestCollector.filterManifestBytesForPanelUser(cached.bytes(), panelUser);
+                String etag = CustomPanelManifestCache.computeStrongEtag(body);
+                boolean notModified = HttpServerPageHandler.sendCachedBytes(ctx, req, body, "custom-manifests.json", etag);
                 com.gmt2001.Console.debug.println((notModified ? "304" : "200") + " " + req.method().asciiName() + ": " + CUSTOM_MANIFESTS_PATH);
                 return;
             } catch (Throwable ex) {

--- a/source/tv/phantombot/panel/PanelUser/PanelUserHandler.java
+++ b/source/tv/phantombot/panel/PanelUser/PanelUserHandler.java
@@ -28,6 +28,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONStringer;
 
+import com.mcawful.CustomPanelManifestRegistry;
+
 import tv.phantombot.PhantomBot;
 import tv.phantombot.panel.WsPanelHandler;
 
@@ -1001,12 +1003,16 @@ public final class PanelUserHandler {
             return true;
         }
 
-        if (section == null || section.isBlank()) {
+        String fromManifestTable = CustomPanelManifestRegistry.panelSectionForTable(lTableName);
+        if (fromManifestTable != null) {
+            section = fromManifestTable;
+            com.gmt2001.Console.debug.println("Auto-detected section " + section + " (custom manifest table)");
+        } else if (section == null || section.isBlank()) {
             Optional<Entry<String, List<String>>> s = PANEL_SECTION_TABLES.entrySet().stream()
                     .filter(kv -> kv.getValue().contains(lTableName)).findFirst();
             if (s.isPresent()) {
                 section = s.get().getKey();
-                com.gmt2001.Console.debug.println("Auto-detected section " + (section == null ? "NULL" : section));
+                com.gmt2001.Console.debug.println("Auto-detected section " + section);
             }
         }
 
@@ -1085,8 +1091,15 @@ public final class PanelUserHandler {
                         || args[0].equalsIgnoreCase("redeemable-reload-managed"))) {
             isWriteAction = false;
         }
-        boolean res = PANEL_SECTION_SCRIPTS.containsKey(section) && PANEL_SECTION_SCRIPTS.get(section).contains(script)
-                && checkPanelUserSectionAccess(user, section, isWriteAction);
+
+        String manifestSection = CustomPanelManifestRegistry.panelSectionForScript(script);
+        boolean res;
+        if (manifestSection != null) {
+            res = checkPanelUserSectionAccess(user, manifestSection, isWriteAction);
+        } else {
+            res = PANEL_SECTION_SCRIPTS.containsKey(section) && PANEL_SECTION_SCRIPTS.get(section).contains(script)
+                    && checkPanelUserSectionAccess(user, section, isWriteAction);
+        }
         if (!res) {
             com.gmt2001.Console.err.println("Script access denied to script " + script + " with args: \""
                     + Arrays.toString(args) + "\" for user " + user.getUsername());


### PR DESCRIPTION
## Brief description of the intended change

Custom panel modules (`manifest.json` **nav** / **cards**) now respect **Settings → Panel Users** section permissions the same way stock panel pages do. Panel Users only receive manifest entries for sections they can read; websocket **section**, INIDB **table**, and Rhino **scriptPath** checks resolve through manifest metadata. Read-only users still see custom UI where allowed, but writes are blocked server-side and in the panel with the standard permission toast.

---

 **PhantomBot/source/com/mcawful/CustomPanelManifestRegistry.java**

- New runtime index built when manifests are merged.
- Maps `settingsModal` field **table** names and card **scriptPath** values to manifest **section** (`games`, `extra`, etc.) for `PanelUserHandler`.

 **PhantomBot/source/com/mcawful/CustomPanelManifestCollector.java**

- Rebuilds `CustomPanelManifestRegistry` after each manifest merge.
- Adds `filterManifestBytesForPanelUser()` to drop **nav** / **cards** entries the logged-in Panel User cannot read.
- Fail-closed: on filter failure or empty cache for a Panel User, returns `{"nav":[],"cards":[]}` instead of the unfiltered merge.
- Config users and unauthenticated manifest requests still receive the full merged JSON.

 **PhantomBot/source/com/mcawful/CustomPanelManifestCache.java**

- Exposes `computeStrongEtag()` so filtered per-user manifest bodies get correct **ETag** / **304** behavior.

 **PhantomBot/source/tv/phantombot/httpserver/HTTPPanelAndYTHandler.java**

- Resolves the logged-in Panel User for `GET /panel/custom-manifests.json`.
- Serves filtered manifest bytes and a per-user strong **ETag** via `sendCachedBytes`.

 **PhantomBot/source/tv/phantombot/panel/PanelUser/PanelUserHandler.java**

- Resolves INIDB table access via `CustomPanelManifestRegistry.panelSectionForTable()` before stock section table lists.
- Resolves script access via `panelSectionForScript()` when the script is declared on a manifest card.

 **PhantomBot/resources/web/panel/js/utils/customPanelManifestLoader.js**

- Adds `panelSectionAccess`, `panelSectionCanWrite`, `requirePanelSectionWrite`, and `notifyPanelWriteDenied` on `window.__pbCustomPanel__`.
- Normalizes manifest section keys to Panel Users section names (e.g. `keywords` → `keywords & emotes`).

 **PhantomBot/resources/web/panel/js/utils/customPanelNav.js**

- Sets `data-panel-section` on manifest-injected sidebar links from `nav.section`.

**PhantomBot/resources/web/panel/js/utils/ajaxLoader.js**

- Stores `panelSection` on `$.currentPage()` when loading a page from a nav link.

 **PhantomBot/resources/web/panel/js/index.js**

- Sends websocket `message.section` from `panelSection` (manifest section) instead of the `custom/...` folder path.

 **PhantomBot/resources/web/panel/js/utils/customPanelCards.js**

- Disables module toggle and settings cog for read-only users; blocked clicks show the stock permission toast.
- Uses `aria-disabled` and read-only CSS on the settings cog (not Bootstrap `disabled`, so clicks still reach the toast handler).
- Skips initial `modules` DB load when the user cannot write.

 **PhantomBot/resources/web/panel/js/utils/customPanelSettingsModal.js**

- Guards `openSettingsModal` and save with `requirePanelSectionWrite` for the card’s manifest section.

 **PhantomBot/docs/guides/content/developerdocs/custommodules.md**

- Documents section-based Panel User permissions for declarative cards and nav-only custom pages.
- Describes `__pbCustomPanel__` helpers, read-only UI patterns, and troubleshooting (wrong section, async delete success).
