### PR TITLE
Upgrade Discord4j to a version which also uses netty 4.2.15

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <dependencies defaultconf="default">
         <!-- General -->
         <dependency org="com.rollbar" name="rollbar-java" rev="2.3.1"/>
-        <dependency org="com.discord4j" name="discord4j-core" rev="3.3.2"/>
+        <dependency org="com.discord4j" name="discord4j-core" rev="3.3.3"/>
         <dependency org="net.engio" name="mbassador" rev="1.3.2"/>
         <dependency org="com.vdurmont" name="emoji-java" rev="5.1.1" />
         <!-- Networking -->

--- a/ivy.xml
+++ b/ivy.xml
@@ -53,18 +53,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <dependency org="com.h2database" name="h2" rev="2.4.240"/>
         <dependency org="com.h2database" name="h2" rev="2.1.214" conf="lib.extra->default"/>
         <dependency org="com.h2database" name="h2" rev="1.4.200" conf="lib.extra->default"/>
-        <dependency org="org.jooq" name="jooq" rev="3.19.29"/>
-        <dependency org="org.mariadb.jdbc" name="mariadb-java-client" rev="3.5.7"/>
-        <dependency org="com.mysql" name="mysql-connector-j" rev="9.5.0"/>
-        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.51.1.0"/>
+        <dependency org="org.jooq" name="jooq" rev="3.19.37"/>
+        <dependency org="org.mariadb.jdbc" name="mariadb-java-client" rev="3.5.10"/>
+        <dependency org="com.mysql" name="mysql-connector-j" rev="26.7.0"/>
+        <dependency org="org.xerial" name="sqlite-jdbc" rev="3.53.2.1"/>
         <!-- Utility -->
-        <dependency org="commons-codec" name="commons-codec" rev="1.20.0"/>
-        <dependency org="commons-io" name="commons-io" rev="2.21.0"/>
+        <dependency org="commons-codec" name="commons-codec" rev="1.22.1"/>
+        <dependency org="commons-io" name="commons-io" rev="2.22.0"/>
         <dependency org="org.apache.commons" name="commons-text" rev="1.15.0"/>
-        <dependency org="org.json" name="json" rev="20251224"/>
+        <dependency org="org.json" name="json" rev="20260814"/>
         <dependency org="org.mozilla" name="rhino" rev="1.9.1"/>
         <dependency org="org.mozilla" name="rhino-tools" rev="1.9.1"/>
-        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.17"/>
+        <dependency org="org.slf4j" name="slf4j-nop" rev="2.0.18"/>
         <!-- Conflict Resolvers -->
         <conflict org="com.h2database" manager="all"/>
     </dependencies>

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2026-02-01 13:15:28</div>
+        2026-08-23 13:31:14</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>
@@ -31,21 +31,21 @@
                     <td class="title">Modules</td><td class="value">1</td>
                 </tr>
                 <tr>
-                    <td class="title">Revisions</td><td class="value">4
+                    <td class="title">Revisions</td><td class="value">2
         (0 searched <img src="https://ant.apache.org/ivy/images/searched.gif" alt="searched" title="module revisions which required a search with a dependency resolver to be resolved">,
         0 downloaded <img src="https://ant.apache.org/ivy/images/downloaded.gif" alt="downloaded" title="module revisions for which ivy file was downloaded by dependency resolver">,
         0 evicted <img src="https://ant.apache.org/ivy/images/evicted.gif" alt="evicted" title="module revisions which were evicted by others">,
         0 errors <img src="https://ant.apache.org/ivy/images/error.gif" alt="error" title="module revisions on which error occurred">)</td>
                 </tr>
                 <tr>
-                    <td class="title">Artifacts</td><td class="value">4
+                    <td class="title">Artifacts</td><td class="value">2
         (0 downloaded,
         0 failed)</td>
                 </tr>
                 <tr>
-                    <td class="title">Artifacts size</td><td class="value">9876 kB
+                    <td class="title">Artifacts size</td><td class="value">4733 kB
         (0 kB downloaded,
-        9876 kB in cache)</td>
+        4733 kB in cache)</td>
                 </tr>
             </table>
             <h2>Conflicts</h2>
@@ -59,7 +59,7 @@
                     <tr>
                         <td><a href="#com.h2database-h2">h2
             by
-            com.h2database</a></td><td><a href="#com.h2database-h2-1.4.200">1.4.200</a> <a href="#com.h2database-h2-2.1.214">2.1.214</a> <a href="#com.h2database-h2-2.2.224">2.2.224</a> <a href="#com.h2database-h2-2.3.232">2.3.232</a> </td><td></td>
+            com.h2database</a></td><td><a href="#com.h2database-h2-1.4.200">1.4.200</a> <a href="#com.h2database-h2-2.1.214">2.1.214</a> </td><td></td>
                     </tr>
                 </tbody>
             </table>
@@ -81,18 +81,6 @@
                         <td><a href="#com.h2database-h2"> h2
         by
         com.h2database</a></td><td><a href="#com.h2database-h2-2.1.214">2.1.214</a></td><td align="center">release</td><td align="center">public</td><td align="center">false</td><td align="center"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td><td align="center">2483 kB
-    </td><td align="center"></td>
-                    </tr>
-                    <tr>
-                        <td><a href="#com.h2database-h2"> h2
-        by
-        com.h2database</a></td><td><a href="#com.h2database-h2-2.2.224">2.2.224</a></td><td align="center">release</td><td align="center">public</td><td align="center">false</td><td align="center"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td><td align="center">2554 kB
-    </td><td align="center"></td>
-                    </tr>
-                    <tr>
-                        <td><a href="#com.h2database-h2"> h2
-        by
-        com.h2database</a></td><td><a href="#com.h2database-h2-2.3.232">2.3.232</a></td><td align="center">release</td><td align="center">public</td><td align="center">false</td><td align="center"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td><td align="center">2589 kB
     </td><td align="center"></td>
                     </tr>
                 </tbody>
