### PR TITLE
Move Internal Bus to Executor Service

### DIFF
--- a/source/tv/phantombot/event/EventBus.java
+++ b/source/tv/phantombot/event/EventBus.java
@@ -39,7 +39,8 @@ public final class EventBus {
     private static final MBassador<Event> bus = new MBassador<>(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
             .addFeature(Feature.AsynchronousHandlerInvocation.Default().setExecutor(com.gmt2001.util.concurrent.ExecutorService.executorService()))
             .addFeature(Feature.AsynchronousMessageDispatch.Default()
-            .setNumberOfMessageDispatchers(10)).addPublicationErrorHandler(new ExceptionHandler()));
+                            .setNumberOfMessageDispatchers(5))
+                            .addPublicationErrorHandler(new ExceptionHandler()));
 
     /**
      * Class constructor.

--- a/source/tv/phantombot/event/EventBus.java
+++ b/source/tv/phantombot/event/EventBus.java
@@ -37,7 +37,8 @@ import tv.phantombot.event.jvm.JVMEvent;
 public final class EventBus {
     private static final EventBus instance = new EventBus();
     private static final MBassador<Event> bus = new MBassador<>(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
-            .addFeature(Feature.AsynchronousHandlerInvocation.Default()).addFeature(Feature.AsynchronousMessageDispatch.Default()
+            .addFeature(Feature.AsynchronousHandlerInvocation.Default().setExecutor(com.gmt2001.util.concurrent.ExecutorService.executorService()))
+            .addFeature(Feature.AsynchronousMessageDispatch.Default()
             .setNumberOfMessageDispatchers(10)).addPublicationErrorHandler(new ExceptionHandler()));
 
     /**


### PR DESCRIPTION
Identical to #3728 but on a separate branch to facility rebasing 

Instead of running the event bus on their ExecutorService we may have it use the internal one

I've also reduced (halved) the amount of dispatchers as 10 seems a little excessive. `Feature.AsynchronousMessageDispatch.Default()` creates 2 by default which is already sufficient for most workloads where threads are not waiting on I/O