### PR TITLE
Ensure proper ThreadLocal Rhino Context

### DIFF
--- a/source/com/gmt2001/JSTimers.java
+++ b/source/com/gmt2001/JSTimers.java
@@ -165,8 +165,11 @@ public class JSTimers {
                 if (this.isCancelled.get()) {
                     return;
                 }
+
+                tv.phantombot.script.RhinoRuntime.getContextFactory().enterContext();
                 this.callback.run();
             } finally {
+                org.mozilla.javascript.Context.exit();
                 if (!this.isInterval) {
                     this.isCancelled.set(true);
                 }

--- a/source/tv/phantombot/script/RhinoContextFactory.java
+++ b/source/tv/phantombot/script/RhinoContextFactory.java
@@ -46,9 +46,7 @@ public final class RhinoContextFactory extends ContextFactory {
     @Override
     public Context enterContext() {
         try {
-            Context cx = super.enterContext();
-            setContextOptions(cx);
-            return cx;
+            return super.enterContext();
         } catch (RuntimeException e) {
             com.gmt2001.Console.err.println("Failed to enter Rhino context. Creating new context: " + e.getMessage());
             com.gmt2001.Console.err.printStackTrace(e);

--- a/source/tv/phantombot/script/RhinoContextFactory.java
+++ b/source/tv/phantombot/script/RhinoContextFactory.java
@@ -31,12 +31,7 @@ public final class RhinoContextFactory extends ContextFactory {
     @Override
     protected Context makeContext() {
         Context cx = super.makeContext();
-        if (CaselessProperties.instance().getPropertyAsBoolean("rhinointerpretmode", false)) {
-            cx.setInterpretedMode(true);
-        }
-        if (PhantomBot.getEnableRhinoDebugger()) {
-            cx.setGeneratingDebug(true);
-        }
+        setContextOptions(cx);
         return cx;
     }
 
@@ -46,5 +41,32 @@ public final class RhinoContextFactory extends ContextFactory {
             return true;
         }
         return super.hasFeature(cx, featureIndex);
+    }
+
+    @Override
+    public Context enterContext() {
+        try {
+            Context cx = super.enterContext();
+            setContextOptions(cx);
+            return cx;
+        } catch (RuntimeException e) {
+            com.gmt2001.Console.err.println("Failed to enter Rhino context. Creating new context: " + e.getMessage());
+            com.gmt2001.Console.err.printStackTrace(e);
+        }
+
+        return this.makeContext();
+    }
+
+    /**
+     * Set Phantombot specific context options based on configuration.
+     * @param cx Context to configure
+     */
+    private void setContextOptions(Context cx) {
+        if (CaselessProperties.instance().getPropertyAsBoolean("rhinointerpretmode", false)) {
+            cx.setInterpretedMode(true);
+        }
+        if (PhantomBot.getEnableRhinoDebugger()) {
+            cx.setGeneratingDebug(true);
+        }
     }
 }

--- a/source/tv/phantombot/script/RhinoRuntime.java
+++ b/source/tv/phantombot/script/RhinoRuntime.java
@@ -39,7 +39,7 @@ public final class RhinoRuntime {
     /**
      * Get the Rhino ContextFactory instance.
      */
-    protected static RhinoContextFactory getContextFactory() {
+    public static RhinoContextFactory getContextFactory() {
         return FACTORY;
     }
     
@@ -87,7 +87,12 @@ public final class RhinoRuntime {
 
     public static String callGlobalExposedScriptMethod(String method, String arg) {
         Object[] obj = new Object[]{arg};
-        return ScriptableObject.callMethod(FACTORY.enterContext(), GLOBAL, method, obj).toString();
+
+        try {
+            return ScriptableObject.callMethod(FACTORY.enterContext(), GLOBAL, method, obj).toString();
+        } finally {
+            org.mozilla.javascript.Context.exit();
+        }
     }
 
     /**

--- a/source/tv/phantombot/script/Script.java
+++ b/source/tv/phantombot/script/Script.java
@@ -144,8 +144,12 @@ public class Script {
         if (PhantomBot.getEnableRhinoDebugger()) {
             od = new ObservingDebugger();
             Context context = RhinoRuntime.getContextFactory().enterContext();
-            context.setDebugger(od, 0);
-            context.setGeneratingDebug(true);
+            try {
+                context.setDebugger(od, 0);
+                context.setGeneratingDebug(true);
+            } finally {
+                Context.exit();
+            }
         }
 
         doDestroyables();

--- a/source/tv/phantombot/script/ScriptEventManager.java
+++ b/source/tv/phantombot/script/ScriptEventManager.java
@@ -79,7 +79,12 @@ public final class ScriptEventManager implements Listener {
                 ScriptEventHandler e = events.get(eventName);
 
                 if (e != null) {
-                    e.handle(event);
+                    tv.phantombot.script.RhinoRuntime.getContextFactory().enterContext();
+                    try {
+                        e.handle(event);
+                    } finally {
+                        org.mozilla.javascript.Context.exit();
+                    }
                 }
 
                 com.gmt2001.Console.debug.println("Dispatched event " + eventName);


### PR DESCRIPTION
We should ensure we enter a fully populated Rhino Context relevant to the script in scope. This is done by entering the context before JavaScript execution in any form (via Bus **Events**, **JSTimers**, or similar). As the context is to be considered thread local we should as well exit them right after the task (method call, timer run, etc.) has completed. This also ensures proper release of resources attached to the context 

To achieve this this PR ensure our **ContextFactory** allows entering a suitable context with the requested options set