@@ -224,132 +212,6 @@
                 <tbody>
                     <tr>
                         <td>h2</td><td>jar</td><td>jar</td><td align="center">no</td><td align="center">2483 kB</td>
-                    </tr>
-                </tbody>
-            </table>
-            <h4>
-                <a name="com.h2database-h2-2.2.224"></a>
-           Revision: 2.2.224<span style="padding-left:15px;"></span>
-            </h4>
-            <table class="header">
-                <tr>
-                    <td class="title">Home Page</td><td class="value"><a href="https://h2database.com">https://h2database.com</a></td>
-                </tr>
-                <tr>
-                    <td class="title">Status</td><td class="value">release</td>
-                </tr>
-                <tr>
-                    <td class="title">Publication</td><td class="value">20230918085906</td>
-                </tr>
-                <tr>
-                    <td class="title">Resolver</td><td class="value">public</td>
-                </tr>
-                <tr>
-                    <td class="title">Configurations</td><td class="value">default, compile, runtime, master</td>
-                </tr>
-                <tr>
-                    <td class="title">Artifacts size</td><td class="value">2554 kB
-          (0 kB downloaded,
-          2554 kB in cache)</td>
-                </tr>
-                <tr>
-                    <td class="title">Licenses</td><td class="value"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td>
-                </tr>
-            </table>
-            <h5>Required by</h5>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Organisation</th><th>Name</th><th>Revision</th><th>In Configurations</th><th>Asked Revision</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>tv.phantombot</td><td><a href="#tv.phantombot-phantombot">phantombot</a></td><td>custom</td><td>lib.extra</td><td>2.2.224</td>
-                    </tr>
-                </tbody>
-            </table>
-            <h5>Dependencies</h5>
-            <table>
-                <tr>
-                    <td>
-    No dependency
-    </td>
-                </tr>
-            </table>
-            <h5>Artifacts</h5>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th><th>Type</th><th>Ext</th><th>Download</th><th>Size</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>h2</td><td>jar</td><td>jar</td><td align="center">no</td><td align="center">2554 kB</td>
-                    </tr>
-                </tbody>
-            </table>
-            <h4>
-                <a name="com.h2database-h2-2.3.232"></a>
-           Revision: 2.3.232<span style="padding-left:15px;"></span>
-            </h4>
-            <table class="header">
-                <tr>
-                    <td class="title">Home Page</td><td class="value"><a href="https://h2database.com">https://h2database.com</a></td>
-                </tr>
-                <tr>
-                    <td class="title">Status</td><td class="value">release</td>
-                </tr>
-                <tr>
-                    <td class="title">Publication</td><td class="value">20240812183609</td>
-                </tr>
-                <tr>
-                    <td class="title">Resolver</td><td class="value">public</td>
-                </tr>
-                <tr>
-                    <td class="title">Configurations</td><td class="value">default, compile, runtime, master</td>
-                </tr>
-                <tr>
-                    <td class="title">Artifacts size</td><td class="value">2589 kB
-          (0 kB downloaded,
-          2589 kB in cache)</td>
-                </tr>
-                <tr>
-                    <td class="title">Licenses</td><td class="value"><span style="padding-right:3px;"><a href="https://www.mozilla.org/en-US/MPL/2.0/">MPL 2.0</a></span><span style="padding-right:3px;"><a href="https://opensource.org/licenses/eclipse-1.0.php">EPL 1.0</a></span></td>
-                </tr>
-            </table>
-            <h5>Required by</h5>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Organisation</th><th>Name</th><th>Revision</th><th>In Configurations</th><th>Asked Revision</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>tv.phantombot</td><td><a href="#tv.phantombot-phantombot">phantombot</a></td><td>custom</td><td>lib.extra</td><td>2.3.232</td>
-                    </tr>
-                </tbody>
-            </table>
-            <h5>Dependencies</h5>
-            <table>
-                <tr>
-                    <td>
-    No dependency
-    </td>
-                </tr>
-            </table>
-            <h5>Artifacts</h5>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th><th>Type</th><th>Ext</th><th>Download</th><th>Size</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>h2</td><td>jar</td><td>jar</td><td align="center">no</td><td align="center">2589 kB</td>
                     </tr>
                 </tbody>
             </table>

--- a/resources/licenses/tv.phantombot-phantombot-lib.extra.html
+++ b/resources/licenses/tv.phantombot-phantombot-lib.extra.html
@@ -18,7 +18,7 @@
         </h1>
         <div id="date">
         resolved on
-        2026-08-23 13:31:14</div>
+        2026-08-23 14:18:37</div>
         <ul id="confmenu">
             <li>
                 <a class="active" href="tv.phantombot-phantombot-lib.extra.html">lib.extra</a>


### PR DESCRIPTION
Upgrade Discord4j to [3.3.3](https://github.com/Discord4J/Discord4J/releases/tag/3.3.3) which uses ractor-bom [2025.0.6](https://github.com/reactor/reactor/releases/tag/2025.0.6) thus fully aligning PhantomBot netty versions to 4.2.15-Final

Also I let Ivy create a new license report so changes from https://github.com/PhantomBot/PhantomBot/pull/3760 are properly reflected 

Edit: also added some minor dependency updates