### PR TITLE
Fix custom module hot-reload not working in Docker

### DIFF
--- a/javascript-source/core/customScripts.js
+++ b/javascript-source/core/customScripts.js
@@ -26,16 +26,12 @@
  *
  * <p>{@code init.js} only fires {@code initReady} once at boot, but most
  * modules register chat commands inside that hook. After the scan we diff
- * {@code $.bot.modules} and selectively re-invoke {@code initReady} handlers
- * for the newly-loaded scripts so their commands actually register.</p>
+ * {@code $.bot.modules} and re-invoke {@code initReady} via {@code $.bot.getHook}
+ * for newly-loaded scripts so their commands actually register.</p>
  *
  * @author mcawful
  */
 (function () {
-    function normalizeScriptName(name) {
-        return ('' + name).replace(/^\.\//, '');
-    }
-
     function snapshotLoadedModules() {
         const out = [];
         if ($.bot && $.bot.modules) {
@@ -67,27 +63,17 @@
             return 0;
         }
 
-        const hookContainer = $.bot && $.bot.hooks ? $.bot.hooks.initReady : null;
-        if (!hookContainer || !hookContainer.handlers) {
-            return 0;
-        }
-
-        // $.bot.modules keys keep the leading "./", Hook.scriptName strips it.
-        const nameSet = {};
-        for (let i = 0; i < newModuleNames.length; i++) {
-            nameSet[normalizeScriptName(newModuleNames[i])] = true;
-        }
-
         let fired = 0;
-        for (let j = 0; j < hookContainer.handlers.length; j++) {
-            const handler = hookContainer.handlers[j];
-            if (handler && nameSet[normalizeScriptName(handler.scriptName)]) {
-                try {
-                    handler.handler(null);
-                    fired++;
-                } catch (ex) {
-                    $.log.error('reloadcustom: initReady handler for ' + handler.scriptName + ' threw: ' + ex);
-                }
+        for (let i = 0; i < newModuleNames.length; i++) {
+            const hook = $.bot.getHook(newModuleNames[i], 'initReady');
+            if (!hook || typeof hook.handler !== 'function') {
+                continue;
+            }
+            try {
+                hook.handler(null);
+                fired++;
+            } catch (ex) {
+                $.log.error('reloadcustom: initReady handler for ' + newModuleNames[i] + ' threw: ' + ex);
             }
         }
         return fired;

--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -380,6 +380,28 @@
     }
 
     /*
+     * @function normalizeHookScriptName
+     *
+     * @param  {String} name module key, hook scriptName, or hook scriptPath
+     * @return {String}
+     */
+    function normalizeHookScriptName(name) {
+        let s = $.replace(('' + name), '\\', '/');
+
+        if (s.indexOf('/scripts/') >= 0) {
+            s = s.substring(s.indexOf('/scripts/') + '/scripts/'.length);
+        } else if (s.indexOf('scripts/') === 0) {
+            s = s.substring('scripts/'.length);
+        }
+
+        if (s.indexOf('./') === 0) {
+            s = s.substring(2);
+        }
+
+        return s.toLowerCase();
+    }
+
+    /*
      * @function getHookIndex
      *
      * @param  {String} scriptName
@@ -389,11 +411,14 @@
     function getHookIndex(scriptName, hookName) {
         hookName = $api.formatEventName(hookName) + '';
         let hook = hooks[hookName],
-                i;
+                i,
+                want = normalizeHookScriptName(scriptName);
 
         if (hook !== undefined) {
             for (i in hook.handlers) {
-                if (hook.handlers[i].scriptName.equalsIgnoreCase(scriptName)) {
+                if (hook.handlers[i].scriptName.equalsIgnoreCase(scriptName)
+                        || normalizeHookScriptName(hook.handlers[i].scriptName) === want
+                        || normalizeHookScriptName(hook.handlers[i].scriptPath) === want) {
                     return i;
                 }
             }
@@ -429,7 +454,7 @@
     }
 
     /*
-     * @function hookName
+     * @function removeHook
      *
      * @param {String} hookName
      */


### PR DESCRIPTION
Fix custom module hot-reload so initReady handlers register after panel reloadcustom in Docker
**init.js**
- Add `normalizeHookScriptName()` to canonicalize module keys, hook `scriptName`, and hook `scriptPath` (strip `/scripts/` prefix, leading `./`, normalize slashes, lowercase).
- Update `getHookIndex()` to match hooks by normalized path in addition to the legacy exact `scriptName` comparison, so `$.bot.getHook('./custom/foo.js', 'initReady')` resolves when hook paths are absolute (e.g. `/opt/PhantomBot/scripts/custom/foo.js`).
- Fix `removeHook` JSDoc (`@function hookName` → `@function removeHook`).
**customScripts.js**
- Replace manual scanning of `$.bot.hooks.initReady.handlers` and local `normalizeScriptName()` with `$.bot.getHook(moduleKey, 'initReady')` when replaying `initReady` for newly loaded `./custom/*.js` modules after `reloadcustom`.
- Update file header comment to describe the `getHook`-based replay flow.