### PR TITLE
Fix Issue in Ads EventBus and Support Announcement of Ads

### DIFF
--- a/javascript-source/handlers/adsAnnounceHandler.js
+++ b/javascript-source/handlers/adsAnnounceHandler.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016-2026 phantombot.github.io/PhantomBot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Script  : adsAnnounceHandler.js
+ * Purpose : Presently interfaces with the ads eventsub events to announce when an ad is rolling.
+ */
+(function () {
+    var toggle = $.getSetIniDbBoolean('adsAnnounceSettings', 'announceadstart', false)
+
+    /*
+     * @function reloadAds
+     */
+    function reloadAds() {
+        toggle = $.getIniDbBoolean('adsAnnounceSettings', 'announceadstart', false);
+    }
+
+    /*
+     * @function subscribeEventSub
+     */
+    function subscribeEventSub() {
+        let subscriptions = [
+            Packages.com.gmt2001.twitch.eventsub.subscriptions.channel.ad_break.AdBreakBegin
+        ];
+
+        for (let i in subscriptions) {
+            let newSubscription = new subscriptions[i]($.viewer.broadcaster().id());
+            try {
+                newSubscription.create().block();
+            } catch (ex) {
+                $.log.error(ex);
+            }
+        }
+    }
+
+
+    /*
+     * @event eventSubWelcome
+     */
+    $.bind('eventSubWelcome', function (event) {
+        if (!event.isReconnect()) {
+            subscribeEventSub();
+        }
+    }, true);
+
+
+    /*
+     * @event command
+     */
+    $.bind('command', function (event) {
+        var sender = event.getSender(),
+                command = event.getCommand(),
+                args = event.getArgs(),
+                argsString = event.getArguments(),
+                action = args[0];
+
+        /*
+         * @commandpath adsannouncestarttoggle - Toggles the ads announcements.
+         */
+        if ($.equalsIgnoreCase(command, 'adsannouncestarttoggle')) {
+            toggle = !toggle;
+            $.setIniDbBoolean('adsAnnounceSettings', 'announceadstart', toggle);
+            $.say($.whisperPrefix(sender) + (toggle ? $.lang.get('adsannouncehandler.toggle.on') : $.lang.get('adsannouncehandler.toggle.off')));
+        }
+    });
+
+
+    /*
+     * @event AdBreakBegin
+     */
+    $.bind('eventSubAdBreakBegin', function (event) {
+        let durationSeconds = event.event().durationSeconds(),
+            startTime = event.event().startedAtString();
+
+        Packages.com.gmt2001.Console.debug.println("Ad Break Begin event. Start Time is: " + startTime + ". Duration (seconds) is: " + durationSeconds);
+
+        if ($.getIniDbBoolean('adsAnnounceSettings', 'announceadstart')) {
+            $.say($.lang.get('adsannouncehandler.announcestart', durationSeconds));
+        }
+    });
+
+    /*
+     * @event initReady
+     */
+    $.bind('initReady', function () {
+        $.registerChatCommand('./handlers/adsAnnounceHandler.js', 'adsannouncestarttoggle', $.PERMISSION.Admin);
+    });
+})();

--- a/javascript-source/lang/english/handlers/handlers-adsAnnounceHandler.json
+++ b/javascript-source/lang/english/handlers/handlers-adsAnnounceHandler.json
@@ -1,0 +1,5 @@
+{
+    "adsannouncehandler.toggle.on": "Ads announcements have been enabled.",
+    "adsannouncehandler.toggle.off": "Ads announcements have been disabled.",
+    "adsannouncehandler.announcestart": "Ads are starting right now and running for $1 seconds."
+}

--- a/source/com/gmt2001/twitch/eventsub/subscriptions/channel/ad_break/AdBreakBegin.java
+++ b/source/com/gmt2001/twitch/eventsub/subscriptions/channel/ad_break/AdBreakBegin.java
@@ -68,7 +68,7 @@ public final class AdBreakBegin extends EventSubSubscriptionType {
         this.requester_user_id = e.event().getString("requester_user_id");
         this.requester_user_login = e.event().getString("requester_user_login");
         this.requester_user_name = e.event().getString("requester_user_name");
-        this.duration_seconds = e.event().getInt("duration");
+        this.duration_seconds = e.event().getInt("duration_seconds");
         this.is_automatic = e.event().getBoolean("is_automatic");
         this.sStarted_at = e.event().getString("started_at");
         this.duration = Duration.ofSeconds(this.duration_seconds);


### PR DESCRIPTION
- Fix issue in Ads eventbus handler in Java where duration was looked for and duration_seconds is the node

- Added in support to read the ads eventbus handler and indicate when an ad break is launching.

**Please read, especially if your first time contributing to PhantomBot:**

Thank you for contributing to PhantomBot! Hopefully you followed the code style guide:
https://github.com/PhantomBot/PhantomBot/blob/master/development-resources/CODESTYLE.md

If you added in code from a third party, it must have a license that is compatible with PhantomBot.  If it is not, we will reject the merge request.  The development team takes this very seriously.  If you add in access to an API and PhantomBot would use that API improperly, we will reject the merge request.  Again, the development team takes this very seriously.

You must provide test results for your change.  If test results are not provided we will do one of two things. We will ask you for test results or we will just reject the change.  Test results convince us that you verified your change.

We reserve the right to reject a change for any reason at all.  Typically, we will provide a reason but if we do not, that is at our discretion.  There are some reasons for which we will reject changes, other than the ones given above (but they will be repeated):

- Code style does not match (Old code styles may not be valid anymore).
- Incompatible license/improper use of license of third party software/API.
- No test results.
- Potential performance issues.
- Design changes that go against the core design philosophy.
- Items with potential to spam or consume the outgoing message queue.
- Poorly architected items.
- Item is supported in chat but no update for the Control Panel.
- Any command that would violate the Twitch Terms of Service or the Terms of Service of any provider.
- The remote panel is changed (docs/panel). This is done via automation from the bot copy (resources/web/panel)
- The stable remote panel is changed (docs/panel-stable). This is done via automation upon release
- The stable guides are changed (docs/guides/content-stable). This is done via automation upon release

You are not to harass the development team if a pull request is rejected.  You may discuss and argue why you disagree with a rejection.  We do ask that you stay professional and amicable in your argument and discussion.

All pull requests will be reviewed by at least one PhantomBot developer. Please be patient while two developers take the time to do so.  We understand that this adds time to an approval, but it is to ensure that the development team is not missing anything.
